### PR TITLE
Revised installation document to recommend enabling required Apache2 modules.

### DIFF
--- a/doc/INSTALLATION.md
+++ b/doc/INSTALLATION.md
@@ -5,11 +5,14 @@ Note: for users without web hosting service or existing environment, packages li
 # Fresh Installation
 
 ## Server Configuration
-In an **Apache** or similar server environment, the following modules (or their equivalents) should be enabled for proper operation of the LibreBooking application:
+In an **Apache** or similar server environment, some required modules for LibreBooking may not be enabled by default. The following modules (or their equivalents) are often not enabled as part of a standard installation but should be enabled for proper operation of the LibreBooking application:
 * headers
 * rewrite
 
-These modules are often not enabled by default and can be enabled in an **Apache2** environment as follows:<br>
+The enabled modules in an **Apache2** environment can be verified as follows:<br>
+```$ apachectl -M```<br>
+
+If required modules are not present in the enabled list, modules can be enabled in an **Apache2** environment as follows:<br>
 ```$ sudo a2enmod headers```<br>
 ```$ sudo a2enmod rewrite```<br>
 ```$ sudo service apache2 restart```

--- a/doc/INSTALLATION.md
+++ b/doc/INSTALLATION.md
@@ -2,7 +2,17 @@
 
 Note: for users without web hosting service or existing environment, packages like [XAMMP](http://www.apachefriends.org/en/index.html) or [WampServer](http://www.wampserver.com/en/) can help you get set up quickly.
 
-## Fresh Installation
+# Fresh Installation
+
+## Server Configuration
+In an Apache or simlar server environment, the following modules (or their equivalents) should be enabled for proper operation of the LibreBooking application:
+* headers
+* rewrite
+
+These modules are often not enabled by default and can be enabled in an **Apache2** environment as follows:<br>
+```$ sudo a2enmod headers```<br>
+```$ sudo a2enmod rewrite```<br>
+```$ sudo service apache2 restart```
 
 ## Application Deployment to Server
 

--- a/doc/INSTALLATION.md
+++ b/doc/INSTALLATION.md
@@ -5,7 +5,7 @@ Note: for users without web hosting service or existing environment, packages li
 # Fresh Installation
 
 ## Server Configuration
-In an Apache or simlar server environment, the following modules (or their equivalents) should be enabled for proper operation of the LibreBooking application:
+In an **Apache** or similar server environment, the following modules (or their equivalents) should be enabled for proper operation of the LibreBooking application:
 * headers
 * rewrite
 


### PR DESCRIPTION
This change to the installation doc recommends enabling the **headers** and **rewrite** modules for an **Apache2** server environment and closes #177 . The rewrite module is used to manipulate url's; the headers module is used to control and modify http request and response headers. Both modules are required for proper operation of LibreBooking.