### PR TITLE
Ldap groups sync: miscellaneous fixes

### DIFF
--- a/lib/Application/Authentication/Registration.php
+++ b/lib/Application/Authentication/Registration.php
@@ -197,7 +197,7 @@ class Registration implements IRegistration
                     Log::Debug('Syncing group %s for user %s', $group->Name(), $user->Username());
                     $groupsToSync[] = new UserGroup($group->Id(), $group->Name());
                 } else {
-                    Log::Debug('User %s is not part of group %s, sync skipped', $group->Name(), $user->Username());
+                    Log::Debug('User %s is not part of group %s, sync skipped', $user->Username(), $group->Name());
                 }
             }
         }

--- a/plugins/Authentication/Ldap/Ldap2Wrapper.php
+++ b/plugins/Authentication/Ldap/Ldap2Wrapper.php
@@ -134,7 +134,7 @@ class Ldap2Wrapper
             }
 
             if ($loadGroups) {
-                $userGroups = $currentResult->getValue('memberof');
+                $userGroups = $currentResult->getValue('memberof', 'all');
                 $userGroups = array_map('trim', $userGroups);
                 $userGroups = array_map('strtolower', $userGroups);
             }


### PR DESCRIPTION
### Changes
- Fix debug message when group is not synced: user and group names are inverted
- Add argument `'all'` to function getValue to ensure that it always return an array, otherwise the following statement with array_map will trigger an exception