### PR TITLE
Fix for inconsistent DateTime behaviour between PHP versions

### DIFF
--- a/lib/Common/Date.php
+++ b/lib/Common/Date.php
@@ -450,7 +450,7 @@ class Date
     public function AddDays($days)
     {
         // can also use DateTime->modify()
-        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($days) . $days . " days", $this->timezone);
+        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($days) . abs($days) . " days", $this->timezone);
     }
 
     /**
@@ -459,7 +459,7 @@ class Date
      */
     public function AddMonths($months)
     {
-        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($months) . $months . " months", $this->timezone);
+        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($months) . abs($months) . " months", $this->timezone);
     }
 
     /**
@@ -468,7 +468,7 @@ class Date
      */
     public function AddYears($years)
     {
-        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($years) . $years . " years", $this->timezone);
+        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($years) . abs($years) . " years", $this->timezone);
     }
 
     /**


### PR DESCRIPTION
Recently a fix for date handling in PHP 8.2 was added in PR #209 which resolves an issue where the Schedule previous date buttons were always progressing forwards rather than back.

@jplagostena correctly traced this back to the handling of the +/- in PHP 8.2 and added a fix.

Unfortunately this fix breaks on 8.1 and lower and introduces the same issue in that environment. While obviously the intent is to support later versions of PHP, I think consistent behaviour across versions is desirable.

I've added a very simple addition to the work by @jplagostena to use the absolute value passed in, once the correct + or - prefix has been determined. This means there is only ever a single plus or minus operator added, and avoids the issue with double negatives across all PHP versions.

Here are some tests showing the handling across PHP versions:
`
$t = new DateTime('2023-10-10 --3 days');
echo $t->format('Y-m-d');
`

**Result under PHP 8.2.10, 8.3.0rc1:**
2023-10-07

**Result under PHP 8.1.23, 8.0.30, 7.4.33:**
2023-10-13

Clearly there was a change in 8.2+ in how these double negatives are handled (8.2+ ignores the double negatives and treats them as just a single negative).

The attached PR should behave correctly regardless of PHP version. Cheers!