### PR TITLE
Add mysqli_report() to the config file.

### DIFF
--- a/lib/Config/Configurator.php
+++ b/lib/Config/Configurator.php
@@ -120,7 +120,7 @@ class Configurator implements IConfigurationSettings
             return;
         }
         $contents = file_get_contents($file);
-        $new = str_replace("<?php", "<?php\r\nerror_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);\r\n", $contents);
+        $new = str_replace("<?php", "<?php\r\nmysqli_report(MYSQLI_REPORT_OFF);\r\nerror_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);\r\n", $contents);
 
         file_put_contents($file, $new);
     }


### PR DESCRIPTION
Without adding mysqli_report() to the config file the config file is automatically broken on hitting "Update" on the Web/admin/manage_configuration.php page.