### PR TITLE
Review the logging feature (Log.php)

### DIFF
--- a/lib/Common/Logging/Log.php
+++ b/lib/Common/Logging/Log.php
@@ -35,11 +35,18 @@ class Log
         if ($log_level != 'none') {
             $log_folder = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_FOLDER);
             $log_sql = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_SQL, new BooleanConverter());
-            $this->logger->pushHandler(new StreamHandler($log_folder.'/app.log', Logger::DEBUG));
-        }
-            if ($log_sql) {
-                $this->sqlLogger->pushHandler(new StreamHandler($log_folder.'/sql.log', Logger::DEBUG));
+            switch ($log_level) {
+                case 'debug':
+                    $this->logger->pushHandler(new StreamHandler($log_folder.'/app.log', Logger::DEBUG));
+                    break;
+                case 'error':
+                    $this->logger->pushHandler(new StreamHandler($log_folder.'/app.log', Logger::ERROR));
+                    break;
             }
+        }
+        if ($log_sql) {
+            $this->sqlLogger->pushHandler(new StreamHandler($log_folder.'/sql.log', Logger::ERROR));
+        }
     }
 
     /**

--- a/lib/Common/Logging/Log.php
+++ b/lib/Common/Logging/Log.php
@@ -79,7 +79,7 @@ class Log
 
             $log = '[User=' . ServiceLocator::GetServer()->GetUserSession() . '] ' . $log;
 
-            self::GetInstance()->logger->info($log);
+            self::GetInstance()->logger->debug($log);
         } catch (Exception $ex) {
             echo $ex;
         }

--- a/lib/Common/Logging/Log.php
+++ b/lib/Common/Logging/Log.php
@@ -68,7 +68,7 @@ class Log
     public static function Debug($message, $args = [])
     {
         $log_level = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_LEVEL);
-        if ($log_level == 'none' || $log_level == 'error') {
+        if ($log_level == 'none') {
             return;
         }
 
@@ -99,7 +99,7 @@ class Log
     public static function Error($message, $args = [])
     {
         $log_level = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_LEVEL);
-        if ($log_level == 'none' || $log_level == 'debug') {
+        if ($log_level == 'none') {
             return;
         }
 


### PR DESCRIPTION
### Changes
1. Function **debug()** should call Monolog method `Logger->debug()` instead of method Logger->info()
2. Method `Logger->PushHandler` should be invoked with the error level which is in line with the settings file config.php
3. Functions **debug()** and **error()** should not test the error level. They should let Monolog decide whether to log the message or not, based on the log level specified on the handler (see above):
   - If log level is **debug**, then debug and error message should be displayed
   - If log level is **error**, then only error messages are displayed