### PR TITLE
Bug Fix and New Feature

### DIFF
--- a/Controls/Dashboard/GroupUpcomingReservations.php
+++ b/Controls/Dashboard/GroupUpcomingReservations.php
@@ -20,7 +20,7 @@ class GroupUpcomingReservations extends DashboardItem implements IGroupUpcomingR
     public function PageLoad()
     {
         $this->Set('DefaultTitle', Resources::GetInstance()->GetString('NoTitleLabel'));
-        $this->presenter->SetSearchCriteria(ServiceLocator::GetServer()->GetUserSession()->UserId, ReservationUserLevel::ALL);
+        $this->presenter->SetSearchCriteria(ReservationViewRepository::ALL_USERS, ReservationUserLevel::ALL);
         $this->presenter->PageLoad();
         $this->Display('group_upcoming_reservations.tpl');
     }
@@ -84,15 +84,4 @@ interface IGroupUpcomingReservationsControl
     public function BindTomorrow($reservations);
     public function BindThisWeek($reservations);
     public function BindNextWeek($reservations);
-}
-
-class AllGroupUpcomingReservations extends GroupUpcomingReservations
-{
-    public function PageLoad()
-    {
-        $this->Set('DefaultTitle', Resources::GetInstance()->GetString('NoTitleLabel'));
-        $this->presenter->SetSearchCriteria(ReservationViewRepository::ALL_USERS, ReservationUserLevel::ALL);
-        $this->presenter->PageLoad();
-        $this->Display('group_upcoming_reservations.tpl');
-    }
 }

--- a/Jobs/deleteolddata.php
+++ b/Jobs/deleteolddata.php
@@ -1,0 +1,249 @@
+<?php
+/**
+*  Cron Example:
+*  This script must be executed at a specific time to be enabled
+*  * * * * * /usr/bin/env php -f ${WWW_DIR}/librebooking/Jobs/sendmissedcheckin.php
+
+*  Each * correspods to Minute Hour Day_Of_Month Month Day_Of_Week, respectively
+
+*  /usr/bin/env php -f                                  -> the path to php (run "which php" to know what it is)
+*  ${WWW_DIR}/librebooking/Jobs/sendmissedcheckin.php   -> the path to this script
+*/
+define('ROOT_DIR', dirname(__FILE__) . '/../');
+require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+require_once(ROOT_DIR . 'Jobs/JobCop.php');
+
+Log::Debug('Running deleteolddata.php');
+
+JobCop::EnsureCommandLine();
+
+try {
+    //Delete announcements, blackouts and reservations older than $deleteBefore (years -> -2 = 2+ years older)
+    $deleteBefore = Date::Now()->AddYears(-(Configuration::Instance()->GetSectionKey(ConfigSection::DELETE_OLD_DATA, ConfigKeys::YEARS_OLD_DATA)));
+    
+    //ANNOUNCEMENTS
+    if (Configuration::Instance()->GetSectionKey(ConfigSection::DELETE_OLD_DATA, ConfigKeys::DELETE_OLD_ANNOUNCEMENTS, new BooleanConverter())){
+        $getAnnouncements = GetAnnoucementsIdsToDeleteQuery($deleteBefore);
+        $reader = ServiceLocator::GetDatabase()->Query($getAnnouncements);
+        Log::Debug('Getting %s old announcements', $reader->NumRows());
+        while ($row = $reader->GetRow()) {
+            $annoucementId = $row[ColumnNames::ANNOUNCEMENT_ID];
+            DeleteAnnouncementsQuery($annoucementId);
+        }
+        $reader->Free();
+    }
+
+    //BLACKOUTS
+    if (Configuration::Instance()->GetSectionKey(ConfigSection::DELETE_OLD_DATA, ConfigKeys::DELETE_OLD_BLACKOUTS, new BooleanConverter())){
+        $getBlackouts = GetBlackoutsIdsToDeleteQuery($deleteBefore);
+        $reader = ServiceLocator::GetDatabase()->Query($getBlackouts);
+        Log::Debug('Getting %s old blackouts', $reader->NumRows());
+        while ($row = $reader->GetRow()) {
+            $blackoutId = $row[ColumnNames::BLACKOUT_SERIES_ID];
+            DeleteBlackoutsQuery($blackoutId);      
+        }
+        $reader->Free();
+    }
+
+    //RESERVATIONS
+    if (Configuration::Instance()->GetSectionKey(ConfigSection::DELETE_OLD_DATA, ConfigKeys::DELETE_OLD_RESERVATIONS, new BooleanConverter())){
+        $getReservations = GetReservationsIdsToDeleteQuery($deleteBefore);
+        $reader = ServiceLocator::GetDatabase()->Query($getReservations);
+        Log::Debug('Getting %s old reservations', $reader->NumRows());
+        while ($row = $reader->GetRow()) {
+            $reservationId = $row[ColumnNames::RESERVATION_SERIES_ID];
+
+            //RESERVATION USERS
+            $getReservationUsers = GetReservationUsersToDelete($reservationId);
+            $auxReader = ServiceLocator::GetDatabase()->Query($getReservationUsers);
+            while ($auxRow = $auxReader->GetRow()){
+                $reservationUser = $auxRow[ColumnNames::RESERVATION_INSTANCE_ID];
+                DeleteReservationUsersQuery($reservationUser);
+            }
+
+            $auxReader->Free();
+            DeleteReservationsQuery($reservationId);
+        }
+        $reader->Free();
+    }
+
+} catch (Exception $ex){
+    Log::Error('Error running deleteolddata.php: %s', $ex);
+}
+
+Log::Debug('Finished running deleteolddata.php');
+
+//GET INSTANCES FUNCTIONS
+
+//          ->  ANNOUNCEMENTS
+function GetAnnoucementsIdsToDeleteQuery($deleteBefore){
+
+    $annoucementsIds = new AdHocCommand(
+        "   SELECT announcementid
+            FROM announcements
+            WHERE end_date < '{$deleteBefore}'"
+    );
+
+    return $annoucementsIds;
+}
+
+//          ->  BLACKOUTS
+function GetBlackoutsIdsToDeleteQuery($deleteBefore){
+
+    $blackoutsIds = new AdHocCommand(
+        "   SELECT blackout_series_id
+            FROM blackout_series
+            WHERE SUBSTRING_INDEX(SUBSTRING_INDEX(SUBSTRING_INDEX(repeat_options, '|', -2),'=',-2),'|',1) < '{$deleteBefore}' AND repeat_options != ''
+            
+            UNION
+            
+            SELECT blackout_series.blackout_series_id
+            FROM blackout_series
+            LEFT JOIN blackout_instances
+            ON blackout_series.blackout_series_id = blackout_instances.blackout_series_id
+            WHERE blackout_series.repeat_type = 'none' AND blackout_instances.end_date < '{$deleteBefore}'"
+    );
+
+    return $blackoutsIds;
+}
+
+//          ->  RESERVATION USERS
+function GetReservationUsersToDelete($reservationSeriesId){ 
+    $reservationInstance = new AdHocCommand(
+        "   SELECT reservation_instance_id
+            FROM reservation_instances
+            WHERE series_id = '{$reservationSeriesId}'"
+    );
+    return $reservationInstance;
+}
+
+//          -> RESERVATIONS
+function GetReservationsIdsToDeleteQuery($deleteBefore) {
+
+    $reservationIds = new AdHocCommand(
+        "   SELECT reservation_series.series_id
+            FROM reservation_series
+            LEFT JOIN reservation_instances 
+            ON reservation_instances.series_id = reservation_series.series_id
+            WHERE reservation_series.repeat_type = 'none' AND end_date < '{$deleteBefore}'
+            
+            UNION
+            
+            SELECT series_id
+            FROM reservation_series
+            WHERE SUBSTRING_INDEX(SUBSTRING_INDEX(repeat_options, '|', -1), '=', -1) < '{$deleteBefore}' AND repeat_options != ''"
+    );
+
+    return $reservationIds;
+}
+
+
+//DELETE INSTANCES FUNCTIONS
+
+//          ->  ANNOUNCEMENTS
+function DeleteAnnouncementsQuery($announcementid){
+    Log::Debug('Deleting announcement with id %s', $announcementid);
+
+    $deleteGroupAnnouncements = new AdHocCommand(
+        "   DELETE FROM announcement_groups 
+            WHERE announcementid = '{$announcementid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteGroupAnnouncements);
+
+    $deleteResourceAnnouncements = new AdHocCommand(
+        "   DELETE FROM announcement_resources 
+            WHERE announcementid = '{$announcementid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteResourceAnnouncements);
+
+    $deleteAnnouncements = new AdHocCommand(
+        "   DELETE FROM announcements
+            WHERE announcementid = '{$announcementid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteAnnouncements);
+
+    Log::Debug('Announcement with id %s deleted', $announcementid);
+}
+
+//          ->    BLACKOUTS
+function DeleteBlackoutsQuery($blackoutid){
+    Log::Debug('Deleting blackout with id %s', $blackoutid);
+
+    $deleteBlackoutSeriesResources = new AdHocCommand(
+        "   DELETE FROM blackout_series_resources
+            WHERE blackout_series_id = '{$blackoutid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteBlackoutSeriesResources);
+
+    $deleteBlackoutInstances = new AdHocCommand(
+        "   DELETE FROM blackout_instances
+            WHERE blackout_series_id = '{$blackoutid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteBlackoutInstances);
+
+    $deleteBlackoutSeries = new AdHocCommand(
+        "   DELETE FROM blackout_series
+            WHERE blackout_series_id = '{$blackoutid}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteBlackoutSeries);
+
+    Log::Debug('Blackout with id %s deleted', $blackoutid);
+}
+
+//          ->    RESERVATION USERS
+function DeleteReservationUsersQuery($reservationInstanceId){
+    $deleteReservationGuests = new AdHocCommand(
+        "DELETE FROM reservation_guests
+        WHERE reservation_instance_id = '{$reservationInstanceId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationGuests);
+
+    $deleteReservationUsers = new AdHocCommand(
+        "DELETE FROM reservation_users
+        WHERE reservation_instance_id = '{$reservationInstanceId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationUsers);
+}
+
+//          ->    RESERVATIONS
+function DeleteReservationsQuery($reservationId){
+    Log::Debug('Deleting reservation with id %s', $reservationId);
+
+    $deleteReservationAcessories = new AdHocCommand(
+        "DELETE FROM reservation_accessories
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationAcessories);
+
+    $deleteReservationFiles = new AdHocCommand(
+        "DELETE FROM reservation_files
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationFiles);
+
+    $deleteReservationReminders = new AdHocCommand(
+        "DELETE FROM reservation_reminders 
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationReminders);
+
+    $deleteReservationResources = new AdHocCommand(
+        "DELETE FROM reservation_resources
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationResources);
+
+    $deleteReservationInstances = new AdHocCommand(
+        "DELETE FROM reservation_instances
+        WHERE series_id = '{$reservationId}'"
+    );
+    ServiceLocator::GetDatabase()->Execute($deleteReservationInstances);
+
+    $deleteReservationSeries = new AdHocCommand(
+        "DELETE FROM reservation_series
+        WHERE series_id = '{$reservationId}'"
+    );    
+    ServiceLocator::GetDatabase()->Execute($deleteReservationSeries);
+
+    Log::Debug('Reservation with id %s deleted', $reservationId);
+}

--- a/Pages/LoginPage.php
+++ b/Pages/LoginPage.php
@@ -124,6 +124,7 @@ class LoginPage extends Page implements ILoginPage
         $this->Set('ShowLoginError', false);
         $this->Set('Languages', Resources::GetInstance()->AvailableLanguages);
 
+        $this->SetFacebookErrorMessage();
         $this->Set('AllowFacebookLogin', Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK, new BooleanConverter()));
         $this->Set('AllowGoogleLogin', Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE, new BooleanConverter()));
         $this->Set('AllowMicrosoftLogin', Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT, new BooleanConverter()));
@@ -301,7 +302,7 @@ class LoginPage extends Page implements ILoginPage
      * Sends the created google url in the presenter to the smarty page 
      */
     public function SetGoogleUrl($googleUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE, new BooleanConverter())){
             $this->Set('GoogleUrl',$googleUrl);
         }
     }
@@ -310,7 +311,7 @@ class LoginPage extends Page implements ILoginPage
      * Sends the created microsoft url in the presenter to the smarty page 
      */
     public function SetMicrosoftUrl($microsoftUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT, new BooleanConverter())){
             $this->Set('MicrosoftUrl',$microsoftUrl);
         }
     }
@@ -319,8 +320,20 @@ class LoginPage extends Page implements ILoginPage
      * Sends the created facebook url in the presenter to the smarty page 
      */
     public function SetFacebookUrl($FacebookUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK, new BooleanConverter())){
             $this->Set('FacebookUrl',$FacebookUrl);
+        }
+    }
+
+    /**
+     * Temporary solution for facebook auth SDK error 
+     * After facebook failed authentication user is redirected to login page (this one) and is shown a message to try again
+     * Error occurs rarely (FacebookSDKException)
+     */
+    private function SetFacebookErrorMessage(){
+        if (isset($_SESSION['facebook_error']) && $_SESSION['facebook_error'] == true) {
+            $this->Set('facebookError',$_SESSION['facebook_error']);
+            unset($_SESSION['facebook_error']);
         }
     }
 }

--- a/Pages/SchedulePage.php
+++ b/Pages/SchedulePage.php
@@ -251,6 +251,7 @@ class SchedulePage extends ActionPage implements ISchedulePage
 
         $this->Set('CanViewUsers', !Configuration::Instance()->GetSectionKey(ConfigSection::PRIVACY, ConfigKeys::PRIVACY_HIDE_USER_DETAILS, new BooleanConverter()));
         $this->Set('AllowParticipation', !Configuration::Instance()->GetSectionKey(ConfigSection::RESERVATION, ConfigKeys::RESERVATION_PREVENT_PARTICIPATION, new BooleanConverter()));
+        $this->Set('ViewPastReservationsButton', ServiceLocator::GetServer()->GetUserSession()->IsAdmin);
 
         $permissionServiceFactory = new PermissionServiceFactory();
         $scheduleRepository = new ScheduleRepository();

--- a/Presenters/Authentication/ExternalAuthLoginPresenter.php
+++ b/Presenters/Authentication/ExternalAuthLoginPresenter.php
@@ -52,7 +52,7 @@ class ExternalAuthLoginPresenter
         if (isset($_GET['code'])) {
             //Token validations for the client
             $token = $client->fetchAccessTokenWithAuthCode($_GET['code']);
-            //set the acess token that it received
+            //set the access token that it received
             $client->setAccessToken($token['access_token']);
         
             //Using the Google API to get the user information 
@@ -140,7 +140,8 @@ class ExternalAuthLoginPresenter
         
         if (isset($_SESSION['facebook_access_token'])) {
             $facebook_Client->setDefaultAccessToken(unserialize($_SESSION['facebook_access_token']));
-        } 
+        }
+        unset($_SESSION['facebook_access_token']);
 
         $profile_request = $facebook_Client ->get('/me?fields=name,first_name,last_name,email');
         $profile = $profile_request ->getGraphUser();

--- a/Presenters/Dashboard/GroupUpcomingReservationsPresenter.php
+++ b/Presenters/Dashboard/GroupUpcomingReservationsPresenter.php
@@ -90,11 +90,8 @@ class GroupUpcomingReservationsPresenter
             //Sort By Date
             $consolidated = $this->BubbleSort($consolidated);
 
-            /* @var $reservation ReservationItemView */
             foreach ($consolidated as $reservation) {
-                $start = $reservation->StartDate->ToTimezone($timezone);
-                //echo '<pre>' , var_dump($start) , '</pre>';
-                
+                $start = $reservation->StartDate->ToTimezone($timezone);                
 
                 if ($start->DateEquals($today)) {
                     $todays[] = $reservation;

--- a/Presenters/DashboardPresenter.php
+++ b/Presenters/DashboardPresenter.php
@@ -39,7 +39,7 @@ class DashboardPresenter
         }
 
         if(ServiceLocator::GetServer()->GetUserSession()->IsResourceAdmin || ServiceLocator::GetServer()->GetUserSession()->IsScheduleAdmin){
-            $myGroupReservations = new AllGroupUpcomingReservations(new SmartyPage());
+            $myGroupReservations = new GroupUpcomingReservations(new SmartyPage());
             $this->_page->AddItem($myGroupReservations);
         }
     }

--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -230,7 +230,7 @@ class LoginPresenter
      * Returns the created google url for the authentication  
      */
     public function GetGoogleUrl(){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE, new BooleanConverter())){
             $client = new Google\Client();
             $client->setClientId(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::GOOGLE_CLIENT_ID));
             $client->setClientSecret(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::GOOGLE_CLIENT_SECRET));
@@ -249,7 +249,7 @@ class LoginPresenter
      * Returns the created microsoft url for the authentication  
      */
     public function GetMicrosoftUrl(){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT, new BooleanConverter())){
             $MicrosoftUrl = 'https://login.microsoftonline.com/'
                             .urlencode(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::MICROSOFT_TENANT_ID))
                             .'/oauth2/v2.0/authorize?'
@@ -268,7 +268,7 @@ class LoginPresenter
      * Returns the created facebook url for the authentication  
      */
     public function GetFacebookUrl(){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK) == 'true'){
+        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK, new BooleanConverter())){
             $facebook_Client = new Facebook\Facebook([
                             'app_id'                => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_ID),
                             'app_secret'            => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_SECRET),

--- a/Web/facebook-auth.php
+++ b/Web/facebook-auth.php
@@ -1,30 +1,35 @@
 <?php
-
+session_start();
 define('ROOT_DIR', '../');
 
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
-//Checks if the user was authenticated by google and redirects to external authentication page
+//Checks if the user was authenticated by facebook and redirects to external authentication page
 //Need to ask facebook token directly in the redirect_uri (?) -> Can't redirect to external auth page and then ask (???)
 if (isset($_GET['code'])) { 
-    //Init the Facebook SDK
-    if (!session_id()) {
-        session_start();
-    }
-    $facebook_Client = new Facebook\Facebook([
-        'app_id'                => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_ID),
-        'app_secret'            => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_SECRET),
-        'default_graph_version' => 'v2.5'
-    ]);
+    try{
+        $facebook_Client = new Facebook\Facebook([
+            'app_id'                => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_ID),
+            'app_secret'            => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_SECRET),
+            'default_graph_version' => 'v2.5'
+        ]);
 
-    $helper = $facebook_Client->getRedirectLoginHelper();
-    $acesstoken = $helper->getAccessToken();
-    $_SESSION['facebook_access_token'] = serialize($acesstoken);
-    
-    $code = filter_input(INPUT_GET,'code');
-    header("Location: ".ROOT_DIR."Web/external-auth.php?type=fb&code=".$code);
-    exit;
+        $helper = $facebook_Client->getRedirectLoginHelper();
+        $accesstoken = $helper->getAccessToken();
+        $_SESSION['facebook_access_token'] = serialize($accesstoken);
+        
+        $code = filter_input(INPUT_GET,'code');
+        header("Location: ".ROOT_DIR."Web/external-auth.php?type=fb&code=".$code);
+        exit;
+    } catch (\Facebook\Exceptions\FacebookResponseException | \Facebook\Exceptions\FacebookSDKException $e) {
+        Log::Debug("Exception during facebook login: %s", $e->getMessage());
+        $_SESSION['facebook_error'] = true;
+        header("Location:".ROOT_DIR."Web");
+        exit();
+    } 
+
 } else{
     header("Location:".ROOT_DIR."Web");
     exit();
-}  
+}
+?>

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -233,3 +233,11 @@ $conf['settings']['authentication']['microsoft.redirect.uri'] = '/Web/microsoft-
 $conf['settings']['authentication']['facebook.client.id'] = '';
 $conf['settings']['authentication']['facebook.client.secret'] = '';
 $conf['settings']['authentication']['facebook.redirect.uri'] = '/Web/facebook-auth.php';
+/**
+ *  Delete old data job configuration
+ *  Activate the deleteolddata.php as a background job to use this feature
+ */
+$conf['settings']['delete.old.data']['years.old.data'] = '3';               //Choose how long a blackout, announcement and reservation stay in the database (in years) counting from the end date
+$conf['settings']['delete.old.data']['delete.old.announcements'] = 'false'; //Choose if this feature deletes old announcements from database
+$conf['settings']['delete.old.data']['delete.old.blackouts'] = 'false';     //Choose if this feature deletes old blackouts from database
+$conf['settings']['delete.old.data']['delete.old.reservations'] = 'false';  //Choose if this feature deletes old reservations from database

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -1014,6 +1014,10 @@ class ar extends en_us
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'الحجوزات القادمة لمجموعتي';
         //End Group Upcoming Reservations 
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'حدث خطأ أثناء تسجيل الدخول باستخدام فيسبوك. يرجى المحاولة مرة أخرى.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/bg_bg.php
+++ b/lang/bg_bg.php
@@ -506,7 +506,11 @@ class bg_bg extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Бъдещите резервации на моята група(и)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Възникна грешка при влизане с Facebook. Моля, опитайте отново.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/ca.php
+++ b/lang/ca.php
@@ -403,7 +403,11 @@ class ca extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Properes reserves del meu(s) grup(s)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+        
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'S\'ha produït un error en iniciar la sessió amb Facebook. Torneu-ho a provar.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/cz.php
+++ b/lang/cz.php
@@ -822,7 +822,11 @@ class cz extends en_us
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Nadcházející rezervace mé skupiny(y)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Při přihlašování přes Facebook došlo k chybě. Zkuste to prosím znovu.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/da_da.php
+++ b/lang/da_da.php
@@ -1009,7 +1009,11 @@ class da_da extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Mine gruppers kommende reservationer';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Der opstod en fejl under login med Facebook. Prøv venligst igen.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -982,7 +982,11 @@ class de_de extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Kommende Reservierungen meiner Gruppe(n)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+        
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Bei der Anmeldung mit Facebook ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/du_be.php
+++ b/lang/du_be.php
@@ -403,7 +403,11 @@ class du_be extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Aankomende reserveringen van mijn groep(en)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Er is een fout opgetreden bij het inloggen met Facebook. Probeer het opnieuw.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/du_nl.php
+++ b/lang/du_nl.php
@@ -1006,6 +1006,10 @@ class du_nl extends en_gb
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Aankomende reserveringen van mijn groep(en)';
         //End Group Upcoming Reservations 
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Er is een fout opgetreden bij het inloggen met Facebook. Probeer het opnieuw.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/ee_ee.php
+++ b/lang/ee_ee.php
@@ -771,7 +771,11 @@ class ee_ee extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Minu grupi(t)e tulevased broneeringud';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Facebooki sisselogimisel ilmnes viga. Palun proovi uuesti.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/el_gr.php
+++ b/lang/el_gr.php
@@ -1028,7 +1028,11 @@ class el_gr extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Μελλοντικές κρατήσεις της ομάδας(ών) μου';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+        
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Προέκυψε σφάλμα κατά τη σύνδεση με το Facebook. Παρακαλούμε δοκιμάστε ξανά.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -1031,6 +1031,10 @@ class en_us extends Language
         $strings['GroupUpcomingReservations'] = 'My Group(s) Upcoming Reservations';
         //End Group Upcoming Reservations
 
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'An error occured while logging in with facebook. Please try again.';
+        //End Facebook Login SDK Error
+
         $this->Strings = $strings;
 
         return $this->Strings;

--- a/lang/es.php
+++ b/lang/es.php
@@ -992,7 +992,11 @@ class es extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Próximas reservas de mi(s) grupo(s)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Se produjo un error al iniciar sesión con Facebook. Por favor, inténtelo de nuevo.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/eu_es.php
+++ b/lang/eu_es.php
@@ -730,7 +730,11 @@ class eu_es extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Nire Taldeen Hurrengo Erreserba(k)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Facebook-en saioa hastean errorea gertatu da. Mesedez, saiatu berriro.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/fi_fi.php
+++ b/lang/fi_fi.php
@@ -923,7 +923,11 @@ class fi_fi extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Ryhmäni tulevat varaukset';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+    
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Virhe kirjautuessa Facebookin kanssa. Yritä uudelleen.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -993,7 +993,11 @@ class fr_fr extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Prochaines réservations de mon/des groupes';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+        
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Une erreur est survenue lors de la connexion avec Facebook. Veuillez réessayer.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/he.php
+++ b/lang/he.php
@@ -741,7 +741,11 @@ class he extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'הזמנות קבוצתי(ות) הבאות';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+        
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'אירעה שגיאה בעת ניסיון להתחבר עם Facebook. אנא נסה שוב.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/hr_hr.php
+++ b/lang/hr_hr.php
@@ -631,7 +631,11 @@ class hr_hr extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Nadolazeće rezervacije moje grupe/ova';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Došlo je do pogreške prilikom prijave putem Facebooka. Molimo pokušajte ponovno.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/hu_hu.php
+++ b/lang/hu_hu.php
@@ -986,7 +986,11 @@ class hu_hu extends en_us
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Csoportom(aim) következő foglalásai';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Hiba történt a bejelentkezés során a Facebookkal. Kérjük, próbálja újra.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/id_id.php
+++ b/lang/id_id.php
@@ -587,7 +587,11 @@ class id_id extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Reservasi Mendatang Grup Saya';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Terjadi kesalahan saat login dengan Facebook. Silakan coba lagi.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -1029,7 +1029,11 @@ class it_it extends en_us
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Prossime prenotazioni del mio(i) gruppo(i)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Si è verificato un errore durante l\'accesso con Facebook. Riprova.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -1005,7 +1005,11 @@ class ja_jp extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = '私のグループの今後の予約';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Facebookでログイン中にエラーが発生しました。もう一度お試しください。';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/lt.php
+++ b/lang/lt.php
@@ -993,7 +993,11 @@ class lt extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Mano grupės ateities rezervacijos';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Vartotojo prisijungimo metu su Facebook įvyko klaida. Bandykite dar kartą.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/no_no.php
+++ b/lang/no_no.php
@@ -645,7 +645,11 @@ class no_no extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Mine grupp(er) kommende reservasjoner';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Det oppstod en feil under pålogging med Facebook. Prøv igjen.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/pl.php
+++ b/lang/pl.php
@@ -1034,7 +1034,11 @@ class pl extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Nadchodzące rezerwacje mojej grupy(y)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Wystąpił błąd podczas logowania przez Facebook. Spróbuj ponownie.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/pt_br.php
+++ b/lang/pt_br.php
@@ -1017,6 +1017,10 @@ class pt_br extends en_gb
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Reservas Futuras do(s) meu(s) Grupo(s)';
         //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Ocorreu um erro ao fazer login com o Facebook. Por favor, tente novamente.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
         // Currently unused strings

--- a/lang/pt_pt.php
+++ b/lang/pt_pt.php
@@ -1006,6 +1006,9 @@ class pt_pt extends en_gb
         $strings['GroupUpcomingReservations'] = 'Reservas Futuras do(s) meu(s) Grupo(s)';
         //End Group Upcoming Reservations
 
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Ocorreu um erro ao fazer login com o Facebook. Por favor, tente novamente.';
+        //End Facebook Login SDK Error
 
         $this->Strings = $strings;
 

--- a/lang/ro_ro.php
+++ b/lang/ro_ro.php
@@ -503,7 +503,11 @@ class ro_ro extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Viitoarele rezervări ale grupului/meu(ă)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'A apărut o eroare la autentificarea cu Facebook. Vă rugăm să încercați din nou.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/ru_ru.php
+++ b/lang/ru_ru.php
@@ -816,7 +816,11 @@ class ru_ru extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Предстоящие бронирования моей группы(ов)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Произошла ошибка при входе через Facebook. Пожалуйста, попробуйте еще раз.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/si_si.php
+++ b/lang/si_si.php
@@ -656,7 +656,11 @@ class si_si extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Prihodnje rezervacije moje skupine(i)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Prijavljanje prek Facebooka ni uspelo. Poskusite znova.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/sk.php
+++ b/lang/sk.php
@@ -642,7 +642,11 @@ class sk extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Nadchádzajúce rezervácie mojej skupiny(y)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Pri prihlásení cez Facebook sa vyskytla chyba. Skúste to prosím znovu.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/sr_sr.php
+++ b/lang/sr_sr.php
@@ -657,7 +657,11 @@ class sr_sr extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Nadolazeće rezervacije moje grupe(ova)';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Došlo je do greške prilikom prijavljivanja putem Facebooka. Molimo pokušajte ponovo.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/sv_sv.php
+++ b/lang/sv_sv.php
@@ -571,7 +571,11 @@ class sv_sv extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Mina grupps kommande bokningar';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Ett fel inträffade vid inloggning med Facebook. Försök igen.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/th_th.php
+++ b/lang/th_th.php
@@ -849,7 +849,11 @@ class th_th extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'การจองที่มีต่อไปของกลุ่มของฉัน';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'เกิดข้อผิดพลาดขณะเข้าสู่ระบบด้วย Facebook กรุณาลองอีกครั้ง';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/tr_tr.php
+++ b/lang/tr_tr.php
@@ -789,7 +789,11 @@ class tr_tr extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Grubumun Yaklaşan Rezervasyonları';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Facebook ile giriş yapılırken bir hata oluştu. Lütfen tekrar deneyin.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/vn_vn.php
+++ b/lang/vn_vn.php
@@ -746,7 +746,11 @@ class vn_vn extends en_gb
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'Đặt phòng sắp tới của Nhóm của tôi';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = 'Đã xảy ra lỗi khi đăng nhập bằng Facebook. Vui lòng thử lại.';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/zh_cn.php
+++ b/lang/zh_cn.php
@@ -544,7 +544,11 @@ class zh_cn extends en_us
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = '我的团体即将到来的预订';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = '使用Facebook登录时发生错误。请重试。';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lang/zh_tw.php
+++ b/lang/zh_tw.php
@@ -627,7 +627,11 @@ class zh_tw extends en_us
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = '我的團體即將到來的預訂';
-        //End Group Upcoming Reservations 
+        //End Group Upcoming Reservations
+
+        //Facebook Login SDK Error
+        $strings['FacebookLoginErrorMessage'] = '使用Facebook登入時發生錯誤。請重試。';
+        //End Facebook Login SDK Error
         //END NEEDS CHECKING
 
 

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -173,6 +173,10 @@ class ConfigKeys
     public const FACEBOOK_CLIENT_SECRET = 'facebook.client.secret';
     public const FACEBOOK_REDIRECT_URI = 'facebook.redirect.uri';
 
+    public const YEARS_OLD_DATA = 'years.old.data';
+    public const DELETE_OLD_ANNOUNCEMENTS = 'delete.old.announcements'; 
+    public const DELETE_OLD_BLACKOUTS = 'delete.old.blackouts'; 
+    public const DELETE_OLD_RESERVATIONS = 'delete.old.reservations'; 
 }
 
 class ConfigSection
@@ -202,4 +206,5 @@ class ConfigSection
     public const TABLET_VIEW = 'tablet.view';
     public const REGISTRATION = 'registration';
     public const LOGGING = 'logging';
+    public const DELETE_OLD_DATA = 'delete.old.data';
 }

--- a/tpl/Dashboard/resource_availability.tpl
+++ b/tpl/Dashboard/resource_availability.tpl
@@ -44,6 +44,9 @@
             {/foreach}
             {/if}
         {/foreach}
+        {if empty($availability)}
+            <div class="no-data" style="text-align: center;">{translate key=None}</div>
+        {/if}
 
         <div class="header">{translate key=Unavailable}</div>
 
@@ -75,35 +78,41 @@
             {/foreach}
             {/if}
         {/foreach}
+        {if empty($availability)}
+            <div class="no-data" style="text-align: center;">{translate key=None}</div>
+        {/if}
 
         <div class="header">{translate key=UnavailableAllDay}</div>
         {foreach from=$Schedules item=s}
             {assign var=availability value=$UnavailableAllDay[$s->GetId()]}
             {if is_array($availability) && $availability|default:array()|count > 0}
-            <h5>{$s->GetName()}</h5>
-            {foreach from=$availability item=i}
-                <div class="availabilityItem">
-                    <div class="col-xs-12 col-sm-5">
-                        <i resource-id="{$i->ResourceId()}" class="resourceNameSelector fa fa-info-circle"></i>
-                        <div class="resourceName" style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};">
-                            <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
-                               resource-id="{$i->ResourceId()}"
-                               class="resourceNameSelector" style="color:{$i->GetTextColor()}">{$i->ResourceName()}</a>
+                <h5>{$s->GetName()}</h5>
+                {foreach from=$availability item=i}
+                    <div class="availabilityItem">
+                        <div class="col-xs-12 col-sm-5">
+                            <i resource-id="{$i->ResourceId()}" class="resourceNameSelector fa fa-info-circle"></i>
+                            <div class="resourceName" style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};">
+                                <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
+                                resource-id="{$i->ResourceId()}"
+                                class="resourceNameSelector" style="color:{$i->GetTextColor()}">{$i->ResourceName()}</a>
+                            </div>
+                        </div>
+                        <div class="availability col-xs-12 col-sm-4">
+                            {translate key=AvailableAt} {format_date date=$i->ReservationEnds() timezone=$Timezone key=dashboard}
+                        </div>
+                        <div class="reserveButton col-xs-12 col-sm-3">
+                            <a class="btn btn-xs col-xs-12"
+                            href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}&{QueryStringKeys::START_DATE}={format_date date=$i->ReservationEnds() timezone=$Timezone key=url_full}">{translate key=Reserve}</a>
                         </div>
                     </div>
-                    <div class="availability col-xs-12 col-sm-4">
-                        {translate key=AvailableAt} {format_date date=$i->ReservationEnds() timezone=$Timezone key=dashboard}
-                    </div>
-                    <div class="reserveButton col-xs-12 col-sm-3">
-                        <a class="btn btn-xs col-xs-12"
-                           href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}&{QueryStringKeys::START_DATE}={format_date date=$i->ReservationEnds() timezone=$Timezone key=url_full}">{translate key=Reserve}</a>
-                    </div>
-                </div>
-                <div class="clearfix"></div>
-                {foreachelse}
-                <div class="no-data">{translate key=None}</div>
-            {/foreach}
+                    <div class="clearfix"></div>
+                    {foreachelse}
+                    <div class="no-data">{translate key=None}</div>
+                {/foreach}
             {/if}
         {/foreach}
+        {if empty($availability)}
+            <div class="no-data" style="text-align: center;">{translate key=None}</div>
+        {/if}
     </div>
 </div>

--- a/tpl/Schedule/schedule-reservations-grid.tpl
+++ b/tpl/Schedule/schedule-reservations-grid.tpl
@@ -21,7 +21,7 @@
             {/if}
             <td class="resdate">{formatdate date=$date key="schedule_daily"}</td>
             {foreach from=$periods.$ts item=period}
-                <td class="reslabel"
+                <td class="reslabel" style="text-align:center"
                     colspan="{$period->Span()}">{$period->Label($date)}</td>
             {/foreach}
         </tr>

--- a/tpl/Schedule/schedule-week-condensed.tpl
+++ b/tpl/Schedule/schedule-week-condensed.tpl
@@ -124,12 +124,15 @@
                                 data-start="{$date->Format('Y-m-d H:i:s')|escape:url}"
                                 data-end="{$date->Format('Y-m-d H:i:s')|escape:url}">
 
-                                <div class="reservable clickres" ref="{$href}&rd={formatdate date=$date key=url}"
-                                     data-href="{$href}" data-start="{$date->Format('Y-m-d H:i:s')|escape:url}"
-                                     data-end="{$date->Format('Y-m-d H:i:s')|escape:url}">
-                                    <i class="fa fa-plus-circle"></i> {translate key=CreateReservation}
-                                    <input type="hidden" class="href" value="{$href}"/>
-                                </div>
+                                {assign var=addButton value=$TodaysDate->LessThanOrEqual($date) || $TodaysDate->DateEquals($date) || $ViewPastReservationsButton}
+                                {if $addButton}
+                                    <div class="reservable clickres" ref="{$href}&rd={formatdate date=$date key=url}"
+                                        data-href="{$href}" data-start="{$date->Format('Y-m-d H:i:s')|escape:url}"
+                                        data-end="{$date->Format('Y-m-d H:i:s')|escape:url}">
+                                        <i class="fa fa-plus-circle"></i> {translate key=CreateReservation}
+                                        <input type="hidden" class="href" value="{$href}"/>
+                                    </div>
+                                {/if}
                                 <div class="reservations" data-min="{$min}" data-max="{$max}" data-resourceid="{$resourceId}"></div>
                             </td>
 {*                        {/if}*}
@@ -159,4 +162,4 @@
             });
         });
     </script>
-{/block}
+{/block}Z

--- a/tpl/login.tpl
+++ b/tpl/login.tpl
@@ -90,12 +90,12 @@
 
 				<div class="clearfix"></div>
 
-				{if $AllowGoogleLogin && $AllowFacebookLogin}
+				{if $AllowGoogleLogin && $AllowFacebookLogin && $AllowMicrosoftLogin}
 					{assign var=socialClass value="col-sm-12 col-md-6"}
 				{else}
 					{assign var=socialClass value="col-sm-12"}
 				{/if}
-				<section style="display: flex; ">
+				<section style="display:flex; margin-top:8px;">
 					{if $AllowGoogleLogin}
 						<div class="{$socialClass} social-login" id="socialLoginGoogle">
 							<a href="{$GoogleUrl}">
@@ -118,6 +118,9 @@
 						</div>
 					{/if}
 				</section>
+				{if $facebookError}
+					<p style="text-align:center; margin-top:10px; margin-bottom:auto" class="text-primary"> {translate key="FacebookLoginErrorMessage"} </p>
+				{/if}
 			</div>
 			<div id="login-footer" class="col-xs-12">
 				{if $ShowForgotPasswordPrompt}


### PR DESCRIPTION
Implemented a script that can be used (as a cron job for example) do delete old data from database (issue #71), similar to other existing cron job scripts.

This features allows the deletion of old announcements, blackouts and reservations and their respective information.

In the config file it's possible to select which data should be deleted (can choose any of the three above) and how +old it has to be in years. This script can only be run through the console (like the others already implemented).

------------------------------------------------------
Fixed the "date range" field in the "Find A Time" feature (issue #245 and #75).

------------------------------------------------------
Removed button to create reservations in condensed schedule, if date is in the past, except for app admins (issue #107).

------------------------------------------------------
Also, the facebook login can sometimes give an sdk error (very rarely), a message is now shown to the user if it happens (message includes translations but should be checked by native speakers). 

