### PR TITLE
Public resource booking for a longer period

### DIFF
--- a/Pages/ResourceDisplayPage.php
+++ b/Pages/ResourceDisplayPage.php
@@ -277,7 +277,7 @@ class ResourceDisplayPage extends ActionPage implements IResourceDisplayPage, IR
         $this->Set('InitialDate', $this->GetStartDate()->Format('Y-m-d H:i:s'));
         $futureDays = Configuration::Instance()->GetSectionKey(ConfigSection::PRIVACY, ConfigKeys::PRIVACY_PUBLIC_FUTURE_DAYS, new IntConverter());
         if ($futureDays == 0) {
-            $futureDays = 7;
+            $futureDays = 1;
         }
         $this->Set('MaxFutureDate', Date::Now()->AddDays($futureDays-1));
         $this->Display('ResourceDisplay/resource-display-shell.tpl');

--- a/Pages/ResourceDisplayPage.php
+++ b/Pages/ResourceDisplayPage.php
@@ -43,13 +43,14 @@ interface IResourceDisplayPage extends IPage, IActionPage
     /**
      * @param IDailyLayout $dailyLayout
      * @param Date $today
+     * @param Date $reservationDate
      * @param ReservationListItem|null $current
      * @param ReservationListItem|null $next
      * @param ReservationListItem[] $upcoming
      * @param bool $requiresCheckin
      * @param string $checkinReferenceNumber
      */
-    public function DisplayAvailability(IDailyLayout $dailyLayout, Date $today, $current, $next, $upcoming, $requiresCheckin, $checkinReferenceNumber);
+    public function DisplayAvailability(IDailyLayout $dailyLayout, Date $today, Date $reservationDate, $current, $next, $upcoming, $requiresCheckin, $checkinReferenceNumber);
 
     /**
      * @param bool $availableNow
@@ -225,16 +226,22 @@ class ResourceDisplayPage extends ActionPage implements IResourceDisplayPage, IR
         return $this->GetQuerystring(QueryStringKeys::RESOURCE_ID);
     }
 
+    public function GetStartDate()
+    {
+        return $this->GetQuerystring(QueryStringKeys::START_DATE);
+    }
+    
     public function BindResource(BookableResource $resource)
     {
         $this->Set('ResourceName', $resource->GetName());
         $this->Set('ResourceId', $resource->GetId());
     }
 
-    public function DisplayAvailability(IDailyLayout $dailyLayout, Date $today, $current, $next, $upcoming, $requiresCheckin, $checkinReferenceNumber)
+    public function DisplayAvailability(IDailyLayout $dailyLayout, Date $today, Date $reservationDate, $current, $next, $upcoming, $requiresCheckin, $checkinReferenceNumber)
     {
         $this->Set('TimeFormat', Resources::GetInstance()->GetDateFormat('period_time'));
         $this->Set('Today', $today);
+        $this->Set('ReservationDate', $reservationDate);
         $this->Set('Now', Date::Now());
         $this->Set('DailyLayout', $dailyLayout);
         $this->Set('SlotLabelFactory', new SlotLabelFactory(new NullUserSession()));
@@ -260,6 +267,7 @@ class ResourceDisplayPage extends ActionPage implements IResourceDisplayPage, IR
     public function DisplayResourceShell()
     {
         $this->Set('PublicResourceId', $this->GetPublicResourceId());
+        $this->Set('StartDate', $this->GetStartDate());
         $this->Display('ResourceDisplay/resource-display-shell.tpl');
     }
 
@@ -271,6 +279,11 @@ class ResourceDisplayPage extends ActionPage implements IResourceDisplayPage, IR
     public function GetBeginTime()
     {
         return $this->GetForm(FormKeys::BEGIN_PERIOD);
+    }
+
+    public function GetBeginDate()
+    {
+        return $this->GetForm(FormKeys::BEGIN_DATE);
     }
 
     public function GetEndTime()

--- a/Web/css/booked.css
+++ b/Web/css/booked.css
@@ -2926,3 +2926,13 @@ ul.jqtree-tree .jqtree-toggler {
 #page-resource-display-resource #validationErrors {
   text-align: left;
 }
+#page-resource-display-resource .date-picker {
+  position: absolute;
+  top: 72px;
+  z-index: 999;
+  left: 48px;
+}
+#page-resource-display-resource .date-picker .date{
+  text-align: left;
+}
+

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -80,6 +80,7 @@ class ConfigKeys
     public const PRIVACY_VIEW_RESERVATIONS = 'view.reservations';
     public const PRIVACY_VIEW_SCHEDULES = 'view.schedules';
     public const PRIVACY_ALLOW_GUEST_BOOKING = 'allow.guest.reservations';
+    public const PRIVACY_PUBLIC_FUTURE_DAYS = 'public.future.days';
 
     public const NOTIFY_CREATE_RESOURCE_ADMINS = 'resource.admin.add';
     public const NOTIFY_CREATE_APPLICATION_ADMINS = 'application.admin.add';

--- a/tests/Presenters/ResourceDisplayPresenterTest.php
+++ b/tests/Presenters/ResourceDisplayPresenterTest.php
@@ -475,7 +475,7 @@ class TestResourceDisplayPage extends FakePageBase implements IResourceDisplayPa
         return $this->_PublicResourceId;
     }
 
-    public function DisplayAvailability(IDailyLayout $dailyLayout, Date $today, $current, $next, $upcoming, $requiresCheckin, $checkinReferenceNumber)
+    public function DisplayAvailability(IDailyLayout $dailyLayout, Date $today, Date $reservationDate, $current, $next, $upcoming, $requiresCheckin, $checkinReferenceNumber)
     {
         $this->_DailyLayout = $dailyLayout;
         $this->_CurrentReservation = $current;

--- a/tpl/ResourceDisplay/resource-display-resource.tpl
+++ b/tpl/ResourceDisplay/resource-display-resource.tpl
@@ -10,7 +10,6 @@
 <div id="resource-display" class="resource-display">
     <div class="col-xs-7 left-panel">
         <div class="resource-display-name">{$ResourceName}</div>
-        <div class="date" style="text-align:left">{formatdate date=$ReservationDate key=schedule_daily timezone=$Timezone}</div>
 
         <div class="resource-display-current">
             {if $AvailableNow}
@@ -45,8 +44,7 @@
         </div>
     </div>
     <div class="col-xs-5 right-panel">
-        <div class="time">{formatdate date=$Now key=period_time timezone=$Timezone}</div>
-        <div class="date">{formatdate date=$Now key=schedule_daily timezone=$Timezone}</div>
+        <div class="date">{formatdate date=$ReservationDate key=schedule_daily timezone=$Timezone}</div>
         <div class="upcoming-reservations">
             <div class="resource-display-heading">{translate key=UpcomingReservations}</div>
             {if $UpcomingReservations|default:array()|count > 0}

--- a/tpl/ResourceDisplay/resource-display-resource.tpl
+++ b/tpl/ResourceDisplay/resource-display-resource.tpl
@@ -10,6 +10,7 @@
 <div id="resource-display" class="resource-display">
     <div class="col-xs-7 left-panel">
         <div class="resource-display-name">{$ResourceName}</div>
+        <div class="date" style="text-align:left">{formatdate date=$ReservationDate key=schedule_daily timezone=$Timezone}</div>
 
         <div class="resource-display-current">
             {if $AvailableNow}
@@ -77,14 +78,14 @@
                         <table class="reservations">
                             <thead>
                             <tr>
-                                {foreach from=$DailyLayout->GetPeriods($Today, true) item=period}
-                                    <td class="reslabel" colspan="{$period->Span()}">{$period->Label($Today)}</td>
+                                {foreach from=$DailyLayout->GetPeriods($ReservationDate, true) item=period}
+                                    <td class="reslabel" colspan="{$period->Span()}">{$period->Label($ReservationDate)}</td>
                                 {/foreach}
                             </tr>
                             </thead>
                             <tbody>
                             <tr>
-                                {assign var=slots value=$DailyLayout->GetLayout($Today, $ResourceId)}
+                                {assign var=slots value=$DailyLayout->GetLayout($ReservationDate, $ResourceId)}
                                 {foreach from=$slots item=slot}
                                     {assign var="referenceNumber" value=""}
                                     {if $slot->IsReserved()}
@@ -130,7 +131,7 @@
                         <select title="Begin" class="form-control" aria-describedby="starttime-addon"
                                 id="beginPeriod" {formname key=BEGIN_PERIOD}>
                             {foreach from=$slots item=slot}
-                                {if $slot->IsReservable() && !$slot->IsPastDate($Today)}
+                                {if $slot->IsReservable() && !$slot->IsPastDate($ReservationDate)}
                                     <option value="{$slot->Begin()}">{$slot->Begin()->Format($TimeFormat)}</option>
                                 {/if}
                             {/foreach}
@@ -144,7 +145,7 @@
                         <select title="End" class="form-control input-lg" aria-describedby="endtime-addon"
                                 id="endPeriod" {formname key=END_PERIOD}>
                             {foreach from=$slots item=slot}
-                                {if $slot->IsReservable() && !$slot->IsPastDate($Today)}
+                                {if $slot->IsReservable() && !$slot->IsPastDate($ReservationDate)}
                                     <option value="{$slot->End()}">{$slot->End()->Format($TimeFormat)}</option>
                                 {/if}
                             {/foreach}
@@ -196,6 +197,7 @@
             <input type="hidden" {formname key=RESOURCE_ID} value="{$ResourceId}"/>
             <input type="hidden" {formname key=SCHEDULE_ID} value="{$ScheduleId}"/>
             <input type="hidden" {formname key=TIMEZONE} value="{$Timezone}"/>
+            <input type="hidden" {formname key=BEGIN_DATE} value="{$ReservationDate}"/>
         </form>
     </div>
 

--- a/tpl/ResourceDisplay/resource-display-shell.tpl
+++ b/tpl/ResourceDisplay/resource-display-shell.tpl
@@ -18,7 +18,7 @@
 		var resourceDisplay = new ResourceDisplay();
 		resourceDisplay.initDisplay(
                 {
-                    url: '{$smarty.server.SCRIPT_NAME}?dr=resource&rid={$PublicResourceId}&dr=display',
+                    url: '{$smarty.server.SCRIPT_NAME}?dr=resource&rid={$PublicResourceId}&dr=display&sd={$StartDate}',
                     userAutocompleteUrl: "ajax/autocomplete.php?type={AutoCompleteType::User}&as=1",
                     allowAutocomplete: {if $AllowAutocomplete}true{else}false{/if}
                 }

--- a/tpl/ResourceDisplay/resource-display-shell.tpl
+++ b/tpl/ResourceDisplay/resource-display-shell.tpl
@@ -1,6 +1,15 @@
 {include file='globalheader.tpl' HideNavBar=true}
 
 <div id="page-resource-display-resource">
+
+<div class="resource-display date-picker">
+        <div class="date form-group" style="width: 50%;">
+                <label for="availabilityStartDate">{translate key='Date'}</label>
+                <input type="text" id="availabilityStartDate" class="form-control" {formname key=ANNOUNCEMENT_START} />
+                <input type="hidden" id="formattedBeginDate" {formname key=ANNOUNCEMENT_START} />
+        </div>
+</div>
+
 <div id="placeholder"></div>
 </div>
 
@@ -13,14 +22,21 @@
 {jsfile src="ajax-helpers.js"}
 {jsfile src="autocomplete.js"}
 
+{control type="DatePickerSetupControl" ControlId="availabilityStartDate" AltId="formattedBeginDate" MaxDate=$MaxFutureDate}
+
 <script type="text/javascript">
+        function getResourceId() {
+                return '{$PublicResourceId}';
+        }
 	$(function () {
 		var resourceDisplay = new ResourceDisplay();
 		resourceDisplay.initDisplay(
                 {
-                    url: '{$smarty.server.SCRIPT_NAME}?dr=resource&rid={$PublicResourceId}&dr=display&sd={$StartDate}',
+                    url: '{$smarty.server.SCRIPT_NAME}?dr=resource&rid={$PublicResourceId}&dr=display',
                     userAutocompleteUrl: "ajax/autocomplete.php?type={AutoCompleteType::User}&as=1",
-                    allowAutocomplete: {if $AllowAutocomplete}true{else}false{/if}
+                    allowAutocomplete: {if $AllowAutocomplete}true{else}false{/if},
+                    initialDate: '{$InitialDate}',
+                    MaxDate: '{$MaxFutureDate}'
                 }
         );
 	});


### PR DESCRIPTION
This feature adds the possibility to choose a later date in the public view of a resource currently limited to the current day only.
- New configuration setting: `$conf['settings']['privacy']['public.future.days']` which default to 1 to get the current behavior
- Date picker on the public resource page which reloads the page accordingly and displays the reservations of the selected day (adds a couple of refresh indicators along the way)
- Server side check to avoid bypass on the maximum bookable day
- Basic error message when the date is not authorized (<- could be improved to be region-based)

![image](https://github.com/LibreBooking/app/assets/15873382/ad24dec8-8948-475f-8f45-dec120b0dd0e)


_Due to the fact that the page is a mix of Smarty templates and static php page loaded by ajax, the date picker is created in the template and displayed over the rest of page as a floating div_