### PR TITLE
Past reservations dashboard

### DIFF
--- a/Controls/Dashboard/PastReservations.php
+++ b/Controls/Dashboard/PastReservations.php
@@ -1,0 +1,98 @@
+<?php
+
+require_once(ROOT_DIR . 'Controls/Dashboard/DashboardItem.php');
+require_once(ROOT_DIR . 'Presenters/Dashboard/PastReservationsPresenter.php');
+require_once(ROOT_DIR . 'Domain/Access/ReservationViewRepository.php');
+
+class PastReservations extends DashboardItem implements IPastReservationsControl
+{
+    /**
+     * @var PastReservationsPresenter
+     */
+    protected $presenter;
+
+    public function __construct(SmartyPage $smarty)
+    {
+        parent::__construct($smarty);
+        $this->presenter = new PastReservationsPresenter($this, new ReservationViewRepository());
+    }
+
+    public function PageLoad()
+    {
+        $this->Set('DefaultTitle', Resources::GetInstance()->GetString('NoTitleLabel'));
+        $this->presenter->SetSearchCriteria(ServiceLocator::GetServer()->GetUserSession()->UserId, ReservationUserLevel::ALL);
+        $this->presenter->PageLoad();
+        $this->Display('past_reservations.tpl');
+    }
+
+    public function SetTimezone($timezone)
+    {
+        $this->Set('Timezone', $timezone);
+    }
+
+    public function SetTotal($total)
+    {
+        $this->Set('Total', $total);
+    }
+
+    public function SetUserId($userId)
+    {
+        $this->Set('UserId', $userId);
+    }
+
+    public function BindToday($reservations)
+    {
+        $this->Set('TodaysReservations', $reservations);        //TodaysReservations (-)
+    }
+
+    public function BindYesterday($reservations)
+    {
+        $this->Set('YesterdayReservations', $reservations);     //YesterdayReservations
+    }
+
+    public function BindThisWeek($reservations)
+    {
+        $this->Set('ThisWeeksReservations', $reservations);     //ThisWeekReservations (-)
+    }
+
+    public function BindPreviousWeek($reservations)                 
+    {
+        $this->Set('PreviousWeekReservations', $reservations);     //PreviousWeekReservations
+    }
+
+    public function SetAllowCheckin($allowCheckin)
+    {
+        $this->Set('allowCheckin', $allowCheckin);
+    }
+
+    public function SetAllowCheckout($allowCheckout)
+    {
+        $this->Set('allowCheckout', $allowCheckout);
+    }
+}
+
+interface IPastReservationsControl
+{
+    public function SetTimezone($timezone);
+    public function SetTotal($total);
+    public function SetUserId($userId);
+
+    public function SetAllowCheckin($allowCheckin);
+    public function SetAllowCheckout($allowCheckout);
+
+    public function BindToday($reservations);       
+    public function BindYesterday($reservations);
+    public function BindThisWeek($reservations);
+    public function BindPreviousWeek($reservations);
+}
+
+class AllPastReservations extends PastReservations
+{
+    public function PageLoad()
+    {
+        $this->Set('DefaultTitle', Resources::GetInstance()->GetString('NoTitleLabel'));
+        $this->presenter->SetSearchCriteria(ReservationViewRepository::ALL_USERS, ReservationUserLevel::ALL);
+        $this->presenter->PageLoad();
+        $this->Display('admin_upcoming_reservations.tpl');
+    }
+}

--- a/Pages/Ajax/ReservationEmailPage.php
+++ b/Pages/Ajax/ReservationEmailPage.php
@@ -52,7 +52,7 @@ class ReservationEmailPage extends Page implements IReservationEmailPage
 
     public function GetEmailAddresses()
     {
-        $email = $this->GetForm('email');
+        $email = implode(',',$this->GetForm('email')); 
         return preg_split('/, ?/', $email);
     }
 }

--- a/Pages/Reservation/ExistingReservationPage.php
+++ b/Pages/Reservation/ExistingReservationPage.php
@@ -198,7 +198,7 @@ class ExistingReservationPage extends ReservationPage implements IExistingReserv
 
     public function SetTitle($title)
     {
-        $this->Set('ReservationTitle', $title);
+        $this->Set('ReservationTitle', htmlspecialchars($title));
     }
 
     public function SetDescription($description)

--- a/Presenters/Authentication/ExternalAuthLoginPresenter.php
+++ b/Presenters/Authentication/ExternalAuthLoginPresenter.php
@@ -164,7 +164,7 @@ class ExternalAuthLoginPresenter
             $this->page->ShowError(array(Resources::GetInstance()->GetString('InvalidEmailDomain')));
             return;
         }
-        if($this->registration->UserExists($email,$email)){
+        if($this->registration->UserExists($username,$email)){
             $this->authentication->Login($email, new WebLoginContext(new LoginData()));
             LoginRedirector::Redirect($this->page);
         }

--- a/Presenters/Dashboard/PastReservationsPresenter.php
+++ b/Presenters/Dashboard/PastReservationsPresenter.php
@@ -1,0 +1,92 @@
+<?php
+
+require_once(ROOT_DIR . 'Controls/Dashboard/PastReservations.php');
+
+class PastReservationsPresenter
+{
+    /**
+     * @var IPastReservationsControl
+     */
+    private $control;
+
+    /**
+     * @var IReservationViewRepository
+     */
+    private $repository;
+
+    /**
+     * @var int
+     */
+    private $searchUserId = ReservationViewRepository::ALL_USERS;
+
+    /**
+     * @var int
+     */
+    private $searchUserLevel = ReservationUserLevel::ALL;
+
+    public function __construct(IPastReservationsControl $control, IReservationViewRepository $repository)
+    {
+        $this->control = $control;
+        $this->repository = $repository;
+    }
+
+    public function SetSearchCriteria($userId, $userLevel)
+    {
+        $this->searchUserId = $userId;
+        $this->searchUserLevel = $userLevel;
+    }
+
+    public function PageLoad()
+    {
+        $user = ServiceLocator::GetServer()->GetUserSession();
+        $timezone = $user->Timezone;
+
+        $now = Date::Now();
+        $today = $now->ToTimezone($timezone)->GetDate();
+        $dayOfWeek = $today->Weekday();
+
+        $firstDate = $now->AddDays(-(13-$dayOfWeek-1));
+        $consolidated = $this->repository->GetReservations($firstDate, $now, $this->searchUserId, $this->searchUserLevel, null, null, true);
+        $yesterday = $today->AddDays(-1);
+
+        $startOfPreviousWeek = $today->AddDays(-(7+$dayOfWeek));
+
+        $todays = [];
+        $yesterdays = [];
+        $thisWeeks = [];
+        $previousWeeks = [];
+
+        /* @var $reservation ReservationItemView */
+        foreach ($consolidated as $reservation) {
+            $start = $reservation->EndDate->ToTimezone($timezone);
+
+            if ($start->DateEquals($today) && $start->TimeLessThan($now->ToTimezone($timezone)->GetTime())) {
+                $todays[] = $reservation;
+            } elseif ($start->DateEquals($yesterday)) {
+                $yesterdays[] = $reservation;
+            } elseif ($start->GreaterThan($startOfPreviousWeek->AddDays(7))) {
+                $thisWeeks[] = $reservation;
+            } else {
+                $previousWeeks[] = $reservation;
+            }
+        }
+
+        $checkinAdminOnly = Configuration::Instance()->GetSectionKey(ConfigSection::RESERVATION, ConfigKeys::RESERVATION_CHECKIN_ADMIN_ONLY, new BooleanConverter());
+        $checkoutAdminOnly = Configuration::Instance()->GetSectionKey(ConfigSection::RESERVATION, ConfigKeys::RESERVATION_CHECKOUT_ADMIN_ONLY, new BooleanConverter());
+
+        $allowCheckin = $user->IsAdmin || !$checkinAdminOnly;
+        $allowCheckout = $user->IsAdmin || !$checkoutAdminOnly;
+
+        $this->control->SetTotal(count($consolidated));
+        $this->control->SetTimezone($timezone);
+        $this->control->SetUserId($user->UserId);
+
+        $this->control->SetAllowCheckin($allowCheckin);
+        $this->control->SetAllowCheckout($allowCheckout);
+
+        $this->control->BindToday($todays);
+        $this->control->BindYesterday($yesterdays);
+        $this->control->BindThisWeek($thisWeeks);
+        $this->control->BindPreviousWeek($previousWeeks);
+    }
+}

--- a/Presenters/Dashboard/PastReservationsPresenter.php
+++ b/Presenters/Dashboard/PastReservationsPresenter.php
@@ -45,7 +45,7 @@ class PastReservationsPresenter
         $today = $now->ToTimezone($timezone)->GetDate();
         $dayOfWeek = $today->Weekday();
 
-        $firstDate = $now->AddDays(-(13-$dayOfWeek-1));
+        $firstDate = $now->AddDays(-13+(6-$dayOfWeek)+1);
         $consolidated = $this->repository->GetReservations($firstDate, $now, $this->searchUserId, $this->searchUserLevel, null, null, true);
         $yesterday = $today->AddDays(-1);
 

--- a/Presenters/Dashboard/PastReservationsPresenter.php
+++ b/Presenters/Dashboard/PastReservationsPresenter.php
@@ -60,8 +60,17 @@ class PastReservationsPresenter
         foreach ($consolidated as $reservation) {
             $start = $reservation->EndDate->ToTimezone($timezone);
 
-            if ($start->DateEquals($today) && $start->TimeLessThan($now->ToTimezone($timezone)->GetTime())) {
-                $todays[] = $reservation;
+            //The reservation gets taken out of the array if it's still ocurring so it doesn't affect the number of reservations in the displayer
+            //Ex: if we have one single past reservation that is happening it won't show on the display but next to the title it will still show 1 
+            //(number of reservations in consolidated) and it won't show the message "You have no past reservations"
+            //By doing this we solve the issue
+            if ($start->DateEquals($today)) {
+                if (!$start->TimeLessThan($now->ToTimezone($timezone)->GetTime())){
+                    $remove = array_search($reservation, $consolidated);
+                    unset($consolidated[$remove]);
+                } else {
+                    $todays[] = $reservation;
+                }
             } elseif ($start->DateEquals($yesterday)) {
                 $yesterdays[] = $reservation;
             } elseif ($start->GreaterThan($startOfPreviousWeek->AddDays(7))) {

--- a/Presenters/DashboardPresenter.php
+++ b/Presenters/DashboardPresenter.php
@@ -8,6 +8,7 @@ require_once(ROOT_DIR . 'lib/Database/Commands/namespace.php');
 require_once(ROOT_DIR . 'Controls/Dashboard/AnnouncementsControl.php');
 require_once(ROOT_DIR . 'Controls/Dashboard/UpcomingReservations.php');
 require_once(ROOT_DIR . 'Controls/Dashboard/ResourceAvailabilityControl.php');
+require_once(ROOT_DIR . 'Controls/Dashboard/PastReservations.php');
 
 class DashboardPresenter
 {
@@ -21,10 +22,12 @@ class DashboardPresenter
     public function Initialize()
     {
         $announcement = new AnnouncementsControl(new SmartyPage());
+        $pastReservations = new PastReservations(new SmartyPage());
         $upcomingReservations = new UpcomingReservations(new SmartyPage());
         $availability = new ResourceAvailabilityControl(new SmartyPage());
 
         $this->_page->AddItem($announcement);
+        $this->_page->AddItem($pastReservations);
         $this->_page->AddItem($upcomingReservations);
         $this->_page->AddItem($availability);
 

--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -278,8 +278,13 @@ class LoginPresenter
             $helper = $facebook_Client->getRedirectLoginHelper();
 
             $permissions = ['email', 'public_profile']; // Add other permissions as needed
-
-            $FacebookUrl = $helper->getLoginUrl(        //??should it use getReAuthenticationUrl??
+            
+            //The FacebookRedirectLoginHelper makes use of sessions to store a CSRF value. 
+            //You need to make sure you have sessions enabled before invoking the getLoginUrl() method.
+            if (!session_id()) {
+                session_start();
+            }
+            $FacebookUrl = $helper->getLoginUrl(
                 Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_REDIRECT_URI),
                 $permissions
             );

--- a/Presenters/Reservation/ReservationSavePresenter.php
+++ b/Presenters/Reservation/ReservationSavePresenter.php
@@ -73,7 +73,7 @@ class ReservationSavePresenter implements IReservationSavePresenter
         $repeatOptions = $roFactory->CreateFromComposite($this->page, $this->userSession->Timezone);
         $duration = $this->GetReservationDuration();
 
-        $reservationSeries = ReservationSeries::Create($userId, $resource, $title, $description, $duration, $repeatOptions, $this->userSession);
+        $reservationSeries = ReservationSeries::Create($userId, $resource, htmlspecialchars_decode($title), htmlspecialchars_decode($description), $duration, $repeatOptions, $this->userSession);
 
         $resourceIds = $this->page->GetResources();
         foreach ($resourceIds as $resourceId) {

--- a/Presenters/Reservation/ReservationUpdatePresenter.php
+++ b/Presenters/Reservation/ReservationUpdatePresenter.php
@@ -84,8 +84,8 @@ class ReservationUpdatePresenter implements IReservationUpdatePresenter
         $existingSeries->Update(
             $this->page->GetUserId(),
             $resource,
-            $this->page->GetTitle(),
-            $this->page->GetDescription(),
+            htmlspecialchars_decode($this->page->GetTitle()),
+            htmlspecialchars_decode($this->page->GetDescription()),
             $this->userSession
         );
 

--- a/Web/facebook-auth.php
+++ b/Web/facebook-auth.php
@@ -8,7 +8,9 @@ require_once(ROOT_DIR . 'lib/Common/namespace.php');
 //Need to ask facebook token directly in the redirect_uri (?) -> Can't redirect to external auth page and then ask (???)
 if (isset($_GET['code'])) { 
     //Init the Facebook SDK
-    session_start();
+    if (!session_id()) {
+        session_start();
+    }
     $facebook_Client = new Facebook\Facebook([
         'app_id'                => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_ID),
         'app_secret'            => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_SECRET),

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -1000,6 +1000,17 @@ class ar extends en_us
         $strings['ReservationParticipantJoin'] = '%s Has Joined Your Reservation for %s on %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'ليس لديك حجوزات سابقة';
+        $strings['PastReservations'] = 'الحجوزات السابقة';
+        $strings['AllNoPastReservations'] = 'لا توجد حجوزات سابقة في الـ %s الأيام السابقة';
+        $strings['AllPastReservations'] = 'كل الحجوزات السابقة';
+        $strings['Yesterday'] = 'أمس';
+        $strings['EarlierThisWeek'] = 'في وقت سابق من هذا الأسبوع';
+        $strings['PreviousWeek'] = 'الأسبوع السابق';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/bg_bg.php
+++ b/lang/bg_bg.php
@@ -493,6 +493,17 @@ class bg_bg extends en_gb
         $strings['ReportSubject'] = 'Вашият заявен отчет (%s)';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Нямате предходни резервации';
+        $strings['PastReservations'] = 'Предходни резервации';
+        $strings['AllNoPastReservations'] = 'Няма предходни резервации в последните %s дни';
+        $strings['AllPastReservations'] = 'Всички предходни резервации';
+        $strings['Yesterday'] = 'Вчера';
+        $strings['EarlierThisWeek'] = 'По-рано този седмица';
+        $strings['PreviousWeek'] = 'Предходна седмица';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/ca.php
+++ b/lang/ca.php
@@ -390,6 +390,16 @@ class ca extends en_gb
         $strings['ForgotPasswordEmailSent'] = 'S\'ha enviat un email a la direcci&oacute; proporcionada amb instruccions per reiniciar la teva contrasenya';
         //
 
+        //Past Reservations
+        $strings['NoPastReservations'] = 'No tens cap reserva anterior';
+        $strings['PastReservations'] = 'Reserves anteriors';
+        $strings['AllNoPastReservations'] = 'No hi ha cap reserva anterior en els darrers %s dies';
+        $strings['AllPastReservations'] = 'Totes les reserves anteriors';
+        $strings['Yesterday'] = 'Ahir';
+        $strings['EarlierThisWeek'] = 'Més aviat aquesta setmana';
+        $strings['PreviousWeek'] = 'Setmana anterior';
+        //End Past Reservations
+
         $this->Strings = $strings;
     }
 

--- a/lang/cz.php
+++ b/lang/cz.php
@@ -809,6 +809,17 @@ class cz extends en_us
         $strings['ReservationParticipantJoin'] = '%s se přidal k vašemu pozvání k rezervaci %s na %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Nemáte žádné minulé rezervace';
+        $strings['PastReservations'] = 'Minulé rezervace';
+        $strings['AllNoPastReservations'] = 'Nejsou žádné minulé rezervace v posledních %s dnech';
+        $strings['AllPastReservations'] = 'Všechny minulé rezervace';
+        $strings['Yesterday'] = 'Včera';
+        $strings['EarlierThisWeek'] = 'Dříve v tomto týdnu';
+        $strings['PreviousWeek'] = 'Předchozí týden';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/da_da.php
+++ b/lang/da_da.php
@@ -996,6 +996,17 @@ class da_da extends en_gb
         $strings['ReservationParticipantJoin'] = '% har tilmeldt sig din reservationen af %s på %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Du har ingen tidligere reservationer';
+        $strings['PastReservations'] = 'Tidligere reservationer';
+        $strings['AllNoPastReservations'] = 'Der er ingen tidligere reservationer i de seneste %s dage';
+        $strings['AllPastReservations'] = 'Alle tidligere reservationer';
+        $strings['Yesterday'] = 'I går';
+        $strings['EarlierThisWeek'] = 'Tidligere på ugen';
+        $strings['PreviousWeek'] = 'Forrige uge';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -969,6 +969,17 @@ class de_de extends en_gb
         $strings['MissedCheckinEmailSubject'] = 'Anmeldung verpasst für %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Sie haben keine vergangenen Reservierungen';
+        $strings['PastReservations'] = 'Vergangene Reservierungen';
+        $strings['AllNoPastReservations'] = 'Es gibt keine vergangenen Reservierungen in den letzten %s Tagen';
+        $strings['AllPastReservations'] = 'Alle vergangenen Reservierungen';
+        $strings['Yesterday'] = 'Gestern';
+        $strings['EarlierThisWeek'] = 'Früher in dieser Woche';
+        $strings['PreviousWeek'] = 'Vorherige Woche';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/du_be.php
+++ b/lang/du_be.php
@@ -388,7 +388,18 @@ class du_be extends en_gb
         $strings['InviteeAddedSubject'] = 'Uitnodiging reservering';
         $strings['ResetPassword'] = 'Verzoek om paswoord te resetten';
         $strings['ForgotPasswordEmailSent'] = 'Een email werd naar uw account gestuurd met de informatie om uw paswoord te resetten';
-        //
+        //End Email Subjects
+
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'U heeft geen vorige reserveringen';
+        $strings['PastReservations'] = 'Vorige reserveringen';
+        $strings['AllNoPastReservations'] = 'Er zijn geen vorige reserveringen in de afgelopen %s dagen';
+        $strings['AllPastReservations'] = 'Alle vorige reserveringen';
+        $strings['Yesterday'] = 'Gisteren';
+        $strings['EarlierThisWeek'] = 'Eerder deze week';
+        $strings['PreviousWeek'] = 'Vorige week';
+        //End Past Reservations
 
         $this->Strings = $strings;
     }

--- a/lang/du_nl.php
+++ b/lang/du_nl.php
@@ -992,6 +992,17 @@ class du_nl extends en_gb
 		$strings['ResourceStatusChangedSubject'] = 'De beschikbaarheid van %s is gewijzigd';
 		// End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'U heeft geen eerdere reserveringen';
+        $strings['PastReservations'] = 'Eerdere reserveringen';
+        $strings['AllNoPastReservations'] = 'Er zijn geen eerdere reserveringen in de afgelopen %s dagen';
+        $strings['AllPastReservations'] = 'Alle eerdere reserveringen';
+        $strings['Yesterday'] = 'Gisteren';
+        $strings['EarlierThisWeek'] = 'Eerder deze week';
+        $strings['PreviousWeek'] = 'Vorige week';
+        //End Past Reservations
+
         $this->Strings = $strings;
     }
 

--- a/lang/ee_ee.php
+++ b/lang/ee_ee.php
@@ -758,6 +758,17 @@ class ee_ee extends en_gb
         $strings['InviteeAddedSubjectWithResource'] = '%s Invited You to a Reservation for %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Teil pole varasemaid broneeringuid';
+        $strings['PastReservations'] = 'Varasemad broneeringud';
+        $strings['AllNoPastReservations'] = 'Viimase %s päeva jooksul pole varasemaid broneeringuid';
+        $strings['AllPastReservations'] = 'Kõik varasemad broneeringud';
+        $strings['Yesterday'] = 'Eile';
+        $strings['EarlierThisWeek'] = 'Varem sel nädalal';
+        $strings['PreviousWeek'] = 'Eelmine nädal';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/el_gr.php
+++ b/lang/el_gr.php
@@ -1015,6 +1015,17 @@ class el_gr extends en_gb
         $strings['ResourceStatusChangedSubject'] = 'Η διαθεσιμότητα του %s άλλαξε';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Δεν έχετε προηγούμενες κρατήσεις';
+        $strings['PastReservations'] = 'Προηγούμενες κρατήσεις';
+        $strings['AllNoPastReservations'] = 'Δεν υπάρχουν προηγούμενες κρατήσεις τις τελευταίες %s ημέρες';
+        $strings['AllPastReservations'] = 'Όλες οι προηγούμενες κρατήσεις';
+        $strings['Yesterday'] = 'Χθες';
+        $strings['EarlierThisWeek'] = 'Νωρίτερα αυτήν την εβδομάδα';
+        $strings['PreviousWeek'] = 'Προηγούμενη εβδομάδα';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -1016,6 +1016,16 @@ class en_us extends Language
         $strings['ReservationAvailableSubject'] = '%s is available on %s';
         $strings['ResourceStatusChangedSubject'] = 'The availability of %s has changed';
         // End Email Subjects
+        
+        //Past Reservations
+        $strings['NoPastReservations'] = 'You have no past reservations';
+        $strings['PastReservations'] = 'Past Reservations';
+        $strings['AllNoPastReservations'] = 'There are no past reservations in previous %s days';
+        $strings['AllPastReservations'] = 'All Past Reservations';
+        $strings['Yesterday'] = 'Yesterday';
+        $strings['EarlierThisWeek'] = 'Earlier This Week';
+        $strings['PreviousWeek'] = 'Previous Week';
+        //End Past Reservations
 
         $this->Strings = $strings;
 

--- a/lang/es.php
+++ b/lang/es.php
@@ -979,6 +979,17 @@ class es extends en_gb
         $strings['ResourceStatusChangedSubject'] = 'La disponibilidad de %s ha cambiado';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'No tienes reservas pasadas';
+        $strings['PastReservations'] = 'Reservas pasadas';
+        $strings['AllNoPastReservations'] = 'No hay reservas pasadas en los %s días anteriores';
+        $strings['AllPastReservations'] = 'Todas las reservas anteriores';
+        $strings['Yesterday'] = 'Ayer'; 
+        $strings['EarlierThisWeek'] = 'A principios de esta semana';
+        $strings['PreviousWeek'] = 'Semana pasada';
+        //End Past Reservations
+
 
         $this->Strings = $strings;
 

--- a/lang/eu_es.php
+++ b/lang/eu_es.php
@@ -717,6 +717,17 @@ class eu_es extends en_gb
         $strings['GuestAccountCreatedSubject'] = 'Kontuaren xehetasunak';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Ez duzu aurreko erreserik';
+        $strings['PastReservations'] = 'Aurreko erreserak';
+        $strings['AllNoPastReservations'] = 'Ez dago aurreko erreserarik azken %s egunetan';
+        $strings['AllPastReservations'] = 'Denak aurreko erreserak';
+        $strings['Yesterday'] = 'Atzo';
+        $strings['EarlierThisWeek'] = 'Aurreko astean';
+        $strings['PreviousWeek'] = 'Aurreko astean';
+        //End Past Reservations
+
 
         $this->Strings = $strings;
     }

--- a/lang/fi_fi.php
+++ b/lang/fi_fi.php
@@ -908,9 +908,18 @@ class fi_fi extends en_gb
         $strings['InviteeAddedSubjectWithResource'] = '%s Kutsui Sinut Varaukseen for %s :lle';
         $strings['MissedCheckinEmailSubject'] = 'Sisäänkirjaus puuttuu %s :lta';
         $strings['ReservationShareSubject'] = '%s Jakoi Varauksen %s :lle';
+        //End Email Subjects
 
-
-        //
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Sinulla ei ole aikaisempia varauksia';
+        $strings['PastReservations'] = 'Aikaisemmat varaukset';
+        $strings['AllNoPastReservations'] = 'Viimeisen %s päivän aikana ei ole aikaisempia varauksia';
+        $strings['AllPastReservations'] = 'Kaikki aikaisemmat varaukset';
+        $strings['Yesterday'] = 'Eilen';
+        $strings['EarlierThisWeek'] = 'Aiemmin tällä viikolla';
+        $strings['PreviousWeek'] = 'Edellinen viikko';
+        //End Past Reservations
 
         $this->Strings = $strings;
 

--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -980,6 +980,17 @@ class fr_fr extends en_gb
         $strings['ResourceStatusChangedSubject'] = 'La disponibilité de %s a changé';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Vous n\'avez aucune réservation passée';
+        $strings['PastReservations'] = 'Réservations passées';
+        $strings['AllNoPastReservations'] = 'Il n\'y a aucune réservation passée au cours des %s derniers jours';
+        $strings['AllPastReservations'] = 'Toutes les réservations passées';
+        $strings['Yesterday'] = 'Hier';
+        $strings['EarlierThisWeek'] = 'Plus tôt cette semaine';
+        $strings['PreviousWeek'] = 'Semaine précédente';
+        //End Past Reservations
+
         $this->Strings = $strings;
     }
 

--- a/lang/he.php
+++ b/lang/he.php
@@ -728,6 +728,17 @@ class he extends en_gb
         $strings['ReportSubject'] = ' הדוח שביקשת (%s)';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'אין לך הזמנות קודמות';
+        $strings['PastReservations'] = 'הזמנות קודמות';
+        $strings['AllNoPastReservations'] = 'אין הזמנות קודמות ב- %s הימים האחרונים';
+        $strings['AllPastReservations'] = 'כל הזמנות הקודמות';
+        $strings['Yesterday'] = 'אתמול';
+        $strings['EarlierThisWeek'] = 'בתחילת השבוע הזה';
+        $strings['PreviousWeek'] = 'השבוע הקודם';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/hr_hr.php
+++ b/lang/hr_hr.php
@@ -618,6 +618,17 @@ class hr_hr extends en_gb
         $strings['UserAdded'] = 'Dodan je novi korisnik';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Nemate prethodne rezervacije';
+        $strings['PastReservations'] = 'Prethodne rezervacije';
+        $strings['AllNoPastReservations'] = 'Nema prethodnih rezervacija u posljednjih %s dana';
+        $strings['AllPastReservations'] = 'Sve prethodne rezervacije';
+        $strings['Yesterday'] = 'Jučer';
+        $strings['EarlierThisWeek'] = 'Ranije ove sedmice';
+        $strings['PreviousWeek'] = 'Prethodni tjedan';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/hu_hu.php
+++ b/lang/hu_hu.php
@@ -973,6 +973,17 @@ class hu_hu extends en_us
         $strings['ReservationParticipantJoin'] = '%s Csatlakozott foglalására for %s on %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Nincsenek korábbi foglalásai';
+        $strings['PastReservations'] = 'Korábbi foglalások';
+        $strings['AllNoPastReservations'] = 'Az elmúlt %s napban nincsenek korábbi foglalásai';
+        $strings['AllPastReservations'] = 'Az összes korábbi foglalás';
+        $strings['Yesterday'] = 'Tegnap';
+        $strings['EarlierThisWeek'] = 'Korábban ezen a héten';
+        $strings['PreviousWeek'] = 'Előző hét';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/id_id.php
+++ b/lang/id_id.php
@@ -574,6 +574,17 @@ class id_id extends en_gb
         $strings['ReservationEndingSoonSubject'] = 'Reservasi untuk %s akan segera berakhir';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Anda tidak memiliki reservasi sebelumnya';
+        $strings['PastReservations'] = 'Reservasi Sebelumnya';
+        $strings['AllNoPastReservations'] = 'Tidak ada reservasi sebelumnya dalam %s hari terakhir';
+        $strings['AllPastReservations'] = 'Semua Reservasi Sebelumnya';
+        $strings['Yesterday'] = 'Kemarin';
+        $strings['EarlierThisWeek'] = 'Lebih awal pekan ini';
+        $strings['PreviousWeek'] = 'Pekan sebelumnya';
+        //End Past Reservations
+
         $this->Strings = $strings;
     }
 

--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -1016,6 +1016,17 @@ class it_it extends en_us
         $strings['ReservationParticipantJoin'] = '%s si è unito alla sua prenotazione per %s il %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Non hai prenotazioni passate';
+        $strings['PastReservations'] = 'Prenotazioni passate';
+        $strings['AllNoPastReservations'] = 'Non ci sono prenotazioni passate nei precedenti %s giorni';
+        $strings['AllPastReservations'] = 'Tutte le prenotazioni passate';
+        $strings['Yesterday'] = 'Ieri';
+        $strings['EarlierThisWeek'] = 'All\'inizio di questa settimana';
+        $strings['PreviousWeek'] = 'Settimana precedente';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -990,8 +990,18 @@ class ja_jp extends en_gb
         $strings['ReservationParticipantAccept'] = '%s は %s ( %s ) の予約への招待を受け入れました';
         $strings['ReservationParticipantDecline'] = '%s は %s ( %s ) の予約招待を拒否しました';
         $strings['ReservationParticipantJoin'] = '%s は %s ( %s ) の予約に参加しました';
-
         // End Email Subjects
+
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = '過去の予約はありません';
+        $strings['PastReservations'] = '過去の予約';
+        $strings['AllNoPastReservations'] = '直近%s日間に過去の予約はありません';
+        $strings['AllPastReservations'] = 'すべての過去の予約';
+        $strings['Yesterday'] = '昨日';
+        $strings['EarlierThisWeek'] = '今週の前半';
+        $strings['PreviousWeek'] = '先週';
+        //End Past Reservations
 
         $this->Strings = $strings;
 

--- a/lang/lt.php
+++ b/lang/lt.php
@@ -978,7 +978,18 @@ class lt extends en_gb
         $strings['ReservationParticipantJoin'] = '%s has joined your reservation for %s on %s';
         $strings['ReservationAvailableSubject'] = '%s is available on %s';
         $strings['ResourceStatusChangedSubject'] = 'The availability of %s has changed';
-        // End Email Subjects
+        //End Email Subjects
+
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Neturite ankstesnių rezervacijų';
+        $strings['PastReservations'] = 'Ankstesnės rezervacijos';
+        $strings['AllNoPastReservations'] = 'Paskutiniuose %s dienos nėra ankstesnių rezervacijų';
+        $strings['AllPastReservations'] = 'Visos ankstesnės rezervacijos';
+        $strings['Yesterday'] = 'Vakar';
+        $strings['EarlierThisWeek'] = 'Anksčiau šią savaitę';
+        $strings['PreviousWeek'] = 'Ankstesnė savaitė';
+        //End Past Reservations
 
         $this->Strings = $strings;
 

--- a/lang/no_no.php
+++ b/lang/no_no.php
@@ -632,6 +632,17 @@ class no_no extends en_gb
         $strings['UserAdded'] = 'En ny bruker er lagt til';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Du har ingen tidligere reservasjoner';
+        $strings['PastReservations'] = 'Tidligere reservasjoner';
+        $strings['AllNoPastReservations'] = 'Det er ingen tidligere reservasjoner de siste %s dagene';
+        $strings['AllPastReservations'] = 'Alle tidligere reservasjoner';
+        $strings['Yesterday'] = 'I går';
+        $strings['EarlierThisWeek'] = 'Tidligere denne uken';
+        $strings['PreviousWeek'] = 'Forrige uke';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/pl.php
+++ b/lang/pl.php
@@ -1021,6 +1021,17 @@ class pl extends en_gb
         $strings['ResourceStatusChangedSubject'] = 'Dostępność %s zmieniła się';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Nie masz żadnych wcześniejszych rezerwacji';
+        $strings['PastReservations'] = 'Wcześniejsze rezerwacje';
+        $strings['AllNoPastReservations'] = 'Nie ma wcześniejszych rezerwacji w ciągu ostatnich %s dni';
+        $strings['AllPastReservations'] = 'Wszystkie wcześniejsze rezerwacje';
+        $strings['Yesterday'] = 'Wczoraj';
+        $strings['EarlierThisWeek'] = 'Wcześniej w tym tygodniu';
+        $strings['PreviousWeek'] = 'Poprzedni tydzień';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/pt_br.php
+++ b/lang/pt_br.php
@@ -1003,6 +1003,17 @@ class pt_br extends en_gb
         $strings['ResourceStatusChangedSubject'] = 'A disponibilidade de %s foi alterada';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Você não possui reservas anteriores';
+        $strings['PastReservations'] = 'Reservas Anteriores';
+        $strings['AllNoPastReservations'] = 'Não há reservas anteriores nos últimos %s dias';
+        $strings['AllPastReservations'] = 'Todas as Reservas Anteriores';
+        $strings['Yesterday'] = 'Ontem';
+        $strings['EarlierThisWeek'] = 'Antes desta semana';
+        $strings['PreviousWeek'] = 'Semana anterior';
+        //End Past Reservations
+
         // Currently unused strings
         $strings['of'] = 'de';
         $strings['ViewWeek'] = 'Ver Semana';

--- a/lang/pt_pt.php
+++ b/lang/pt_pt.php
@@ -528,7 +528,7 @@ class pt_pt extends en_gb
         $strings['NoSavedReports'] = 'Não tem relatórios guardados';
         $strings['NoScheduleAdministratorLabel'] = 'Sem administrador de agenda';
         $strings['NoTitleLabel'] = '(nenhum título)';
-        $strings['NoUpcomingReservations'] = 'Não tem futuras reservas';
+        $strings['NoUpcomingReservations'] = 'Não tem reservas futuras';
         $strings['NoUpgradeNeeded'] = 'O LibreBooking está atualizado. Não há nenhuma atualização necessária.';
         $strings['None'] = 'Nenhum';
         $strings['NotAttending'] = 'Não comparecer';
@@ -871,7 +871,7 @@ class pt_pt extends en_gb
         $strings['UnknownError'] = 'Erro Desconhecido';
         $strings['Unlimited'] = 'Ilimitado';
         $strings['Unreservable'] = 'Não reservável';
-        $strings['UpcomingReservations'] = 'Futuras reservas';
+        $strings['UpcomingReservations'] = 'Reservas Futuras';
         $strings['Update'] = 'Atualizar';
         $strings['UpdateEmailTemplateFailure'] = 'Não foi possível atualizar o modelo de email. Por favor confirme que a pasta tem permissões de escrita';
         $strings['UpdateEmailTemplateSuccess'] = 'Modelo de email atualizado';
@@ -991,6 +991,16 @@ class pt_pt extends en_gb
         $strings['AvailableGroups'] = 'Grupos disponiveis';
         $strings['CheckingAvailabilityError'] = 'Não é possível obter a disponibilidade do recurso - demasiados recursos';
         //--
+
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Não tem reservas passadas';
+        $strings['PastReservations'] = 'Reservas Passadas';
+        $strings['AllNoPastReservations'] = 'Não existem reservas passadas nos anteriores %s dias';
+        $strings['AllPastReservations'] = 'Todas as Reservas Passadas';
+        $strings['Yesterday'] = 'Ontem';
+        $strings['EarlierThisWeek'] = 'Anteriormente Nesta Semana';
+        $strings['PreviousWeek'] = 'Semana Passada';
+        //End Past Reservations
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/ro_ro.php
+++ b/lang/ro_ro.php
@@ -488,7 +488,18 @@ class ro_ro extends en_gb
         $strings['InviteeAddedSubject'] = 'Invito a prenotazione';
         $strings['ResetPassword'] = 'Cerere de resetare parola';
         $strings['ForgotPasswordEmailSent'] = 'Un email\' a fost transmis\'in care sunt furnizate instructiuni pentru resetarea parolei';
-        //
+        //End Email Subjects
+
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Nu aveți rezervări anterioare';
+        $strings['PastReservations'] = 'Rezervări Anterioare';
+        $strings['AllNoPastReservations'] = 'Nu există rezervări anterioare în ultimele %s zile';
+        $strings['AllPastReservations'] = 'Toate Rezervările Anterioare';
+        $strings['Yesterday'] = 'Ieri';
+        $strings['EarlierThisWeek'] = 'Mai devreme în această săptămână';
+        $strings['PreviousWeek'] = 'Săptămâna trecută';
+        //End Past Reservations
 
         $this->Strings = $strings;
     }

--- a/lang/ru_ru.php
+++ b/lang/ru_ru.php
@@ -803,6 +803,17 @@ class ru_ru extends en_gb
         $strings['AnnouncementSubject'] = 'Новое объявление было опубликовано %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'У вас нет предыдущих бронирований';
+        $strings['PastReservations'] = 'Предыдущие бронирования';
+        $strings['AllNoPastReservations'] = 'За последние %s дней нет предыдущих бронирований';
+        $strings['AllPastReservations'] = 'Все предыдущие бронирования';
+        $strings['Yesterday'] = 'Вчера';
+        $strings['EarlierThisWeek'] = 'Ранее на этой неделе';
+        $strings['PreviousWeek'] = 'Прошлая неделя';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/si_si.php
+++ b/lang/si_si.php
@@ -643,6 +643,17 @@ class si_si extends en_gb
         $strings['UserAdded'] = 'Dodan je bil nov uporabnik';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Ni preteklih rezervacij';
+        $strings['PastReservations'] = 'Pretekla rezervacija';
+        $strings['AllNoPastReservations'] = 'Ni preteklih rezervacij v zadnjih %s dneh';
+        $strings['AllPastReservations'] = 'Vse pretekle rezervacije';
+        $strings['Yesterday'] = 'Včeraj';
+        $strings['EarlierThisWeek'] = 'Prejšnji teden';
+        $strings['PreviousWeek'] = 'Prejšnji teden';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/sk.php
+++ b/lang/sk.php
@@ -629,6 +629,17 @@ class sk extends en_gb
         $strings['UserAdded'] = 'Nový užívateľ bol pridaný';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Nemáte žiadne predchádzajúce rezervácie';
+        $strings['PastReservations'] = 'Predchádzajúce rezervácie';
+        $strings['AllNoPastReservations'] = 'Žiadne predchádzajúce rezervácie v posledných %s dňoch';
+        $strings['AllPastReservations'] = 'Všetky predchádzajúce rezervácie';
+        $strings['Yesterday'] = 'Včera';
+        $strings['EarlierThisWeek'] = 'Skôr tento týždeň';
+        $strings['PreviousWeek'] = 'Predchádzajúci týždeň';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/sr_sr.php
+++ b/lang/sr_sr.php
@@ -644,6 +644,17 @@ class sr_sr extends en_gb
         $strings['UserAdded'] = 'Dodat je novi korisnik';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Nemate prethodne rezervacije';
+        $strings['PastReservations'] = 'Prethodne rezervacije';
+        $strings['AllNoPastReservations'] = 'Nema prethodnih rezervacija u poslednjih %s dana';
+        $strings['AllPastReservations'] = 'Sve prethodne rezervacije';
+        $strings['Yesterday'] = 'Juče';
+        $strings['EarlierThisWeek'] = 'Ranije ove nedelje';
+        $strings['PreviousWeek'] = 'Prethodna nedelja';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/sv_sv.php
+++ b/lang/sv_sv.php
@@ -556,8 +556,18 @@ class sv_sv extends en_gb
         $strings['ReservationUpdatedAdminSubjectWithResource'] = 'Underrättelse: En bokning av %s har uppdaterats';
         $strings['ReservationDeleteAdminSubjectWithResource'] = 'Underrättelse: En bokning av %s har tagits bort';
         $strings['ReservationApprovalAdminSubjectWithResource'] = 'Underrättelse: En bokning av %s måste godkännas';
-
         // End Email Subjects
+
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Du har inga tidigare bokningar';
+        $strings['PastReservations'] = 'Tidigare bokningar';
+        $strings['AllNoPastReservations'] = 'Det finns inga tidigare bokningar de senaste %s dagarna';
+        $strings['AllPastReservations'] = 'Alla tidigare bokningar';
+        $strings['Yesterday'] = 'Igår';
+        $strings['EarlierThisWeek'] = 'Tidigare den här veckan';
+        $strings['PreviousWeek'] = 'Förra veckan';
+        //End Past Reservations
 
         $this->Strings = $strings;
     }

--- a/lang/th_th.php
+++ b/lang/th_th.php
@@ -836,6 +836,17 @@ class th_th extends en_gb
         $strings['MissedCheckinEmailSubject'] = 'ไม่ได้รับการเช็คอินสำหรับ %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'คุณไม่มีการจองที่ผ่านมา';
+        $strings['PastReservations'] = 'การจองที่ผ่านมา';
+        $strings['AllNoPastReservations'] = 'ไม่มีการจองที่ผ่านมาใน %s วันที่ผ่านมา';
+        $strings['AllPastReservations'] = 'การจองที่ผ่านมาทั้งหมด';
+        $strings['Yesterday'] = 'เมื่อวาน';
+        $strings['EarlierThisWeek'] = 'ก่อนหน้านี้ในสัปดาห์นี้';
+        $strings['PreviousWeek'] = 'สัปดาห์ที่แล้ว';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/tr_tr.php
+++ b/lang/tr_tr.php
@@ -776,6 +776,17 @@ class tr_tr extends en_gb
         $strings['MissedCheckinEmailSubject'] = 'Missed checkin for %s';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Daha önce yapılmış rezervasyonunuz yok';
+        $strings['PastReservations'] = 'Önceki Rezervasyonlar';
+        $strings['AllNoPastReservations'] = 'Son %s günde önceki rezervasyon yok';
+        $strings['AllPastReservations'] = 'Tüm Önceki Rezervasyonlar';
+        $strings['Yesterday'] = 'Dün';
+        $strings['EarlierThisWeek'] = 'Bu Haftanın Daha Önceki Günleri';
+        $strings['PreviousWeek'] = 'Geçen Hafta';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/vn_vn.php
+++ b/lang/vn_vn.php
@@ -733,6 +733,17 @@ class vn_vn extends en_gb
         $strings['GuestAccountCreatedSubject'] = 'Thông tin tài khoản của bạn';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = 'Bạn không có đặt phòng nào trong quá khứ';
+        $strings['PastReservations'] = 'Đặt phòng trong quá khứ';
+        $strings['AllNoPastReservations'] = 'Không có đặt phòng nào trong %s ngày qua';
+        $strings['AllPastReservations'] = 'Tất cả đặt phòng trong quá khứ';
+        $strings['Yesterday'] = 'Hôm qua';
+        $strings['EarlierThisWeek'] = 'Trước đó trong tuần này';
+        $strings['PreviousWeek'] = 'Tuần trước';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/zh_cn.php
+++ b/lang/zh_cn.php
@@ -531,6 +531,17 @@ class zh_cn extends en_us
         $strings['ActivateYourAccount'] = '请启动您的账号';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = '您没有以前的预订';
+        $strings['PastReservations'] = '以前的预订';
+        $strings['AllNoPastReservations'] = '在过去的%s天内没有以前的预订';
+        $strings['AllPastReservations'] = '所有以前的预订';
+        $strings['Yesterday'] = '昨天';
+        $strings['EarlierThisWeek'] = '本周早些时候';
+        $strings['PreviousWeek'] = '上周';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/zh_tw.php
+++ b/lang/zh_tw.php
@@ -614,6 +614,17 @@ class zh_tw extends en_us
         $strings['ReservationEndingSoonSubject'] = '%s 的預約即將結束';
         // End Email Subjects
 
+        //NEEDS CHECKING
+        //Past Reservations
+        $strings['NoPastReservations'] = '您沒有以前的預訂';
+        $strings['PastReservations'] = '以前的預訂';
+        $strings['AllNoPastReservations'] = '在過去的%s天內沒有以前的預訂';
+        $strings['AllPastReservations'] = '所有以前的預訂';
+        $strings['Yesterday'] = '昨天';
+        $strings['EarlierThisWeek'] = '本週早些時候';
+        $strings['PreviousWeek'] = '上週';
+        //End Past Reservations
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lib/Common/Date.php
+++ b/lib/Common/Date.php
@@ -331,6 +331,15 @@ class Date
     }
 
     /**
+     * Compares the time component of this date to the one passed in
+     * @param Time $time
+     * @return bool if the current object is greater than the one passed in
+     */
+    public function TimeLessThan(Time $time){
+        return $this->GetTime()->Compare($time) < 0;
+    }
+
+    /**
      * Compares this date to the one passed in
      * @param Date $end
      * @return bool if the current object is greater than the one passed in

--- a/lib/external/SimpleImage/SimpleImage.php
+++ b/lib/external/SimpleImage/SimpleImage.php
@@ -98,21 +98,21 @@ class SimpleImage
 	function resizeToHeight($height)
 	{
 		$ratio = $height / $this->getHeight();
-		$width = $this->getWidth() * $ratio;
+		$width = (int)($this->getWidth() * $ratio);
 		$this->resize($width, $height);
 	}
 
 	function resizeToWidth($width)
 	{
 		$ratio = $width / $this->getWidth();
-		$height = $this->getheight() * $ratio;
+		$height = (int)($this->getheight() * $ratio);
 		$this->resize($width, $height);
 	}
 
 	function scale($scale)
 	{
-		$width = $this->getWidth() * $scale / 100;
-		$height = $this->getheight() * $scale / 100;
+		$width = (int)($this->getWidth() * $scale / 100);
+		$height = (int)($this->getheight() * $scale / 100);
 		$this->resize($width, $height);
 	}
 

--- a/tpl/Dashboard/past_reservations.tpl
+++ b/tpl/Dashboard/past_reservations.tpl
@@ -1,0 +1,58 @@
+<div class="dashboard upcomingReservationsDashboard" id="upcomingReservationsDashboard">
+	<div class="dashboardHeader">
+		<div class="pull-left">{translate key="PastReservations"} <span class="badge">{$Total}</span></div>
+		<div class="pull-right">
+			<a href="#" title="{translate key=ShowHide} {translate key="PastReservations"}">
+				<i class="glyphicon"></i>
+                <span class="no-show">Expand/Collapse</span>
+            </a>
+		</div>
+		<div class="clearfix"></div>
+	</div>
+	<div class="dashboardContents">
+		{assign var=colspan value="5"}
+		{if $Total > 0}
+			<div>
+				<div class="timespan">
+					{translate key="Today"} ({$TodaysReservations|default:array()|count})
+				</div>
+				{foreach from=$TodaysReservations item=reservation}
+                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+				{/foreach}
+
+				<div class="timespan">
+					{translate key="Yesterday"} ({$YesterdayReservations|default:array()|count})
+				</div>
+				{foreach from=$YesterdayReservations item=reservation}
+                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+				{/foreach}
+
+				<div class="timespan">
+					{translate key="EarlierThisWeek"} ({$ThisWeeksReservations|default:array()|count})
+				</div>
+				{foreach from=$ThisWeeksReservations item=reservation}
+                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+				{/foreach}
+
+				<div class="timespan">
+					{translate key="PreviousWeek"} ({$PreviousWeekReservations|default:array()|count})
+				</div>
+				{foreach from=$PreviousWeekReservations item=reservation}
+                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+				{/foreach}
+			</div>
+		{else}
+			<div class="noresults">{translate key="NoPastReservations"}</div>
+		{/if}
+	</div>
+
+	<form id="form-checkin" method="post">
+		<input type="hidden" id="referenceNumber" {formname key=REFERENCE_NUMBER} />
+		{csrf_token}
+	</form>
+
+    {*<form id="form-checkout" method="post" action="ajax/reservation_checkin.php?action={ReservationAction::Checkout}">*}
+		{*<input type="hidden" id="referenceNumber" {formname key=REFERENCE_NUMBER} />*}
+		{*{csrf_token}*}
+	{*</form>*}
+</div>


### PR DESCRIPTION
Similar to Upcoming Reservations, there is now a Past Reservations section on the dashboard, with the relevant reservations of the logged in user.

This new feature comes with the all the translations for the existing languages, but they should be checked by native speakers.

A solution to issue #156 was implemented (now the title is saved to db and shown to user with correct quotes instead of &quote).

A solution for issue #80 and #187 was also implemented following the answers from their respective threads.