### PR TITLE
Plus operator fixed with negative numbers in Date Add methods

### DIFF
--- a/lib/Common/Date.php
+++ b/lib/Common/Date.php
@@ -439,6 +439,10 @@ class Date
         return !$this->IsWeekday();
     }
 
+    private function getOperator(int $number): string
+    {
+        return $number < 0 ? " -" : " +";
+    }
     /**
      * @param int $days
      * @return Date
@@ -446,7 +450,7 @@ class Date
     public function AddDays($days)
     {
         // can also use DateTime->modify()
-        return new Date($this->Format(self::SHORT_FORMAT) . " +" . $days . " days", $this->timezone);
+        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($days) . $days . " days", $this->timezone);
     }
 
     /**
@@ -455,7 +459,7 @@ class Date
      */
     public function AddMonths($months)
     {
-        return new Date($this->Format(self::SHORT_FORMAT) . " +" . $months . " months", $this->timezone);
+        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($months) . $months . " months", $this->timezone);
     }
 
     /**
@@ -464,7 +468,7 @@ class Date
      */
     public function AddYears($years)
     {
-        return new Date($this->Format(self::SHORT_FORMAT) . " +" . $years . " years", $this->timezone);
+        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($years) . $years . " years", $this->timezone);
     }
 
     /**

--- a/tests/Infrastructure/Common/DateTest.php
+++ b/tests/Infrastructure/Common/DateTest.php
@@ -377,9 +377,9 @@ class DateTests extends TestBase
         //			echo $d->ToString();
         //			echo "\n";
         //		}
-//
+        //
         //		echo "\n";
-//
+        //
         //		foreach ($actual as $d)
         //		{
         //			echo $d->ToString();
@@ -549,9 +549,9 @@ class DateTests extends TestBase
         $this->assertTrue($d1->DateEquals($d2));
 
         //		$d1 = new Date('2014-09-14 02:00:00', 'America/Chicago');
-//		$d2 = new Date('2014-09-14 22:00:00', 'Europe/Berlin');
-//
-//		$this->assertFalse($d1->DateEquals($d2));
+        //		$d2 = new Date('2014-09-14 22:00:00', 'Europe/Berlin');
+        //
+        //		$this->assertFalse($d1->DateEquals($d2));
     }
 
     public function testCountsWeekdaysAndWeekends()
@@ -641,5 +641,47 @@ class DateTests extends TestBase
         $this->assertTrue($expected[1]->Equals($actual[1]), "Dates[1] are not equal");
         $this->assertTrue($expected[2]->Equals($actual[2]), "Dates[2] are not equal");
         $this->assertTrue($expected[3]->Equals($actual[3]), "Dates[3] are not equal");
+    }
+
+    public function testAddMonth()
+    {
+        $hour = 11;
+        $minute = 40;
+        $second = 22;
+        $month = 3;
+        $day = 21;
+        $year = 2007;
+
+        $now = new Date("$year-$month-$day $hour:$minute:$second");
+        $expectedTS = mktime($hour, $minute, $second, $month + 1, $day, $year);
+        $nextMonth = $now->AddMonths(1);
+
+        $this->assertEquals($expectedTS, $nextMonth->Timestamp());
+
+        $expectedTS = mktime($hour, $minute, $second, $month - 1, $day, $year);
+        $nextMonth = $now->AddMonths(-1);
+
+        $this->assertEquals($expectedTS, $nextMonth->Timestamp());
+    }
+
+    public function testAddYear()
+    {
+        $hour = 11;
+        $minute = 40;
+        $second = 22;
+        $month = 3;
+        $day = 21;
+        $year = 2007;
+
+        $now = new Date("$year-$month-$day $hour:$minute:$second");
+        $expectedTS = mktime($hour, $minute, $second, $month, $day, $year + 1);
+        $nextMonth = $now->AddYears(1);
+
+        $this->assertEquals($expectedTS, $nextMonth->Timestamp());
+
+        $expectedTS = mktime($hour, $minute, $second, $month, $day, $year - 1);
+        $nextMonth = $now->AddYears(-1);
+
+        $this->assertEquals($expectedTS, $nextMonth->Timestamp());
     }
 }


### PR DESCRIPTION
This fix is for issue the https://github.com/LibreBooking/app/issues/173 .

I added a couple of tests related with month and year handling and the current days tests are failing, so it was not necessary to add more tests, just fix them was ok.

I don't know if exists some guidelines to contribute, the README.md in /doc was not helpful to make this PR, but just let me know if I have to modify something.

