### PR TITLE
Enhance LDAP group synching

### DIFF
--- a/lib/Application/Authentication/Registration.php
+++ b/lib/Application/Authentication/Registration.php
@@ -188,6 +188,8 @@ class Registration implements IRegistration
         $groupsToSync = [];
         if ($userGroups != null) {
             $lowercaseGroups = array_map('strtolower', $userGroups);
+            $altGroups = $userGroups;
+            $altGroups= array_map(function($dn) {return sscanf(explode(",", $dn)[0], "cn=%s,")[0];}, $altGroups);
 
             $groupsToSync = [];
             $groups = $this->groupRepository->GetList()->Results();
@@ -197,7 +199,12 @@ class Registration implements IRegistration
                     Log::Debug('Syncing group %s for user %s', $group->Name(), $user->Username());
                     $groupsToSync[] = new UserGroup($group->Id(), $group->Name());
                 } else {
-                    Log::Debug('User %s is not part of group %s, sync skipped', $user->Username(), $group->Name());
+                    if (in_array(strtolower($group->Name()), $altGroups)) {
+                      Log::Debug('Syncing group %s for user %s', $group->Name(), $user->Username());
+                      $groupsToSync[] = new UserGroup($group->Id(), $group->Name());
+                    } else {
+                      Log::Debug('User %s is not part of group %s, sync skipped', $user->Username(), $group->Name());
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Changes

- Before modification: synch worked only for librebooking groups whose name matched the LDAP dn, as in `cn=librebooking.users,ou=groups,dc=example,dc=org`.
- After modification: sync works also for librebooking groups whose name matches the LDAP cn, as in `librebooking.users`