### PR TITLE
Add support for multiple payment configurations

### DIFF
--- a/Domain/CreditCost.php
+++ b/Domain/CreditCost.php
@@ -6,6 +6,10 @@ use Booked\Currency;
 class CreditCost
 {
     /**
+     * @var int
+     */
+    private $count;
+    /**
      * @var float
      */
     private $cost;
@@ -18,10 +22,19 @@ class CreditCost
      * @param float $cost
      * @param string $currency
      */
-    public function __construct($cost = 0.0, $currency = 'USD')
+    public function __construct($count = 1, $cost = 0.0, $currency = 'USD')
     {
+        $this->count = $count;
         $this->cost = $cost;
         $this->currency = $currency;
+    }
+
+    /**
+     * @return int
+     */
+    public function Count()
+    {
+        return $this->count;
     }
 
     /**

--- a/Pages/Admin/ManagePaymentsPage.php
+++ b/Pages/Admin/ManagePaymentsPage.php
@@ -11,6 +11,10 @@ interface IManagePaymentsPage extends IActionPage
     /**
      * @return string
      */
+    public function GetCreditCount();
+    /**
+     * @return string
+     */
     public function GetCreditCost();
 
     /**
@@ -22,7 +26,7 @@ interface IManagePaymentsPage extends IActionPage
      * @param float $cost
      * @param string $currency
      */
-    public function SetCreditCost($cost, $currency);
+    public function SetCreditCosts($creditCosts);
 
     /**
      * @return bool
@@ -153,6 +157,10 @@ class ManagePaymentsPage extends ActionPage implements IManagePaymentsPage
         $this->presenter->PageLoad();
         $this->Display('Admin/Payments/manage_payments.tpl');
     }
+    
+    public function GetCreditCount() {
+        return $this->GetForm(FormKeys::CREDIT_COUNT);
+    }
 
     public function GetCreditCost()
     {
@@ -164,10 +172,9 @@ class ManagePaymentsPage extends ActionPage implements IManagePaymentsPage
         return $this->GetForm(FormKeys::CREDIT_CURRENCY);
     }
 
-    public function SetCreditCost($cost, $currency)
+    public function SetCreditCosts($creditCosts)
     {
-        $this->Set('CreditCost', $cost);
-        $this->Set('CreditCurrency', $currency);
+        $this->Set('CreditCosts', $creditCosts);
     }
 
     public function GetPayPalIsEnabled()

--- a/Pages/Credits/CheckoutPage.php
+++ b/Pages/Credits/CheckoutPage.php
@@ -5,6 +5,8 @@ require_once(ROOT_DIR . 'Pages/SecurePage.php');
 
 interface ICheckoutPage extends IActionPage
 {
+    public function GetCreditCount();
+
     public function GetCreditQuantity();
 
     /**
@@ -92,6 +94,11 @@ class CheckoutPage extends ActionPage implements ICheckoutPage
         $this->Display('Credits/checkout.tpl');
     }
 
+    public function GetCreditCount()
+    {
+        return $this->GetForm(FormKeys::CREDIT_COUNT);
+    }
+
     public function GetCreditQuantity()
     {
         return $this->GetForm(FormKeys::CREDIT_QUANTITY);
@@ -114,6 +121,7 @@ class CheckoutPage extends ActionPage implements ICheckoutPage
     {
         $this->Set('Total', $cost->FormatCurrency($total));
         $this->Set('CreditCost', $cost->FormatCurrency());
+        $this->Set('CreditCount', $cost->Count());
         $this->Set('CreditQuantity', $creditQuantity);
         $this->Set('Currency', $cost->Currency());
         $this->Set('TotalUnformatted', $cost->GetTotal($creditQuantity));

--- a/Pages/Credits/UserCreditsPage.php
+++ b/Pages/Credits/UserCreditsPage.php
@@ -12,6 +12,11 @@ interface IUserCreditsPage extends IPage, IActionPage
     public function SetCurrentCredits($credits);
 
     /**
+     * @param CreditCost[] $cost
+     */
+    public function SetCreditCosts($costs);
+
+    /**
      * @param CreditCost $cost
      */
     public function SetCreditCost(CreditCost $cost);
@@ -20,6 +25,11 @@ interface IUserCreditsPage extends IPage, IActionPage
      * @return float
      */
     public function GetQuantity();
+
+    /**
+     * @return int
+     */
+    public function GetCount();
 
     /**
      * @param string $formattedTotal
@@ -89,6 +99,11 @@ class UserCreditsPage extends ActionPage implements IUserCreditsPage
         $this->Set('CurrentCredits', $credits);
     }
 
+    public function SetCreditCosts($costs)
+    {
+        $this->Set('CreditCosts', $costs);
+    }
+
     public function SetCreditCost(CreditCost $cost)
     {
         $this->Set('CreditCost', $cost->FormatCurrency());
@@ -98,6 +113,11 @@ class UserCreditsPage extends ActionPage implements IUserCreditsPage
     public function GetQuantity()
     {
         return $this->GetQuerystring(QueryStringKeys::QUANTITY);
+    }
+
+    public function GetCount()
+    {
+        return $this->GetQuerystring(QueryStringKeys::COUNT);
     }
 
     public function SetTotalCost($formattedTotal)

--- a/Presenters/Admin/ManagePaymentsPresenter.php
+++ b/Presenters/Admin/ManagePaymentsPresenter.php
@@ -7,6 +7,7 @@ require_once(ROOT_DIR . 'Domain/Access/PaymentRepository.php');
 class ManagePaymentsActions
 {
     public const UPDATE_CREDIT_COST = 'updateCreditCost';
+    public const DELETE_CREDIT_COST = 'deleteCreditCost';
     public const UPDATE_PAYMENT_GATEWAYS = 'updatePaymentGateways';
     public const ISSUE_REFUND = 'issueRefund';
 }
@@ -34,14 +35,15 @@ class ManagePaymentsPresenter extends ActionPresenter
         $this->paymentLogger = $logger;
 
         $this->AddAction(ManagePaymentsActions::UPDATE_CREDIT_COST, 'UpdateCreditCost');
+        $this->AddAction(ManagePaymentsActions::DELETE_CREDIT_COST, 'UpdateCreditCost');
         $this->AddAction(ManagePaymentsActions::UPDATE_PAYMENT_GATEWAYS, 'UpdatePaymentGateways');
         $this->AddAction(ManagePaymentsActions::ISSUE_REFUND, 'IssueRefund');
     }
 
     public function PageLoad()
     {
-        $cost = $this->paymentRepository->GetCreditCost();
-        $this->page->SetCreditCost($cost->Cost(), $cost->Currency());
+        $costs = $this->paymentRepository->GetCreditCosts();
+        $this->page->SetCreditCosts($costs);
 
         $paypal = $this->paymentRepository->GetPayPalGateway();
         $stripe = $this->paymentRepository->GetStripeGateway();
@@ -52,11 +54,20 @@ class ManagePaymentsPresenter extends ActionPresenter
 
     public function UpdateCreditCost()
     {
+        $count = max(1, intval($this->page->GetCreditCount()));
         $cost = max(0, floatval($this->page->GetCreditCost()));
         $currency = $this->page->GetCreditCurrency();
 
-        Log::Debug('Updating credit cost. %s, %s', $cost, $currency);
-        $this->paymentRepository->UpdateCreditCost(new CreditCost($cost, $currency));
+        Log::Debug('Updating credit cost. %s, %s, %s', $count, $cost, $currency);
+        $this->paymentRepository->UpdateCreditCost(new CreditCost($count, $cost, $currency));
+    }
+
+    public function DeleteCreditCost()
+    {
+        $count = max(1, intval($this->page->GetCreditCount()));
+
+        Log::Debug('Deleting credit cost. %s', $count);
+        $this->paymentRepository->DeleteCreditCost($count);
     }
 
     public function UpdatePaymentGateways()

--- a/Presenters/Credits/UserCreditsPresenter.php
+++ b/Presenters/Credits/UserCreditsPresenter.php
@@ -45,9 +45,10 @@ class UserCreditsPresenter extends ActionPresenter
         $user = $this->userRepository->LoadById($userSession->UserId);
         $this->page->SetCurrentCredits($user->GetCurrentCredits());
 
-        $cost = $this->paymentRepository->GetCreditCost();
+        $costs = $this->paymentRepository->GetCreditCosts();
 
-        $this->page->SetCreditCost($cost);
+        $this->page->SetCreditCosts($costs);
+        $this->page->SetCreditCost($costs[0]); // Just a default value, will be overwritten by javascript
     }
 
     /**
@@ -62,8 +63,20 @@ class UserCreditsPresenter extends ActionPresenter
             $this->GetTransactionLog($userSession);
         } else {
             $quantity = $this->page->GetQuantity();
-            $cost = $this->paymentRepository->GetCreditCost();
-            $this->page->SetTotalCost($cost->GetFormattedTotal($quantity));
+            $count = $this->page->GetCount();
+            $costs = $this->paymentRepository->GetCreditCosts();
+            // Get the cost that matches the count
+            foreach ($costs as $c) {
+                if ($c->Count() == $count) {
+                    $cost = $c;
+                    break;
+                }
+            }
+            if (!isset($cost)) { // Error if not found
+                echo "ERR|ERR";
+                return;
+            }
+            $this->page->SetTotalCost($cost->FormatCurrency($cost->Cost())."|".$cost->GetFormattedTotal($quantity));
         }
     }
 

--- a/Presenters/Reservation/ReservationCreditsPresenter.php
+++ b/Presenters/Reservation/ReservationCreditsPresenter.php
@@ -56,8 +56,11 @@ class ReservationCreditsPresenter
 
         $cost = '';
         if (Configuration::Instance()->GetSectionKey(ConfigSection::CREDITS, ConfigKeys::CREDITS_ALLOW_PURCHASE, new BooleanConverter())) {
-            $creditCost = $this->paymentRepository->GetCreditCost();
-            $cost = $creditCost->GetFormattedTotal($creditsRequired);
+            $creditCost = $this->paymentRepository->GetCreditCosts();
+            // Only give an estimation of costs if there is only one cost configured
+            if (count($creditCost) == 1) {
+                $cost = $creditCost[0]->GetFormattedTotal($creditsRequired);
+            }
         }
         $this->page->SetCreditRequired($creditsRequired, $cost);
     }

--- a/Web/scripts/admin/payments.js
+++ b/Web/scripts/admin/payments.js
@@ -1,6 +1,7 @@
 function Payments(opts) {
     var elements = {
         updateCreditsForm: $('#updateCreditsForm'),
+        deleteCreditsForms: $('.deleteCreditsForm'),
         updateGatewayForm: $('#updateGatewayForm'),
         transactionLog: $('#transaction-log-content'),
         transactionLogIndicator: $('#transactionLogIndicator'),
@@ -46,8 +47,14 @@ function Payments(opts) {
         loadTransactionLog(0, 0);
 
         ConfigureAsyncForm(elements.updateCreditsForm, defaultSubmitCallback, function () {
-            showMessage('updatedCreditsMessage');
+            showMessage('updatedCreditsMessage').animate({height: 0}, {complete: function() { location.reload() }}); // TODO: cleaner table reload
         }, function () {
+        });
+        elements.deleteCreditsForms.each(function () {
+          ConfigureAsyncForm($(this), defaultSubmitCallback, function () {
+              showMessage('updatedCreditsMessage').animate({height: 0}, {complete: function() { location.reload() }}); // TODO: cleaner table reload
+          }, function () {
+          });
         });
         ConfigureAsyncForm(elements.updateGatewayForm, defaultSubmitCallback, function () {
             showMessage('updatedGatewayMessage');
@@ -91,6 +98,6 @@ function Payments(opts) {
     };
 
     var showMessage = function (id) {
-        $('#' + id).show().delay(2000).fadeOut(200);
+        return $('#' + id).show().delay(2000).fadeOut(200);
     }
 }

--- a/Web/scripts/user-credits.js
+++ b/Web/scripts/user-credits.js
@@ -7,9 +7,11 @@ function UserCredits(opts) {
     };
 
     UserCredits.prototype.init = function () {
-        $('#quantity').on('change', function (e) {
-            ajaxGet(opts.calcQuantityUrl + $('#quantity').val(), null, function (data) {
-                $('#totalCost').text(data);
+        $('#quantity, #count').change(function (e) {
+            ajaxGet(opts.calcQuantityUrl + $('#quantity').val() + "&count=" + $('#count').val(), null, function (data) {
+                var values = data.split("|");
+                $('#cost').text(values[0]);
+                $('#totalCost').text(values[1]);
             });
         });
 

--- a/database_schema/upgrades/2.8/schema.sql
+++ b/database_schema/upgrades/2.8/schema.sql
@@ -11,3 +11,10 @@ ALTER TABLE `schedules`
 
 ALTER TABLE `resources`
   ADD COLUMN `additional_properties` TEXT;
+
+ALTER TABLE `payment_configuration`
+  DROP COLUMN `payment_configuration_id`;
+ALTER TABLE `payment_configuration`
+  ADD COLUMN `credit_count` INT UNSIGNED NOT NULL DEFAULT 1 CHECK (`credit_count` > 0);
+ALTER TABLE `payment_configuration`
+  ADD CONSTRAINT `credit_count` PRIMARY KEY (`credit_count`);

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -630,7 +630,10 @@ class en_us extends Language
         $strings['Reject'] = 'Reject';
         $strings['CheckingAvailability'] = 'Checking availability';
         $strings['CreditPurchaseNotEnabled'] = 'You have not enabled the ability to purchase credits';
-        $strings['CreditsCost'] = 'Each credit costs';
+        $strings['CreditsEachCost1'] = 'Each';
+        $strings['CreditsEachCost2'] = 'credit(s) cost';
+        $strings['CreditsCount'] = 'Number of credits';
+        $strings['CreditsCost'] = 'Cost';
         $strings['Currency'] = 'Currency';
         $strings['PayPalClientId'] = 'Client ID';
         $strings['PayPalSecret'] = 'Secret';

--- a/lang/es.php
+++ b/lang/es.php
@@ -597,7 +597,10 @@ class es extends en_gb
         $strings['Reject'] = 'Rechazar';
         $strings['CheckingAvailability'] = 'Comprobando disponibilidad';
         $strings['CreditPurchaseNotEnabled'] = 'No tiene habilitada la opción de comprar créditos';
-        $strings['CreditsCost'] = 'Cada crédito cuesta';
+        $strings['CreditsEachCost1'] = 'Cada';
+        $strings['CreditsEachCost2'] = 'crédito(s) cuesta(n)';
+        $strings['CreditsCount'] = 'Número de créditos';
+        $strings['CreditsCost'] = 'Coste';
         $strings['Currency'] = 'Moneda';
         $strings['PayPalClientId'] = 'ID de cliente';
         $strings['PayPalSecret'] = 'Password';

--- a/lib/Database/Commands/Commands.php
+++ b/lib/Database/Commands/Commands.php
@@ -250,6 +250,17 @@ class AddCustomLayoutPeriodCommand extends SqlCommand
     }
 }
 
+class AddPaymentConfigurationCommand extends SqlCommand
+{
+    public function __construct($creditCount, $creditCost, $creditCurrency)
+    {
+        parent::__construct(Queries::ADD_PAYMENT_CONFIGURATION);
+        $this->AddParameter(new Parameter(ParameterNames::CREDIT_COUNT, $creditCount));
+        $this->AddParameter(new Parameter(ParameterNames::CREDIT_COST, $creditCost));
+        $this->AddParameter(new Parameter(ParameterNames::CREDIT_CURRENCY, $creditCurrency));
+    }
+}
+
 class AddPaymentGatewaySettingCommand extends SqlCommand
 {
     public function __construct($gatewayType, $settingName, $settingValue)
@@ -963,6 +974,15 @@ class DeleteOrphanLayoutsCommand extends SqlCommand
     public function __construct()
     {
         parent::__construct(Queries::DELETE_ORPHAN_LAYOUTS);
+    }
+}
+
+class DeletePaymentConfigurationCommand extends SqlCommand
+{
+    public function __construct($creditCount)
+    {
+        parent::__construct(Queries::DELETE_PAYMENT_CONFIGURATION);
+        $this->AddParameter(new Parameter(ParameterNames::CREDIT_COUNT, $creditCount));
     }
 }
 
@@ -2557,16 +2577,6 @@ class UpdateLoginDataCommand extends SqlCommand
         $this->AddParameter(new Parameter(ParameterNames::LAST_LOGIN, $lastLoginTime));
         $this->AddParameter(new Parameter(ParameterNames::LANGUAGE, $language));
         $this->AddParameter(new Parameter(ParameterNames::USER_ID, $userId));
-    }
-}
-
-class UpdatePaymentConfigurationCommand extends SqlCommand
-{
-    public function __construct($creditCost, $creditCurrency)
-    {
-        parent::__construct(Queries::UPDATE_PAYMENT_CONFIGURATION);
-        $this->AddParameter(new Parameter(ParameterNames::CREDIT_COST, $creditCost));
-        $this->AddParameter(new Parameter(ParameterNames::CREDIT_CURRENCY, $creditCurrency));
     }
 }
 

--- a/lib/Database/Commands/Queries.php
+++ b/lib/Database/Commands/Queries.php
@@ -79,6 +79,8 @@ class Queries
         'INSERT INTO `quotas` (`quota_limit`, `unit`, `duration`, `resource_id`, `group_id`, `schedule_id`, `enforced_time_start`, `enforced_time_end`, `enforced_days`, `scope`)
 			VALUES (@limit, @unit, @duration, @resourceid, @groupid, @scheduleid, @startTime, @endTime, @enforcedDays, @scope)';
 
+    public const ADD_PAYMENT_CONFIGURATION = 'INSERT INTO `payment_configuration` (`credit_cost`, `credit_currency`, `credit_count`) VALUES (@credit_cost, @credit_currency, @credit_count)';
+
     public const ADD_PAYMENT_GATEWAY_SETTING = 'INSERT INTO `payment_gateway_settings` (`gateway_type`, `setting_name`, `setting_value`)
                                       VALUES (@gateway_type, @setting_name, @setting_value)';
 
@@ -247,6 +249,8 @@ class Queries
     public const DELETE_GROUP_ROLE = 'DELETE FROM `group_roles` WHERE `group_id` = @groupid AND `role_id` = @roleid';
 
     public const DELETE_ORPHAN_LAYOUTS = 'DELETE `l`.* FROM `layouts` `l` LEFT JOIN `schedules` `s` ON `l`.`layout_id` = `s`.`layout_id` WHERE `s`.`layout_id` IS NULL';
+
+    public const DELETE_PAYMENT_CONFIGURATION = 'DELETE FROM `payment_configuration` WHERE `credit_count` = @credit_count';
 
     public const DELETE_PAYMENT_GATEWAY_SETTINGS = 'DELETE FROM `payment_gateway_settings` WHERE `gateway_type` = @gateway_type';
 
@@ -1030,8 +1034,6 @@ class Queries
 		WHERE `group_id` = @groupid';
 
     public const UPDATE_LOGINDATA = 'UPDATE `users` SET `lastlogin` = @lastlogin, `language` = @language WHERE `user_id` = @userid';
-
-    public const UPDATE_PAYMENT_CONFIGURATION = 'UPDATE `payment_configuration` SET `credit_cost` = @credit_cost, `credit_currency` = @credit_currency';
 
     public const UPDATE_FUTURE_RESERVATION_INSTANCES =
         'UPDATE `reservation_instances`

--- a/lib/Server/FormKeys.php
+++ b/lib/Server/FormKeys.php
@@ -60,6 +60,7 @@ class FormKeys
     public const CONFLICT_ACTION = 'conflictAction';
     public const CONTACT_INFO = 'contactInfo';
     public const CREDITS = 'CREDITS';
+    public const CREDIT_COUNT = 'CREDIT_COUNT';
     public const CREDIT_COST = 'CREDIT_COST';
     public const CREDIT_CURRENCY = 'CREDIT_CURRENCY';
     public const CSS_FILE = 'CSS_FILE';

--- a/lib/Server/QueryStringKeys.php
+++ b/lib/Server/QueryStringKeys.php
@@ -43,6 +43,7 @@ class QueryStringKeys
     public const PARTICIPANT_ID = 'pid';
     public const PERIOD_ID = 'pid';
     public const PREVIOUS_ID = 'pid';
+    public const COUNT = 'count';
     public const QUANTITY = 'quantity';
     public const QUOTA_ID = 'qid';
     public const READ_ONLY = 'ro';

--- a/tests/Domain/Payment/PaymentRepositoryTest.php
+++ b/tests/Domain/Payment/PaymentRepositoryTest.php
@@ -17,20 +17,20 @@ class PaymentRepositoryTests extends TestBase
 
     public function testGetsCreditCost()
     {
-        $expectedRows = [[ColumnNames::CREDIT_COST => 32.99, ColumnNames::CREDIT_CURRENCY => 'USD']];
+        $expectedRows = [[ColumnNames::CREDIT_COUNT => 1, ColumnNames::CREDIT_COST => 32.99, ColumnNames::CREDIT_CURRENCY => 'USD']];
         $this->db->SetRows($expectedRows);
 
-        $cost = $this->repository->GetCreditCost();
+        $cost = $this->repository->GetCreditCosts();
 
-        $this->assertEquals(new CreditCost(32.99, 'USD'), $cost);
+        $this->assertEquals(new CreditCost(1, 32.99, 'USD'), $cost[0]);
         $this->assertEquals(new GetPaymentConfigurationCommand(), $this->db->_LastCommand);
     }
 
     public function testUpdatesCreditCost()
     {
-        $this->repository->UpdateCreditCost(new CreditCost(32.99, 'USD'));
+        $this->repository->UpdateCreditCost(new CreditCost(1, 32.99, 'USD'));
 
-        $this->assertEquals(new UpdatePaymentConfigurationCommand(32.99, 'USD'), $this->db->_LastCommand);
+        $this->assertEquals(new AddPaymentConfigurationCommand(1, 32.99, 'USD'), $this->db->_LastCommand);
     }
 
     public function testUpdatesPayPal()

--- a/tests/Presenters/Admin/ManagePaymentsPresenterTest.php
+++ b/tests/Presenters/Admin/ManagePaymentsPresenterTest.php
@@ -170,6 +170,7 @@ class ManagePaymentsPresenterTests extends TestBase
 
 class FakeManagePaymentsPage extends ManagePaymentsPage
 {
+    public $_CreditCount;
     public $_CreditCost;
     public $_CreditCurrency;
     public $_PayPalEnabled;
@@ -203,8 +204,9 @@ class FakeManagePaymentsPage extends ManagePaymentsPage
         return $this->_CreditCurrency;
     }
 
-    public function SetCreditCost($cost, $currency)
+    public function SetCreditCost($count, $cost, $currency)
     {
+        $this->_CreditCount = $count;
         $this->_CreditCost = $cost;
         $this->_CreditCurrency = $currency;
     }

--- a/tests/Presenters/CheckoutPresenterTest.php
+++ b/tests/Presenters/CheckoutPresenterTest.php
@@ -127,6 +127,7 @@ class CheckoutPresenterTests extends TestBase
 
 class FakeCheckoutPage extends CheckoutPage
 {
+    public $_CreditCount;
     public $_CreditQuantity;
     public $_Total;
     public $_PayPalEnabled;
@@ -141,6 +142,11 @@ class FakeCheckoutPage extends CheckoutPage
     public $_PayerId;
     public $_StripeToken;
     public $_StripePaymentResult;
+
+    public function GetCreditCount()
+    {
+        return $this->_CreditCount;
+    }
 
     public function GetCreditQuantity()
     {

--- a/tpl/Admin/Payments/manage_payments.tpl
+++ b/tpl/Admin/Payments/manage_payments.tpl
@@ -42,14 +42,18 @@
 
             <div class="tab-pane" id="cost" role="tabpanel">
                 <div>
+                    {* Form to add or update credit payment configurations *}
                     <form role="form" name="updateCreditsForm" id="updateCreditsForm" method="post"
-                          ajaxAction="updateCreditCost"
-                          action="{$smarty.server.SCRIPT_NAME}">
+                          ajaxAction="updateCreditCost" action="{$smarty.server.SCRIPT_NAME}">
                         <div class="form-group">
-                            <label for="creditCost" class="inline-block">{translate key=CreditsCost}</label>
+                            <label for="creditCount" class="inline-block">{translate key=CreditsEachCost1}</label>
+                            <input type="number" min="0" max="1000000000" id="creditCount" step="1"
+                                  class="form-control inline-block" style="width:auto;" {formname key=CREDIT_COUNT}
+                                  value="1"/>
+                            <label for="creditCost" class="inline-block">{translate key=CreditsEachCost2}</label>
                             <input type="number" min="0" max="1000000000" id="creditCost" step="any"
                                    class="form-control inline-block" style="width:auto;" {formname key=CREDIT_COST}
-                                   value="{$CreditCost}"/>
+                                   value="30.00"/>
                             <label for="creditCurrency" class="inline-block no-show">{translate key=Currency}</label>
                             <select id="creditCurrency" {formname key=CREDIT_CURRENCY} class="form-control inline-block"
                                     style="width:auto;">
@@ -61,6 +65,40 @@
                             {indicator id="updateCreditsIndicator"}
                         </div>
                     </form>
+                    {* Table to show and delete credit offers *}
+                    <table class="table" id="creditsTable">
+                      <thead>
+                      <tr>
+                        <th>{translate key=CreditsCount}</th>
+                        <th>{translate key=CreditsCost}</th>
+                        <th>{translate key=Currency}</th>
+                        <th class="action">{translate key=Actions}</th>
+                      </tr>
+                      </thead>
+                      <tbody>
+                      {foreach from=$CreditCosts item=credit}
+                        {cycle values='row0,row1' assign=rowCss}
+                        <tr class="{$rowCss}" data-credit-id="{$credit->Count()}">
+                        <td>{$credit->Count()}</td>
+                        <td>{$credit->Cost()}</td>
+                        <td>{$credit->Currency()}</td>
+                        <td class="action">
+                        {if $credit->Count() != 1}
+                          <form role="form" name="{($credit->Count())}" id="{$credit->Count()}"
+                                class="deleteCreditsForm" method="post"
+                                ajaxAction="deleteCreditCost" action="{$smarty.server.SCRIPT_NAME}">
+                                <input type="hidden" {formname key=CREDIT_COUNT} value="{$credit->Count()}"/>
+                                <button type="submit" style="border: 0; padding: 0">
+                                  <span class="no-show">{translate key=Delete}</span>
+                                  <span class="fa fa-trash icon remove"></span>
+                                </button>
+                                {indicator id="deleteCreditsIndicator"}
+                          </form>
+                        {/if}
+                        </tr>
+                      {/foreach}
+                      </tbody>
+                    </table>
                 </div>
             </div>
 

--- a/tpl/Credits/checkout.tpl
+++ b/tpl/Credits/checkout.tpl
@@ -16,13 +16,13 @@
 					<div class="col-xs-12 col-sm-4">
 						<h4>{translate key=PurchaseSummary}</h4>
 						<div class="col-xs-8">
-                            {translate key=EachCreditCosts}
+                            {translate key=CreditsEachCost1} {$CreditCount} {translate key=CreditsEachCost2}
 						</div>
 						<div class="col-xs-4 align-right">
                             {$CreditCost}
 						</div>
 						<div class="col-xs-8">
-                            {translate key=Credits}
+                            {translate key=Quantity}
 						</div>
 						<div class="col-xs-4 align-right">
                             {$CreditQuantity}</div>
@@ -65,7 +65,7 @@
 			<div class="no-show" id="success">
 				<div class="alert alert-success">
 					<div>{translate key=Success}</div>
-					<div><em>{$CreditQuantity}</em> {translate key=CreditsPurchased}</div>
+					<div><em>{$CreditQuantity * $CreditCount}</em> {translate key=CreditsPurchased}</div>
 					<div><a href="{$ScriptUrl}/{Pages::CREDITS}">{translate key=ViewYourCredits}</a></div>
 				</div>
 			</div>

--- a/tpl/Credits/user_credits.tpl
+++ b/tpl/Credits/user_credits.tpl
@@ -43,7 +43,13 @@
                     <div class="col-xs-4">
                         <form role="form" name="purchaseCreditsForm" id="purchaseCreditsForm" method="post"
                               action="checkout.php">
-                            <div>{translate key=EachCreditCosts} <span class="cost">{$CreditCost}</span></div>
+                            <div>{translate key=CreditsEachCost1} 
+                            <select id="count" {formname key=CREDIT_COUNT} class="form-control inline-block" style="width:auto">
+                                {foreach from=$CreditCosts item=credit}
+                                    <option value="{$credit->Count()}">{$credit->Count()}</option>
+                                {/foreach}
+                            </select>
+                            {translate key=CreditsEachCost2} <span id="cost" class="cost">{$CreditCost}</span></div>
                             <div>{translate key=Quantity}
                                 <input id="quantity" {formname key=CREDIT_QUANTITY} type="number"
                                        class="form-control inline-block" min="1"


### PR DESCRIPTION
Hi @effgarces, thanks for maintaining this project!

I needed support for multiple payment configurations to offer discounts when a user buys several credits at the same time. This pull request implements this feature.

The main changes are a payment configuration table where admins can create, update, read and delete payment configurations:
![Screenshot_20221113_170622](https://user-images.githubusercontent.com/4929005/201531667-7e8df3f0-90f8-4059-a4a6-c06b2ec94c81.png)

And a selector for users to buy a pack of credits at a different cost:
![Screenshot_20221113_170718](https://user-images.githubusercontent.com/4929005/201531775-a60849d9-0d85-4a6c-8405-55deda174f84.png)
![Screenshot_20221113_170728](https://user-images.githubusercontent.com/4929005/201531777-ed0fea5b-2f94-4817-bb1f-8d8a195673d6.png)
![Screenshot_20221113_170805](https://user-images.githubusercontent.com/4929005/201531788-595ca751-4327-480b-81f4-65765b0efd2b.png)

This is my first time working on this codebase, so it probably needs a review. Things I'm not sure about:
- Database migration: I ran the commands manually and wrote them in `database_schema/upgrades/2.8/schema.sql`, will this work for upgrades?
- Tests: I slightly modified some of them, but I don't know how to run them.
- Did I update the translations properly? (for others to work on other languages)
