### PR TITLE
Fix REST API for PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
         "phpcompatibility/php-compatibility": "^9.3.5",
         "kint-php/kint": "^4.2.3"
     },
-    "require" : {
-        "php": ">=7.4",
+    "require": {
+        "php": ">=8.1",
         "smarty/smarty": "^4.3",
         "stripe/stripe-php": "^10.2",
         "monolog/monolog": "^2.9",
@@ -15,14 +15,14 @@
         "gregwar/captcha": "1.*"
     },
     "scripts": {
-        "install-tools":"phive install --trust-gpg-keys",
-        "build":"./tools/phing",
+        "install-tools": "phive install --trust-gpg-keys",
+        "build": "./tools/phing",
         "fix": "./tools/php-cs-fixer fix -v",
         "lint": "./tools/php-cs-fixer fix -vv --dry-run",
         "test": [
             "./tools/phpunit",
             "@lint"
         ],
-		"sniffer:php8": "phpcs -p ./ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --report-full=./php8-report.log --ignore=./vendor/*,./tools/*,./.git/*,./tpl_c/*,./build/*,./.phpdoc/*,./var/*,./Web/scripts/*,./Web/css/* --runtime-set testVersion 8.0"
+        "sniffer:php8": "phpcs -p ./ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --report-full=./php8-report.log --ignore=./vendor/*,./tools/*,./.git/*,./tpl_c/*,./build/*,./.phpdoc/*,./var/*,./Web/scripts/*,./Web/css/* --runtime-set testVersion 8.0"
     }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.1-apache
 
 WORKDIR "/var/www/html"
 
@@ -15,3 +15,4 @@ RUN pecl install xdebug \
     && docker-php-ext-enable xdebug
 
 RUN a2enmod rewrite
+RUN a2enmod headers

--- a/lib/WebService/Slim/SlimServiceRegistration.php
+++ b/lib/WebService/Slim/SlimServiceRegistration.php
@@ -103,6 +103,11 @@ class SlimAdminServiceRegistration extends SlimSecureServiceRegistration
 
 class SlimServiceMetadata
 {
+    public $description;
+    public $return;
+    public $request;
+    public $name;
+
     public function __construct($callback)
     {
         if (is_object($callback[0])) {
@@ -117,7 +122,7 @@ class SlimServiceMetadata
         $this->name = isset($doc['name']) ? $doc['name'] : null;
         $this->description = isset($doc['description']) ? $doc['description'] : null;
         $this->return = $doc['response'];
-        $this->request = $doc['request'];
+        $this->request = isset($doc['request']) ? $doc['request'] : null;
     }
 
     /**

--- a/lib/external/Slim/Http/Util.php
+++ b/lib/external/Slim/Http/Util.php
@@ -54,10 +54,9 @@ class Util
      * @var    array|string    $rawData
      * @return array|string
      */
-    public static function stripSlashesIfMagicQuotes($rawData, $overrideStripSlashes = null)
+    public static function stripSlashesIfMagicQuotes($rawData, $stripSlashes = false)
     {
-        $strip = is_null($overrideStripSlashes) ? get_magic_quotes_gpc() : $overrideStripSlashes;
-        if ($strip) {
+        if ($stripSlashes) {
             return self::_stripSlashes($rawData);
         } else {
             return $rawData;


### PR DESCRIPTION
Fixes some deprecations issues in the REST api on PHP8. Most problematic is the use of `get_magic_quotes_gpc()`, which has been removed in PHP8.0.

LibreBooking runs on Slim framework V2, which has been EOL for some time now. It is recommended to upgrade to Slim V4 at some point (along with other third party libs like Pearc components). But this will take considerably more effort.