### PR TITLE
Pending approval reservation dashboard displayer

### DIFF
--- a/Controls/Dashboard/PendingApprovalReservations.php
+++ b/Controls/Dashboard/PendingApprovalReservations.php
@@ -1,0 +1,99 @@
+<?php
+
+require_once(ROOT_DIR . 'Controls/Dashboard/DashboardItem.php');
+require_once(ROOT_DIR . 'Presenters/Dashboard/PendingApprovalReservationsPresenter.php');
+require_once(ROOT_DIR . 'Domain/Access/ReservationViewRepository.php');
+
+class PendingApprovalReservations extends DashboardItem implements IPendingApprovalReservationsControl
+{
+    /**
+     * @var PendingApprovalReservationsPresenter
+     */
+    protected $presenter;
+
+    public function __construct(SmartyPage $smarty)
+    {
+        parent::__construct($smarty);
+        $this->presenter = new PendingApprovalReservationsPresenter($this, new ReservationViewRepository());
+    }
+
+    public function PageLoad()
+    {
+        $this->Set('DefaultTitle', Resources::GetInstance()->GetString('NoTitleLabel'));
+        $this->presenter->SetSearchCriteria(ReservationViewRepository::ALL_USERS, ReservationUserLevel::ALL);
+        $this->presenter->PageLoad();
+        $this->Display('pending__approval_reservations.tpl');
+    }
+
+    public function SetTimezone($timezone)
+    {
+        $this->Set('Timezone', $timezone);
+    }
+
+    public function SetTotal($total)
+    {
+        $this->Set('Total', $total);
+    }
+
+    public function SetUserId($userId)
+    {
+        $this->Set('UserId', $userId);
+    }
+
+    public function BindToday($reservations)
+    {
+        $this->Set('TodaysReservations', $reservations);
+    }
+
+    public function BindTomorrow($reservations)
+    {
+        $this->Set('TomorrowsReservations', $reservations);
+    }
+
+    public function BindThisWeek($reservations)
+    {
+        $this->Set('ThisWeeksReservations', $reservations);
+    }
+
+    public function BindThisMonth($reservations)
+    {
+        $this->Set('ThisMonthsReservations', $reservations);
+    }
+
+    public function BindThisYear($reservations)
+    {
+        $this->Set('ThisYearsReservations', $reservations);
+    }
+
+    public function BindRemaining($reservations)
+    {
+        $this->Set('RemainingReservations', $reservations);
+    }
+
+    public function SetAllowCheckin($allowCheckin)
+    {
+        $this->Set('allowCheckin', $allowCheckin);
+    }
+
+    public function SetAllowCheckout($allowCheckout)
+    {
+        $this->Set('allowCheckout', $allowCheckout);
+    }
+}
+
+interface IPendingApprovalReservationsControl
+{
+    public function SetTimezone($timezone);
+    public function SetTotal($total);
+    public function SetUserId($userId);
+
+    public function SetAllowCheckin($allowCheckin);
+    public function SetAllowCheckout($allowCheckout);
+
+    public function BindToday($reservations);
+    public function BindTomorrow($reservations);
+    public function BindThisWeek($reservations);
+    public function BindThisMonth($reservations);
+    public function BindThisYear($reservations);
+    public function BindRemaining($reservations);
+}

--- a/Domain/Access/ReservationViewRepository.php
+++ b/Domain/Access/ReservationViewRepository.php
@@ -47,6 +47,27 @@ interface IReservationViewRepository
     /**
      * @param Date $startDate
      * @param Date $endDate
+     * @param int|null|int[] $userIds
+     * @param int|ReservationUserLevel|null $userLevel
+     * @param int|int[]|null $scheduleIds
+     * @param int|int[]|null $resourceIds
+     * @param int|int[]|null $participantIds
+     * @param bool $consolidateByReferenceNumber
+     * @return ReservationItemView[]
+     */
+    public function GetReservationsPendingApproval(
+        Date $startDate,
+        $userIds = ReservationViewRepository::ALL_USERS,
+        $userLevel = ReservationUserLevel::OWNER,
+        $scheduleIds = ReservationViewRepository::ALL_SCHEDULES,
+        $resourceIds = ReservationViewRepository::ALL_RESOURCES,
+        $consolidateByReferenceNumber = false,
+        $participantIds = ReservationViewRepository::ALL_USERS
+    );
+
+    /**
+     * @param Date $startDate
+     * @param Date $endDate
      * @param string $accessoryName
      * @return ReservationItemView[]
      */
@@ -237,6 +258,93 @@ class ReservationViewRepository implements IReservationViewRepository
             return array_values($reservations);
         }
         return $reservations;
+    }
+
+    public function GetReservationsPendingApproval(
+        Date $startDate,
+        $userIds = self::ALL_USERS,
+        $userLevel = ReservationUserLevel::OWNER,
+        $scheduleIds = self::ALL_SCHEDULES,
+        $resourceIds = self::ALL_RESOURCES,
+        $consolidateByReferenceNumber = false,
+        $participantIds = self::ALL_USERS
+    ) {
+        if (empty($userIds)) {
+            $userIds = self::ALL_USERS;
+        }
+        if (is_null($userLevel)) {
+            $userLevel = ReservationUserLevel::OWNER;
+        }
+        if (empty($scheduleIds)) {
+            $scheduleIds = self::ALL_SCHEDULES;
+        }
+        if (empty($resourceIds)) {
+            $resourceIds = self::ALL_RESOURCES;
+        }
+        if (empty($participantIds)) {
+            $participantIds = self::ALL_USERS;
+        }
+        if ($resourceIds == self::ALL_RESOURCES) {
+            $resourceIds = null;
+        }
+        if ($scheduleIds == self::ALL_SCHEDULES) {
+            $scheduleIds = null;
+        }
+        if ($userIds == self::ALL_USERS) {
+            $userIds = null;
+        }
+        if ($participantIds == self::ALL_USERS) {
+            $participantIds = null;
+        }
+
+        if (!empty($resourceIds) && $resourceIds != ReservationViewRepository::ALL_RESOURCES && !is_array($resourceIds)) {
+            $resourceIds = [$resourceIds];
+        }
+        if (!empty($scheduleIds) && $scheduleIds != ReservationViewRepository::ALL_SCHEDULES && !is_array($scheduleIds)) {
+            $scheduleIds = [$scheduleIds];
+        }
+        if (!empty($userIds) && $userIds != ReservationViewRepository::ALL_USERS && !is_array($userIds)) {
+            $userIds = [$userIds];
+        }
+        if (!empty($participantIds) && $participantIds != ReservationViewRepository::ALL_USERS && !is_array($participantIds)) {
+            $participantIds = [$participantIds];
+        }
+
+        $getReservations = new GetReservationsPendingApprovalCommand($startDate, $userIds, $userLevel, $scheduleIds, $resourceIds, $participantIds);
+
+        $reader = ServiceLocator::GetDatabase()->Query($getReservations);
+
+        $reservations = [];
+
+        $reservationRepository = new ReservationRepository();
+        $rules = $reservationRepository->GetReservationColorRules();
+
+        while ($row = $reader->GetRow()) {
+            if ($consolidateByReferenceNumber) {
+                $refNum = $row[ColumnNames::REFERENCE_NUMBER];
+
+                if (array_key_exists($refNum, $reservations)) {
+                    $reservations[$refNum]->ResourceNames[] = $row[ColumnNames::RESOURCE_NAME];
+                } else {
+                    $reservation = ReservationItemView::Populate($row);
+                    $reservation->WithColorRules($rules);
+                    $reservations[$refNum] = $reservation;
+                }
+            } else {
+                $reservation = ReservationItemView::Populate($row);
+                $reservation->WithColorRules($rules);
+                $reservations[] = $reservation;
+            }
+        }
+
+        $reader->Free();
+
+        if ($consolidateByReferenceNumber) {
+            return array_values($reservations);
+        }
+        return $reservations;
+        
+
     }
 
     public function GetAccessoryReservationList(Date $startDate, Date $endDate, $accessoryName)

--- a/Presenters/DashboardPresenter.php
+++ b/Presenters/DashboardPresenter.php
@@ -10,6 +10,7 @@ require_once(ROOT_DIR . 'Controls/Dashboard/UpcomingReservations.php');
 require_once(ROOT_DIR . 'Controls/Dashboard/ResourceAvailabilityControl.php');
 require_once(ROOT_DIR . 'Controls/Dashboard/PastReservations.php');
 require_once(ROOT_DIR . 'Controls/Dashboard/GroupUpcomingReservations.php');
+require_once(ROOT_DIR . 'Controls/Dashboard/PendingApprovalReservations.php');
 
 
 class DashboardPresenter
@@ -41,6 +42,11 @@ class DashboardPresenter
         if(ServiceLocator::GetServer()->GetUserSession()->IsResourceAdmin || ServiceLocator::GetServer()->GetUserSession()->IsScheduleAdmin){
             $myGroupReservations = new GroupUpcomingReservations(new SmartyPage());
             $this->_page->AddItem($myGroupReservations);
+        }
+
+        if(ServiceLocator::GetServer()->GetUserSession()->IsResourceAdmin || ServiceLocator::GetServer()->GetUserSession()->IsAdmin){
+            $pendingApprovalReservations = new PendingApprovalReservations(new SmartyPage());
+            $this->_page->AddItem($pendingApprovalReservations);
         }
     }
 }

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -212,8 +212,9 @@ $conf['settings']['logging']['folder'] = '/var/log/librebooking/log'; //Absolute
 $conf['settings']['logging']['level'] = 'debug'; //Set to none disable logs, error to only log errors or debug to log all messages to the app.log file 
 $conf['settings']['logging']['sql'] = 'false'; //Set to true no enable the creation of and sql.log file
 
-//IN THE REDIRECT URI'S (OF THE AUTHENTICATION YOU ARE USING) YOU NEED TO ADD THE PATH FROM THE WEBSITE DOMAIN TO THE WEB/GOOGLE-AUTH.PHP
-//EG: http://localhost/Web/facebook-auth.php
+// IN THE REDIRECT URI'S (OF THE AUTHENTICATION YOU ARE USING) YOU NEED TO ADD THE PATH FROM THE WEBSITE DOMAIN TO THE
+// WEB/GOOGLE-AUTH.PHP or WEB/FACEBOOK-AUTH.PHP or WEB/MICROSOFT-AUTH.PHP (depending on the services you are using)
+// EG: http://localhost/Web/facebook-auth.php
 /**
 * Google login configuration
 */
@@ -228,14 +229,14 @@ $conf['settings']['authentication']['microsoft.tenant.id'] = 'common'; //Replace
 $conf['settings']['authentication']['microsoft.client.secret'] = '';
 $conf['settings']['authentication']['microsoft.redirect.uri'] = '/Web/microsoft-auth.php';
 /**
- * Fcebook login configuration
+ * Facebook login configuration
  */
 $conf['settings']['authentication']['facebook.client.id'] = '';
 $conf['settings']['authentication']['facebook.client.secret'] = '';
 $conf['settings']['authentication']['facebook.redirect.uri'] = '/Web/facebook-auth.php';
 /**
- *  Delete old data job configuration
- *  Activate the deleteolddata.php as a background job to use this feature
+ * Delete old data job configuration
+ * Activate the deleteolddata.php as a background job to use this feature
  */
 $conf['settings']['delete.old.data']['years.old.data'] = '3';               //Choose how long a blackout, announcement and reservation stay in the database (in years) counting from the end date
 $conf['settings']['delete.old.data']['delete.old.announcements'] = 'false'; //Choose if this feature deletes old announcements from database

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -1012,12 +1012,22 @@ class ar extends en_us
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'ليس لديكم مجموعة قادمة للحجز';
         $strings['GroupUpcomingReservations'] = 'الحجوزات القادمة لمجموعتي';
         //End Group Upcoming Reservations 
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'حدث خطأ أثناء تسجيل الدخول باستخدام فيسبوك. يرجى المحاولة مرة أخرى.';
         //End Facebook Login SDK Error
+
+        
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'ليس لديك حجوزات في انتظار الموافقة';
+        $strings['PendingApprovalReservations'] = 'الحجوزات قيد الموافقة';
+        $strings['LaterThisMonth'] = 'في وقت لاحق هذا الشهر';
+        $strings['LaterThisYear'] = 'في وقت لاحق هذا العام';
+        $strings['Remaining'] = 'المتبقي';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/bg_bg.php
+++ b/lang/bg_bg.php
@@ -505,13 +505,25 @@ class bg_bg extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Вашата група няма предстоящи резервации';
         $strings['GroupUpcomingReservations'] = 'Бъдещите резервации на моята група(и)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Възникна грешка при влизане с Facebook. Моля, опитайте отново.';
         //End Facebook Login SDK Error
+
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Нямате резервации, изчакващи одобрение';
+        $strings['PendingApprovalReservations'] = 'Резервации в очакване на одобрение';
+        $strings['LaterThisMonth'] = 'По-късно този месец';
+        $strings['LaterThisYear'] = 'По-късно тази година';
+        $strings['Remaining'] = 'Оставащи';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
+
+
 
         $this->Strings = $strings;
 

--- a/lang/ca.php
+++ b/lang/ca.php
@@ -402,13 +402,24 @@ class ca extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'El vostre grup no té cap reserva futura';
         $strings['GroupUpcomingReservations'] = 'Properes reserves del meu(s) grup(s)';
         //End Group Upcoming Reservations
         
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'S\'ha produït un error en iniciar la sessió amb Facebook. Torneu-ho a provar.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'No teniu cap reserva a l\'espera d\'aprovació';
+        $strings['PendingApprovalReservations'] = 'Reserves pendents d\'aprovació';
+        $strings['LaterThisMonth'] = 'Més endavant aquest mes';
+        $strings['LaterThisYear'] = 'Més endavant aquest any';
+        $strings['Remaining'] = 'Restant';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
+
+
 
         $this->Strings = $strings;
     }

--- a/lang/cz.php
+++ b/lang/cz.php
@@ -821,12 +821,21 @@ class cz extends en_us
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Vaše skupina nemá žádné nadcházející rezervace';
         $strings['GroupUpcomingReservations'] = 'Nadcházející rezervace mé skupiny(y)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Při přihlašování přes Facebook došlo k chybě. Zkuste to prosím znovu.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Nemáte žádné rezervace čekající na schválení';
+        $strings['PendingApprovalReservations'] = 'Rezervace čekající na schválení';
+        $strings['LaterThisMonth'] = 'Později tento měsíc';
+        $strings['LaterThisYear'] = 'Později letos';
+        $strings['Remaining'] = 'Zbývající';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/da_da.php
+++ b/lang/da_da.php
@@ -1008,12 +1008,21 @@ class da_da extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Din gruppe har ingen kommende reservationer';
         $strings['GroupUpcomingReservations'] = 'Mine gruppers kommende reservationer';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Der opstod en fejl under login med Facebook. Prøv venligst igen.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Du har ingen reservationer, der venter på godkendelse';
+        $strings['PendingApprovalReservations'] = 'Reservationer afventer godkendelse';
+        $strings['LaterThisMonth'] = 'Senere denne måned';
+        $strings['LaterThisYear'] = 'Senere på året';
+        $strings['Remaining'] = 'Resterende';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -981,12 +981,21 @@ class de_de extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Ihre Gruppe hat keine kommenden Reservierungen';
         $strings['GroupUpcomingReservations'] = 'Kommende Reservierungen meiner Gruppe(n)';
         //End Group Upcoming Reservations
         
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Bei der Anmeldung mit Facebook ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Sie haben keine Reservierungen, die auf Genehmigung warten';
+        $strings['PendingApprovalReservations'] = 'Reservierungen zur Genehmigung ausstehend';
+        $strings['LaterThisMonth'] = 'Später in diesem Monat';
+        $strings['LaterThisYear'] = 'Später in diesem Jahr';
+        $strings['Remaining'] = 'Verbleibend';  
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/du_be.php
+++ b/lang/du_be.php
@@ -402,12 +402,21 @@ class du_be extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Uw groep heeft geen toekomstige reserveringen';
         $strings['GroupUpcomingReservations'] = 'Aankomende reserveringen van mijn groep(en)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Er is een fout opgetreden bij het inloggen met Facebook. Probeer het opnieuw.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'U heeft geen reserveringen die wachten op goedkeuring';
+        $strings['PendingApprovalReservations'] = 'Reserveringen in afwachting van goedkeuring';
+        $strings['LaterThisMonth'] = 'Later deze maand';
+        $strings['LaterThisYear'] = 'Later dit jaar';
+        $strings['Remaining'] = 'Resterend';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/du_nl.php
+++ b/lang/du_nl.php
@@ -1004,12 +1004,21 @@ class du_nl extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Uw groep heeft geen toekomstige reserveringen';
         $strings['GroupUpcomingReservations'] = 'Aankomende reserveringen van mijn groep(en)';
         //End Group Upcoming Reservations 
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Er is een fout opgetreden bij het inloggen met Facebook. Probeer het opnieuw.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'U heeft geen reserveringen die wachten op goedkeuring';
+        $strings['PendingApprovalReservations'] = 'Reserveringen in afwachting van goedkeuring';
+        $strings['LaterThisMonth'] = 'Later deze maand';
+        $strings['LaterThisYear'] = 'Later dit jaar';
+        $strings['Remaining'] = 'Resterend';     
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/ee_ee.php
+++ b/lang/ee_ee.php
@@ -770,12 +770,21 @@ class ee_ee extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Teie grupil pole tulevasi broneeringuid';
         $strings['GroupUpcomingReservations'] = 'Minu grupi(t)e tulevased broneeringud';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Facebooki sisselogimisel ilmnes viga. Palun proovi uuesti.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Teil pole ühtegi ootel olevat broneeringut';
+        $strings['PendingApprovalReservations'] = 'Ootel heakskiitmiseks määratud broneeringud';
+        $strings['LaterThisMonth'] = 'Hiljem sel kuul';
+        $strings['LaterThisYear'] = 'Hiljem sel aastal';
+        $strings['Remaining'] = 'Jäänud';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/el_gr.php
+++ b/lang/el_gr.php
@@ -1027,12 +1027,21 @@ class el_gr extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Η ομάδα σας δεν έχει καμία προσεχή κράτηση';
         $strings['GroupUpcomingReservations'] = 'Μελλοντικές κρατήσεις της ομάδας(ών) μου';
         //End Group Upcoming Reservations
         
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Προέκυψε σφάλμα κατά τη σύνδεση με το Facebook. Παρακαλούμε δοκιμάστε ξανά.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Δεν έχετε κρατήσεις που αναμένουν έγκριση';
+        $strings['PendingApprovalReservations'] = 'Κρατήσεις προς Έγκριση';
+        $strings['LaterThisMonth'] = 'Αργότερα αυτόν το μήνα';
+        $strings['LaterThisYear'] = 'Αργότερα φέτος';
+        $strings['Remaining'] = 'Υπολειπόμενο';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -24,7 +24,7 @@ class en_us extends Language
         $dates['res_popup'] = 'D, n/d g:i A';
         $dates['res_popup_time'] = 'g:i A';
         $dates['short_reservation_date'] = 'n/j/y g:i A';
-        $dates['dashboard'] = 'D, n/d g:i A';
+        $dates['dashboard'] = 'D, n/d Y g:i A';
         $dates['period_time'] = 'g:i A';
         $dates['timepicker'] = 'h:i a';
         $dates['mobile_reservation_date'] = 'n/j g:i A';
@@ -1029,11 +1029,20 @@ class en_us extends Language
 
         //Group Upcoming Reservations
         $strings['GroupUpcomingReservations'] = 'My Group(s) Upcoming Reservations';
+        $strings['NoGroupUpcomingReservations'] = 'Your group has no upcoming reservations';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'An error occured while logging in with facebook. Please try again.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'You have no reservations pending approval';
+        $strings['PendingApprovalReservations'] = 'Reservations Pending Approval';
+        $strings['LaterThisMonth'] = 'Later This Month';
+        $strings['LaterThisYear'] = 'Later This Year';
+        $strings['Remaining'] = 'Remaining';
+        //End Pending Approval Reservations in Dashboard
 
         $this->Strings = $strings;
 

--- a/lang/es.php
+++ b/lang/es.php
@@ -991,12 +991,21 @@ class es extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Tu grupo no tiene reservas futuras';
         $strings['GroupUpcomingReservations'] = 'Próximas reservas de mi(s) grupo(s)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Se produjo un error al iniciar sesión con Facebook. Por favor, inténtelo de nuevo.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'No tienes reservas pendientes de aprobación';
+        $strings['PendingApprovalReservations'] = 'Reservas pendientes de aprobación';
+        $strings['LaterThisMonth'] = 'Más tarde este mes';
+        $strings['LaterThisYear'] = 'Más tarde este año';
+        $strings['Remaining'] = 'Restante';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/eu_es.php
+++ b/lang/eu_es.php
@@ -729,12 +729,21 @@ class eu_es extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Zure taldeak ez du etorriko erreserbarik';
         $strings['GroupUpcomingReservations'] = 'Nire Taldeen Hurrengo Erreserba(k)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Facebook-en saioa hastean errorea gertatu da. Mesedez, saiatu berriro.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Ez duzu onartu beharreko erreserbarik';
+        $strings['PendingApprovalReservations'] = 'Onartzea zaindako erreserbak';
+        $strings['LaterThisMonth'] = 'Hilabete honetan geroago';
+        $strings['LaterThisYear'] = 'Aurten geroago';
+        $strings['Remaining'] = 'Geratzen dena';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/fi_fi.php
+++ b/lang/fi_fi.php
@@ -922,12 +922,21 @@ class fi_fi extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Ryhmällänne ei ole tulevia varauksia';
         $strings['GroupUpcomingReservations'] = 'Ryhmäni tulevat varaukset';
         //End Group Upcoming Reservations
     
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Virhe kirjautuessa Facebookin kanssa. Yritä uudelleen.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Sinulla ei ole odottavia hyväksyttäviä varauksia';
+        $strings['PendingApprovalReservations'] = 'Odottaa hyväksyntää olevat varaukset';
+        $strings['LaterThisMonth'] = 'Myöhemmin tänä kuukautena';
+        $strings['LaterThisYear'] = 'Myöhemmin tänä vuonna';
+        $strings['Remaining'] = 'Jäljellä oleva';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -992,12 +992,21 @@ class fr_fr extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Votre groupe n\'a aucune réservation à venir';
         $strings['GroupUpcomingReservations'] = 'Prochaines réservations de mon/des groupes';
         //End Group Upcoming Reservations
         
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Une erreur est survenue lors de la connexion avec Facebook. Veuillez réessayer.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Vous n\'avez aucune réservation en attente d\'approbation';
+        $strings['PendingApprovalReservations'] = 'Réservations en attente d\'approbation';
+        $strings['LaterThisMonth'] = 'Plus tard ce mois-ci';
+        $strings['LaterThisYear'] = 'Plus tard cette année';
+        $strings['Remaining'] = 'Restant';    
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/he.php
+++ b/lang/he.php
@@ -740,12 +740,21 @@ class he extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'אין לקבוצתך הזמנות עתידיות';
         $strings['GroupUpcomingReservations'] = 'הזמנות קבוצתי(ות) הבאות';
         //End Group Upcoming Reservations
         
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'אירעה שגיאה בעת ניסיון להתחבר עם Facebook. אנא נסה שוב.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'אין לך הזמנות בהמתנה לאישור';
+        $strings['PendingApprovalReservations'] = 'ההזמנות בהמתנה לאישור';
+        $strings['LaterThisMonth'] = 'מאוחר יותר החודש';
+        $strings['LaterThisYear'] = 'מאוחר יותר השנה';
+        $strings['Remaining'] = 'יתרה';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/hr_hr.php
+++ b/lang/hr_hr.php
@@ -630,12 +630,21 @@ class hr_hr extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Vaša grupa nema nadolazećih rezervacija';
         $strings['GroupUpcomingReservations'] = 'Nadolazeće rezervacije moje grupe/ova';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Došlo je do pogreške prilikom prijave putem Facebooka. Molimo pokušajte ponovno.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Nemate rezervacija koje čekaju odobrenje';
+        $strings['PendingApprovalReservations'] = 'Rezervacije na odobrenje';
+        $strings['LaterThisMonth'] = 'Kasnije ovog mjeseca';
+        $strings['LaterThisYear'] = 'Kasnije ove godine';
+        $strings['Remaining'] = 'Preostalo';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/hu_hu.php
+++ b/lang/hu_hu.php
@@ -985,12 +985,21 @@ class hu_hu extends en_us
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'A csoportodnak nincs következő foglalása';
         $strings['GroupUpcomingReservations'] = 'Csoportom(aim) következő foglalásai';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Hiba történt a bejelentkezés során a Facebookkal. Kérjük, próbálja újra.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Nincsenek függő jóváhagyásra váró foglalásai';
+        $strings['PendingApprovalReservations'] = 'Jóváhagyásra váró foglalások';
+        $strings['LaterThisMonth'] = 'Később ebben a hónapban';
+        $strings['LaterThisYear'] = 'Később idén';
+        $strings['Remaining'] = 'Megmaradt';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/id_id.php
+++ b/lang/id_id.php
@@ -586,12 +586,21 @@ class id_id extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Grup Anda tidak memiliki reservasi mendatang';
         $strings['GroupUpcomingReservations'] = 'Reservasi Mendatang Grup Saya';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Terjadi kesalahan saat login dengan Facebook. Silakan coba lagi.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Anda tidak memiliki reservasi yang menunggu persetujuan';
+        $strings['PendingApprovalReservations'] = 'Pemesanan Menunggu Persetujuan';
+        $strings['LaterThisMonth'] = 'Nanti Bulan Ini';
+        $strings['LaterThisYear'] = 'Nanti Tahun Ini';
+        $strings['Remaining'] = 'Sisa';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -1028,12 +1028,21 @@ class it_it extends en_us
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Il tuo gruppo non ha prenotazioni future';
         $strings['GroupUpcomingReservations'] = 'Prossime prenotazioni del mio(i) gruppo(i)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Si è verificato un errore durante l\'accesso con Facebook. Riprova.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Non hai prenotazioni in attesa di approvazione';
+        $strings['PendingApprovalReservations'] = 'Prenotazioni in attesa di approvazione';
+        $strings['LaterThisMonth'] = 'Più tardi questo mese';
+        $strings['LaterThisYear'] = 'Più tardi quest\'anno';
+        $strings['Remaining'] = 'Rimanenti';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -1004,12 +1004,21 @@ class ja_jp extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'あなたのグループには今後の予約がありません';
         $strings['GroupUpcomingReservations'] = '私のグループの今後の予約';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Facebookでログイン中にエラーが発生しました。もう一度お試しください。';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = '承認待ちの予約はありません';
+        $strings['PendingApprovalReservations'] = '承認待ちの予約';
+        $strings['LaterThisMonth'] = '今月の後で';
+        $strings['LaterThisYear'] = '今年の後で';
+        $strings['Remaining'] = '残り';
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/lt.php
+++ b/lang/lt.php
@@ -992,12 +992,21 @@ class lt extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Jūsų grupė neturi ateinančių rezervacijų';
         $strings['GroupUpcomingReservations'] = 'Mano grupės ateities rezervacijos';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Vartotojo prisijungimo metu su Facebook įvyko klaida. Bandykite dar kartą.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Jūs neturite laukiančių patvirtinimo rezervacijų';
+        $strings['PendingApprovalReservations'] = 'Laukiančios patvirtinimo rezervacijos';
+        $strings['LaterThisMonth'] = 'Vėliau šį mėnesį';
+        $strings['LaterThisYear'] = 'Vėliau šiais metais';
+        $strings['Remaining'] = 'Liko';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/no_no.php
+++ b/lang/no_no.php
@@ -644,12 +644,21 @@ class no_no extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Din gruppe har ingen kommende reservasjoner';
         $strings['GroupUpcomingReservations'] = 'Mine grupp(er) kommende reservasjoner';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Det oppstod en feil under pålogging med Facebook. Prøv igjen.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Du har ingen reservasjoner som venter på godkjenning';
+        $strings['PendingApprovalReservations'] = 'Reservasjoner venter på godkjenning';
+        $strings['LaterThisMonth'] = 'Senere denne måneden';
+        $strings['LaterThisYear'] = 'Senere i år';
+        $strings['Remaining'] = 'Gjenstående';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/pl.php
+++ b/lang/pl.php
@@ -1033,12 +1033,21 @@ class pl extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Twoja grupa nie ma żadnych nadchodzących rezerwacji';
         $strings['GroupUpcomingReservations'] = 'Nadchodzące rezerwacje mojej grupy(y)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Wystąpił błąd podczas logowania przez Facebook. Spróbuj ponownie.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Nie masz żadnych rezerwacji oczekujących na zatwierdzenie';
+        $strings['PendingApprovalReservations'] = 'Rezerwacje oczekujące na zatwierdzenie';
+        $strings['LaterThisMonth'] = 'Później w tym miesiącu';
+        $strings['LaterThisYear'] = 'Później w tym roku';
+        $strings['Remaining'] = 'Pozostałe';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/pt_br.php
+++ b/lang/pt_br.php
@@ -1015,12 +1015,21 @@ class pt_br extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Seu grupo não tem reservas futuras';
         $strings['GroupUpcomingReservations'] = 'Reservas Futuras do(s) meu(s) Grupo(s)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Ocorreu um erro ao fazer login com o Facebook. Por favor, tente novamente.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Você não tem reservas aguardando aprovação';
+        $strings['PendingApprovalReservations'] = 'Reservas aguardando aprovação';
+        $strings['LaterThisMonth'] = 'Mais tarde neste mês';
+        $strings['LaterThisYear'] = 'Mais tarde neste ano';
+        $strings['Remaining'] = 'Restante';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
         // Currently unused strings

--- a/lang/pt_pt.php
+++ b/lang/pt_pt.php
@@ -1003,12 +1003,21 @@ class pt_pt extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'O seu grupo não tem reservas futuras';
         $strings['GroupUpcomingReservations'] = 'Reservas Futuras do(s) meu(s) Grupo(s)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Ocorreu um erro ao fazer login com o Facebook. Por favor, tente novamente.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Não existem reservas aguardando aprovação';
+        $strings['PendingApprovalReservations'] = 'Reservas Aguardando Aprovação';
+        $strings['LaterThisMonth'] = 'Ainda este mês';
+        $strings['LaterThisYear'] = 'Ainda este ano';
+        $strings['Remaining'] = 'Restantes';
+        //End Pending Approval Reservations in Dashboard
 
         $this->Strings = $strings;
 

--- a/lang/ro_ro.php
+++ b/lang/ro_ro.php
@@ -502,12 +502,21 @@ class ro_ro extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Grupul tău nu are rezervări viitoare';
         $strings['GroupUpcomingReservations'] = 'Viitoarele rezervări ale grupului/meu(ă)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'A apărut o eroare la autentificarea cu Facebook. Vă rugăm să încercați din nou.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Nu aveți rezervări în așteptare de aprobare';
+        $strings['PendingApprovalReservations'] = 'Rezervări în așteptare de aprobare';
+        $strings['LaterThisMonth'] = 'Mai târziu în acest lună';
+        $strings['LaterThisYear'] = 'Mai târziu în acest an';
+        $strings['Remaining'] = 'Rămase';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/ru_ru.php
+++ b/lang/ru_ru.php
@@ -815,12 +815,21 @@ class ru_ru extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Ваша группа не имеет предстоящих бронирований';
         $strings['GroupUpcomingReservations'] = 'Предстоящие бронирования моей группы(ов)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Произошла ошибка при входе через Facebook. Пожалуйста, попробуйте еще раз.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'У вас нет резерваций, ожидающих утверждения';
+        $strings['PendingApprovalReservations'] = 'Резервации ожидают утверждения';
+        $strings['LaterThisMonth'] = 'Позже в этом месяце';
+        $strings['LaterThisYear'] = 'Позже в этом году';
+        $strings['Remaining'] = 'Осталось';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/si_si.php
+++ b/lang/si_si.php
@@ -655,12 +655,21 @@ class si_si extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Vaša skupina nima prihodnjih rezervacij';
         $strings['GroupUpcomingReservations'] = 'Prihodnje rezervacije moje skupine(i)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Prijavljanje prek Facebooka ni uspelo. Poskusite znova.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Nimate rezervacij, ki čakajo na odobritev';
+        $strings['PendingApprovalReservations'] = 'Rezervacije, ki čakajo na odobritev';
+        $strings['LaterThisMonth'] = 'Kasneje ta mesec';
+        $strings['LaterThisYear'] = 'Kasneje letos';
+        $strings['Remaining'] = 'Preostalo';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/sk.php
+++ b/lang/sk.php
@@ -641,12 +641,21 @@ class sk extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Vaša skupina nemá žiadne nadchádzajúce rezervácie';
         $strings['GroupUpcomingReservations'] = 'Nadchádzajúce rezervácie mojej skupiny(y)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Pri prihlásení cez Facebook sa vyskytla chyba. Skúste to prosím znovu.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Nemáte žiadne rezervácie čakajúce na schválenie';
+        $strings['PendingApprovalReservations'] = 'Rezervácie čakajúce na schválenie';
+        $strings['LaterThisMonth'] = 'Neskôr tento mesiac';
+        $strings['LaterThisYear'] = 'Neskôr tento rok';
+        $strings['Remaining'] = 'Zostáva';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/sr_sr.php
+++ b/lang/sr_sr.php
@@ -656,12 +656,21 @@ class sr_sr extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Vaša grupa nema nadolazeće rezervacije';
         $strings['GroupUpcomingReservations'] = 'Nadolazeće rezervacije moje grupe(ova)';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Došlo je do greške prilikom prijavljivanja putem Facebooka. Molimo pokušajte ponovo.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Nemate rezervacija koje čekaju odobrenje';
+        $strings['PendingApprovalReservations'] = 'Rezervacije koje čekaju odobrenje';
+        $strings['LaterThisMonth'] = 'Kasnije ovog meseca';
+        $strings['LaterThisYear'] = 'Kasnije ove godine';
+        $strings['Remaining'] = 'Preostalo';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/sv_sv.php
+++ b/lang/sv_sv.php
@@ -570,12 +570,21 @@ class sv_sv extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Din grupp har inga kommande bokningar';
         $strings['GroupUpcomingReservations'] = 'Mina grupps kommande bokningar';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Ett fel inträffade vid inloggning med Facebook. Försök igen.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Du har inga bokningar som väntar på godkännande';
+        $strings['PendingApprovalReservations'] = 'Bokningar väntar på godkännande';
+        $strings['LaterThisMonth'] = 'Senare denna månad';
+        $strings['LaterThisYear'] = 'Senare i år';
+        $strings['Remaining'] = 'Återstående';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/th_th.php
+++ b/lang/th_th.php
@@ -848,12 +848,21 @@ class th_th extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'กลุ่มของคุณไม่มีการจองที่จะมาถึง';
         $strings['GroupUpcomingReservations'] = 'การจองที่มีต่อไปของกลุ่มของฉัน';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'เกิดข้อผิดพลาดขณะเข้าสู่ระบบด้วย Facebook กรุณาลองอีกครั้ง';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'คุณไม่มีการจองที่รอการอนุมัติ';
+        $strings['PendingApprovalReservations'] = 'การจองรอการอนุมัติ';
+        $strings['LaterThisMonth'] = 'ในภายหลังเดือนนี้';
+        $strings['LaterThisYear'] = 'ในภายหลังปีนี้';
+        $strings['Remaining'] = 'ที่เหลือ';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/tr_tr.php
+++ b/lang/tr_tr.php
@@ -788,12 +788,21 @@ class tr_tr extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Grubunuzun gelecek rezervasyonu yok';
         $strings['GroupUpcomingReservations'] = 'Grubumun Yaklaşan Rezervasyonları';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Facebook ile giriş yapılırken bir hata oluştu. Lütfen tekrar deneyin.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Onay bekleyen rezervasyonunuz bulunmamaktadır';
+        $strings['PendingApprovalReservations'] = 'Onay bekleyen rezervasyonlar';
+        $strings['LaterThisMonth'] = 'Bu ayın ilerisinde';
+        $strings['LaterThisYear'] = 'Bu yılın ilerisinde';
+        $strings['Remaining'] = 'Kalan';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/vn_vn.php
+++ b/lang/vn_vn.php
@@ -745,12 +745,21 @@ class vn_vn extends en_gb
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = 'Nhóm của bạn không có đặt phòng sắp tới';
         $strings['GroupUpcomingReservations'] = 'Đặt phòng sắp tới của Nhóm của tôi';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = 'Đã xảy ra lỗi khi đăng nhập bằng Facebook. Vui lòng thử lại.';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = 'Bạn không có đặt phòng nào đang chờ duyệt';
+        $strings['PendingApprovalReservations'] = 'Đặt phòng đang chờ duyệt';
+        $strings['LaterThisMonth'] = 'Sau này trong tháng này';
+        $strings['LaterThisYear'] = 'Sau này trong năm nay';
+        $strings['Remaining'] = 'Còn lại';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/zh_cn.php
+++ b/lang/zh_cn.php
@@ -543,12 +543,21 @@ class zh_cn extends en_us
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = '您的团体没有即将到来的预订';
         $strings['GroupUpcomingReservations'] = '我的团体即将到来的预订';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = '使用Facebook登录时发生错误。请重试。';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = '您没有等待批准的预订';
+        $strings['PendingApprovalReservations'] = '等待批准的预订';
+        $strings['LaterThisMonth'] = '本月晚些时候';
+        $strings['LaterThisYear'] = '本年晚些时候';
+        $strings['Remaining'] = '剩余';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lang/zh_tw.php
+++ b/lang/zh_tw.php
@@ -626,12 +626,21 @@ class zh_tw extends en_us
         //End Past Reservations
 
         //Group Upcoming Reservations
+        $strings['NoGroupUpcomingReservations'] = '您的團體沒有即將到來的預訂';
         $strings['GroupUpcomingReservations'] = '我的團體即將到來的預訂';
         //End Group Upcoming Reservations
 
         //Facebook Login SDK Error
         $strings['FacebookLoginErrorMessage'] = '使用Facebook登入時發生錯誤。請重試。';
         //End Facebook Login SDK Error
+
+        //Pending Approval Reservations in Dashboard
+        $strings['NoPendingApprovalReservations'] = '您沒有等待審批的預訂';
+        $strings['PendingApprovalReservations'] = '等待審批的預訂';
+        $strings['LaterThisMonth'] = '本月晚些時候';
+        $strings['LaterThisYear'] = '本年晚些時候';
+        $strings['Remaining'] = '剩餘';        
+        //End Pending Approval Reservations in Dashboard
         //END NEEDS CHECKING
 
 

--- a/lib/Common/Date.php
+++ b/lib/Common/Date.php
@@ -742,6 +742,40 @@ class Date
     {
         return $this->ApplyDifference($interval->Diff());
     }
+
+
+    /**
+     * Implements bubble sort algorithm to sort dates from array
+     */
+    public static function BubbleSort($array) {
+        for ($i = 0; $i < count($array); $i++){
+            $swapped = false;
+            for ($j = 0; $j < count($array) - $i - 1; $j++)
+            {
+
+                if ($array[$j]->StartDate->DateCompare($array[$j+1]->StartDate) == 1) {
+                    $t = $array[$j];
+                    $array[$j] = $array[$j+1];
+                    $array[$j+1] = $t;
+                    $swapped = True;
+                }
+
+                else if($array[$j]->StartDate->DateCompare($array[$j+1]->StartDate) == 0){
+                    if ($array[$j]->StartDate->CompareTime($array[$j+1]->StartDate) == 1) {
+                        $t = $array[$j];
+                        $array[$j] = $array[$j+1];
+                        $array[$j+1] = $t;
+                        $swapped = True;
+                    }
+                }
+            }
+
+            if ($swapped == false){
+                break;
+            }
+        }
+        return $array;
+    }
 }
 
 class NullDate extends Date
@@ -1041,5 +1075,32 @@ class DateDiff
         }
 
         return trim($str);
+    }
+
+
+    /**
+     * Gets the number of remaining days in the present month
+     */
+    public static function getMonthRemainingDays($timezone){
+        date_default_timezone_set($timezone);           //NECESSARY??
+        $currentDate = new DateTime();
+        $endOfMonth = new DateTime($currentDate->format('Y-m-t 23:59:59'));
+        $interval = $currentDate->diff($endOfMonth);
+        $daysUntilEndOfMonth = $interval->days;
+
+        return $daysUntilEndOfMonth;
+    }
+
+    /**
+     * Gets the number of remaining days in the present year
+     */
+    public static function getYearRemainingDays($timezone){
+        date_default_timezone_set($timezone);           //NECESSARY??
+        $currentDate = new DateTime();
+        $endOfYear = new DateTime($currentDate->format('Y-12-31 23:59:59'));
+        $interval = $currentDate->diff($endOfYear);
+        $daysUntilEndOfYear = $interval->days;
+
+        return $daysUntilEndOfYear;
     }
 }

--- a/lib/Common/Helpers/ArrayDiff.php
+++ b/lib/Common/Helpers/ArrayDiff.php
@@ -42,4 +42,28 @@ class ArrayDiff
     {
         return $this->_unchanged;
     }
+
+    /**
+     * Eliminates duplicate objects from array
+     */
+    public static function EliminateDuplicates($array, $keep_key_assoc = false){
+        $duplicate_keys = array();
+        $tmp = array();       
+    
+        foreach ($array as $key => $val){
+            // convert objects to arrays, in_array() does not support objects
+            if (is_object($val))
+                $val = (array)$val;
+    
+            if (!in_array($val, $tmp))
+                $tmp[] = $val;
+            else
+                $duplicate_keys[] = $key;
+        }
+    
+        foreach ($duplicate_keys as $key)
+            unset($array[$key]);
+    
+        return $keep_key_assoc ? $array : array_values($array);
+    }
 }

--- a/lib/Database/Commands/Commands.php
+++ b/lib/Database/Commands/Commands.php
@@ -1780,6 +1780,24 @@ class GetReservationListCommand extends SqlCommand
     }
 }
 
+class GetReservationsPendingApprovalCommand extends SqlCommand
+{
+    public function __construct(Date $startDate, $userIds, $userLevelId, $scheduleIds, $resourceIds, $participantIds)
+    {
+        parent::__construct(QueryBuilder::GET_RESERVATION_PENDING_APPROVAL_LIST());
+        $this->AddParameter(new Parameter(ParameterNames::START_DATE, $startDate->ToDatabase()));
+        $this->AddParameter(new Parameter(ParameterNames::USER_ID, $userIds));
+        $this->AddParameter(new Parameter(ParameterNames::RESERVATION_USER_LEVEL_ID, $userLevelId));
+        $this->AddParameter(new Parameter(ParameterNames::SCHEDULE_ID, $scheduleIds));
+        $this->AddParameter(new Parameter(ParameterNames::RESOURCE_ID, $resourceIds));
+        $this->AddParameter(new Parameter(ParameterNames::PARTICIPANT_ID, $participantIds));
+        $this->AddParameter(new Parameter(ParameterNames::ALL_RESOURCES, (int)empty($resourceIds)));
+        $this->AddParameter(new Parameter(ParameterNames::ALL_SCHEDULES, (int)empty($scheduleIds)));
+        $this->AddParameter(new Parameter(ParameterNames::All_OWNERS, (int)empty($userIds)));
+        $this->AddParameter(new Parameter(ParameterNames::ALL_PARTICIPANTS, (int)empty($participantIds)));
+    }
+}
+
 class GetReminderNoticesCommand extends SqlCommand
 {
     public function __construct(Date $currentDate, $type)

--- a/lib/Database/Commands/Queries.php
+++ b/lib/Database/Commands/Queries.php
@@ -1264,6 +1264,17 @@ class QueryBuilder
 					(@all_participants = 1 OR `ri`.`reservation_instance_id` IN (SELECT `reservation_instance_id` FROM `reservation_users` WHERE `user_id` IN (@participant_id) AND `reservation_user_level` IN (2, 3)))');
     }
 
+	public static function GET_RESERVATION_PENDING_APPROVAL_LIST()
+    {
+        return self::Build(self::$SELECT_LIST_FRAGMENT, null,' AND
+					(@all_owners = 1 OR `ru`.`user_id` IN (@userid) ) AND
+					(@levelid = 0 OR `ru`.`reservation_user_level` = @levelid) AND
+					(@all_schedules = 1 OR `resources`.`schedule_id` IN (@scheduleid)) AND
+					(@all_resources = 1 OR `rr`.`resource_id` IN (@resourceid)) AND
+					(@all_participants = 1 OR `ri`.`reservation_instance_id` IN (SELECT `reservation_instance_id` FROM `reservation_users` WHERE `user_id` IN (@participant_id) AND `reservation_user_level` IN (2, 3)))
+					AND `rs`.`status_id` = 3 AND `ri`.`start_date` >= @startDate');
+    }
+
     public static function GET_RESERVATION_LIST_FULL()
     {
         return self::Build(self::$SELECT_LIST_FRAGMENT, null, 'AND `ru`.`reservation_user_level` = @levelid');

--- a/tpl/Dashboard/pending__approval_reservations.tpl
+++ b/tpl/Dashboard/pending__approval_reservations.tpl
@@ -1,6 +1,6 @@
 <div class="dashboard upcomingReservationsDashboard" id="upcomingReservationsDashboard">
 	<div class="dashboardHeader">
-		<div class="pull-left">{translate key="GroupUpcomingReservations"} <span class="badge">{$Total}</span></div>
+		<div class="pull-left">{translate key="PendingApprovalReservations"}<span class="badge">{$Total}</span></div>
 		<div class="pull-right">
 			<a href="#" title="{translate key=ShowHide} {translate key="GroupUpcomingReservations"}">
 				<i class="glyphicon"></i>
@@ -35,14 +35,28 @@
 				{/foreach}
 
 				<div class="timespan">
-					{translate key="NextWeek"} ({$NextWeeksReservations|default:array()|count})
+					{translate key="LaterThisMonth"} ({$T|default:array()|count})
 				</div>
-				{foreach from=$NextWeeksReservations item=reservation}
+				{foreach from=$ThisMonthsReservations item=reservation}
+                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+				{/foreach}
+
+				<div class="timespan">
+					{translate key="LaterThisYear"} ({$T|default:array()|count})
+				</div>
+				{foreach from=$ThisYearsReservations item=reservation}
+                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+				{/foreach}
+
+				<div class="timespan">
+					{translate key="Remaining"} ({$T|default:array()|count})
+				</div>
+				{foreach from=$RemainingReservations item=reservation}
                     {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
 				{/foreach}
 			</div>
 		{else}
-			<div class="noresults">{translate key="NoGroupUpcomingReservations"}</div>
+			<div class="noresults">{translate key="NoPendingApprovalReservations"}</div>
 		{/if}
 	</div>
 


### PR DESCRIPTION
Added a section in the dashboard that shows upcoming reservations that require approval. The section only shows to resource and application admins. Only reservations that can be approved by the user will show.

This new feature comes with the all the translations for the existing languages, but they should be checked by native speakers.