### PR TITLE
Fix homepage default value in self-register form

### DIFF
--- a/Presenters/RegistrationPresenter.php
+++ b/Presenters/RegistrationPresenter.php
@@ -207,7 +207,7 @@ class RegistrationPresenter extends ActionPresenter
 
         $this->page->SetHomepages($homepageValues, $homepageOutput);
 
-        $homepageId = 1;
+        $homepageId = Configuration::Instance()->GetKey(ConfigKeys::DEFAULT_HOMEPAGE, new IntConverter());
         if ($this->page->IsPostBack()) {
             $homepageId = $this->page->GetHomepage();
         }


### PR DESCRIPTION
homepage default value should come from the application settings and not forced to 1 (ie. Dashboard)