### PR TITLE
Close a critical vulnerability hole in .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,8 +6,8 @@ RewriteEngine On
 #RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
 RewriteRule ^Web - [L,NC]
-RewriteCond %{REQUEST_FILENAME} !-d
-RewriteCond %{REQUEST_FILENAME} !-f
+#RewriteCond %{REQUEST_FILENAME} !-d
+#RewriteCond %{REQUEST_FILENAME} !-f
 RewriteRule ^(.*)$ Web/$1 [QSA,L]
 
 #Header Set Access-Control-Allow-Origin "*"


### PR DESCRIPTION
The rewrite rules for `REQUEST_FILENAME ` allow direct file access to all existing paths that don't match the first rule.

For example you can read the git config of an instance simply be entering

> https:://librebooking.example.com/.git/config

in your browser.