### PR TITLE
BUGFIX - API: reflect qry param in GetAvailability

### DIFF
--- a/WebServices/ResourcesWebService.php
+++ b/WebServices/ResourcesWebService.php
@@ -128,9 +128,10 @@ class ResourcesWebService
      * @response ResourcesAvailabilityResponse
      * @return void
      */
-    public function GetAvailability($resourceId = null)
+    public function GetAvailability()
     {
         $dateQueryString = $this->server->GetQueryString(WebServiceQueryStringKeys::DATE_TIME);
+        $resourceId = $this->server->GetQueryString(WebServiceQueryStringKeys::RESOURCE_ID);
 
         if (!empty($dateQueryString)) {
             $requestedTime = WebServiceDate::GetDate($dateQueryString, $this->server->GetSession());
@@ -144,7 +145,7 @@ class ResourcesWebService
             $resources[] = $this->resourceRepository->LoadById($resourceId);
         }
 
-        $lastDateSearched = $requestedTime->AddDays(30);
+        $lastDateSearched = $requestedTime->AddDays(7);
         $reservations = $this->GetReservations($this->reservationRepository->GetReservations($requestedTime, $lastDateSearched, null, null, null, $resourceId));
 
         $resourceAvailability = [];


### PR DESCRIPTION
With GetAvailability(resourceId = null) the GET query parameter is not reflected in the response. Maybe this was intermittently set since there is an alternative route for GetAvailability that uses a static URI instead of a query parameter for resourceId. See /Web/Services/index.php . This fix prefers the route with explicit query params for resourceId and dateTime over the static route. Hence, the alternative route should be disabled with a subsequent change.

Please feel free to correct me if I misunderstood the function signature or if there is a way to enable both routes. I have tried but the Slim framework seems not to allow alternative signatures on the same function.

In addition, I have set the time span for the delivered availability to 7 instead of 30 days as described in the API documentation.