### PR TITLE
Fix directive for Strict-Transport-Security

### DIFF
--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -169,7 +169,7 @@ $conf['settings']['reservation.labels']['reservation.popup'] = ''; // Format for
  * Security header settings
  */
 $conf['settings']['security']['security.headers'] = 'false'; // Enable the following options
-$conf['settings']['security']['security.strict-transport'] = 'true';
+$conf['settings']['security']['security.strict-transport'] = 'max-age=31536000';
 $conf['settings']['security']['security.x-frame'] = 'deny';
 $conf['settings']['security']['security.x-xss'] = '1; mode=block';
 $conf['settings']['security']['security.x-content-type'] = 'nosniff';

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -169,7 +169,7 @@ $conf['settings']['reservation.labels']['reservation.popup'] = ''; // Format for
  * Security header settings
  */
 $conf['settings']['security']['security.headers'] = 'false'; // Enable the following options
-$conf['settings']['security']['security.strict-transport'] = 'true';
+$conf['settings']['security']['security.strict-transport'] = 'max-age=31536000';
 $conf['settings']['security']['security.x-frame'] = 'deny';
 $conf['settings']['security']['security.x-xss'] = '1; mode=block';
 $conf['settings']['security']['security.x-content-type'] = 'nosniff';


### PR DESCRIPTION
### Changes
- Fix the directive for header `Strict-Transport-Security`

### Rationale
True | false is not a valid directive for the STS header. Valid directives are:
- max-age
- includeSubDomains
- preload

Check https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
