### PR TITLE
MultiQuery - free results after each query

### DIFF
--- a/lib/Database/MySQL/MySqlConnection.php
+++ b/lib/Database/MySQL/MySqlConnection.php
@@ -95,6 +95,11 @@ class MySqlConnection implements IDbConnection
 
         if ($sqlCommand->IsMultiQuery()) {
             $result = mysqli_multi_query($this->_db, $mysqlCommand->GetQuery());
+            do
+            {
+                if ($r = mysqli_store_result($this->_db))
+                    mysqli_free_result($r);
+            } while(mysqli_next_result($this->_db));
         } else {
             $result = mysqli_query($this->_db, $mysqlCommand->GetQuery());
         }


### PR DESCRIPTION
I am working with a derived transaction save database class which uses multi queries. The current implementation of multi queries does not work.

Results must be freed after each query of a multi query!