### PR TITLE
Review user authentication logging

### DIFF
--- a/lib/Application/Authentication/Authentication.php
+++ b/lib/Application/Authentication/Authentication.php
@@ -98,7 +98,7 @@ class Authentication implements IAuthentication
         }
 
         if ($valid) {
-            Log::Debug('Successfull user authentication for %s', $username);
+            Log::Debug('Successful user authentication for %s', $username);
           }
           else {
             Log::Error('Failed user authentication for %s', $username);

--- a/lib/Application/Authentication/Authentication.php
+++ b/lib/Application/Authentication/Authentication.php
@@ -97,8 +97,14 @@ class Authentication implements IAuthentication
             }
         }
 
-        Log::Debug('User: %s, was validated: %d', $username, $valid);
-        return $valid;
+        if ($valid) {
+            Log::Debug('Successfull user authentication for %s', $username);
+          }
+          else {
+            Log::Error('Failed user authentication for %s', $username);
+          }
+        
+          return $valid;
     }
 
     public function Login($username, $loginContext)


### PR DESCRIPTION
### Changes
- Use easier-to-read statements
- Failed user authentication triggers an error logging
