### PR TITLE
Use the Monolog-provided WebProcessor to log extra data

### DIFF
--- a/lib/Common/Logging/Log.php
+++ b/lib/Common/Logging/Log.php
@@ -6,6 +6,7 @@ if (file_exists(ROOT_DIR . 'vendor/autoload.php')) {
 
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
+use Monolog\Processor\WebProcessor;
 
 
 class Log
@@ -43,6 +44,7 @@ class Log
                     $this->logger->pushHandler(new StreamHandler($log_folder.'/app.log', Logger::ERROR));
                     break;
             }
+            $this->logger->pushProcessor(new WebProcessor());
         }
         if ($log_sql) {
             $this->sqlLogger->pushHandler(new StreamHandler($log_folder.'/sql.log', Logger::ERROR));


### PR DESCRIPTION
The following data will be added to the Monolog `app` channel:
- 'REQUEST_URI'
- 'REMOTE_ADDR'
- 'REQUEST_METHOD'
- 'SERVER_NAME'
- 'HTTP_REFERER'
- 'HTTP_USER_AGENT'

The `REMOTE_ADDR` enables the future implementation of a `fail2ban` jail.