### PR TITLE
Update minimum PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a community effort to keep the OpenSource [GPLv3](./LICENSE.md) LibreBoo
 
 ## Prerequisites
 
-- PHP 8.1 or greater
+- PHP 8.2 or greater
 - MySQL 5.5 or greater
 - Web server (Apache, IIS)
 


### PR DESCRIPTION
`php composer.phar show --tree` outputs:

    ...
    gregwar/captcha v1.2.1 Captcha generator
    |--ext-gd *
    |--ext-mbstring *
    |  +--php >=7.1
    |--php >=5.3.0
    +--symfony/finder *
       +--php >=8.2

So the `develop` branch of this repo requires PHP >= 8.2.