### PR TITLE
Fix resource-group deletion

### DIFF
--- a/Presenters/Admin/ManageResourceGroupsPresenter.php
+++ b/Presenters/Admin/ManageResourceGroupsPresenter.php
@@ -120,7 +120,7 @@ class ManageResourceGroupsPresenter extends ActionPresenter
     {
         $nodeId = $this->page->GetNodeId();
 
-        Log::Debug('Deleting resource group. NodeId=%s, NewName=%s', $nodeId);
+        Log::Debug('Deleting resource group. NodeId=%s', $nodeId);
 
         $this->resourceRepository->DeleteResourceGroup($nodeId);
     }


### PR DESCRIPTION
Fix wrong call to Log::Debug
When deleting a resource group, Log::debug only needs the nodeId