### PR TITLE
Fix missing query column and better docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV ADMIN_EMAIL=$ADMIN_EMAIL
 RUN mkdir /var/www/librebooking/
 COPY . /var/www/librebooking/
 COPY entrypoint.sh /
-RUN sed -i "s#DocumentRoot /var/www/html#DocumentRoot /var/www/librebooking/Web#" /etc/apache2/sites-enabled/000-default.conf
+RUN sed -i "s#DocumentRoot /var/www/html#DocumentRoot /var/www/librebooking#" /etc/apache2/sites-enabled/000-default.conf
 RUN a2enmod rewrite
 RUN docker-php-ext-install mysqli
 

--- a/doc/INSTALLATION.md
+++ b/doc/INSTALLATION.md
@@ -6,8 +6,9 @@ Note: for users without web hosting service or existing environment, packages li
 
 ## Application Deployment to Server
 
-Unzip the archived distribution to your webserver's document root. 
-Or If you don't have direct access to your document root or use hosting service, then transfer the extracted directory to your web server's document root using FTP or [WinSCP](https://winscp.net/). 
+Unzip the archived distribution and execute `composer install` (after installing [composer](https://getcomposer.org/doc/00-intro.md)) in the extraction directory to download dependencies to the `vendor` folder.
+Move the contents of the directory to your webserver's document root. 
+If you don't have direct access to your document root or use hosting service, then transfer the directory to your web server's document root using FTP or [WinSCP](https://winscp.net/). 
 
 Copy `/config/config.dist.php` to `/config/config.php` and adjust the settings for your environment.
 
@@ -89,7 +90,9 @@ You are done. Try to load the application at (eg. http://yourhostname/librebooki
 
 ## Registering the Administrator Account
 
- After the database has been set up you will need to register the account for your application administrator. Navigate to register.php register an account with email address set in $conf['settings']['admin.email']. # Upgrading
+After the database has been set up you will need to register the account for your application administrator. Navigate to register.php register an account with email address set in $conf['settings']['admin.email'].
+
+# Upgrading
 
 ## Upgrading from a previous version of LibreBooking (or Booked 2.x and phpScheduleIt 2.x)
 

--- a/lib/Database/Commands/Queries.php
+++ b/lib/Database/Commands/Queries.php
@@ -518,7 +518,7 @@ class Queries
     public const GET_ATTRIBUTE_MULTIPLE_VALUES = 'SELECT *
 		FROM `custom_attribute_values` WHERE `entity_id` IN (@entity_ids) AND `attribute_category` = @attribute_category';
 
-    public const GET_ATTRIBUTE_VALUES = 'SELECT `cav`.*, `ca`.`display_label`
+    public const GET_ATTRIBUTE_VALUES = 'SELECT `cav`.*, `ca`.`display_label`, `ca`.`admin_only`
 		FROM `custom_attribute_values` `cav`
 		INNER JOIN `custom_attributes` `ca` ON `ca`.`custom_attribute_id` = `cav`.`custom_attribute_id`
 		WHERE `cav`.`attribute_category` = @attribute_category AND `cav`.`entity_id` = @entity_id';


### PR DESCRIPTION
A fix for a PHP 8 warning (missing column when querying the database) and a change to the DocumentRoot of the Dockerfile to avoid issues.

I also improved the installation docs to note that `composer install` is now required to download vendored dependencies before uploading the app to the server. Required because https://github.com/LibreBooking/app/pull/160 removed old dependencies by using composer to manage them.