### PR TITLE
Schedule Resource Permissions

### DIFF
--- a/Controls/Dashboard/PendingApprovalReservations.php
+++ b/Controls/Dashboard/PendingApprovalReservations.php
@@ -4,6 +4,8 @@ require_once(ROOT_DIR . 'Controls/Dashboard/DashboardItem.php');
 require_once(ROOT_DIR . 'Presenters/Dashboard/PendingApprovalReservationsPresenter.php');
 require_once(ROOT_DIR . 'Domain/Access/ReservationViewRepository.php');
 
+//This section of the dashboard doesn't show pending approval reservations as orange because all of them are pending
+
 class PendingApprovalReservations extends DashboardItem implements IPendingApprovalReservationsControl
 {
     /**

--- a/Domain/Access/IResourceRepository.php
+++ b/Domain/Access/IResourceRepository.php
@@ -74,6 +74,31 @@ interface IResourceRepository
     public function GetResourceGroups($scheduleId = null, $resourceFilter = null);
 
     /**
+     * @param int $userId
+     * @param array $resourceIds
+     */
+    public function GetUserResourcePermissions($userId, $resourceIds = []);
+
+    /**
+     * @param int $userId
+     * @param array $resourceIds
+     */
+    public function GetUserGroupResourcePermissions($userId, $resourceIds = []);
+    
+    /**
+     * @param int $userId
+     * @param array $resourceIds
+     */
+    public function GetResourceAdminResourceIds($userId,  $resourceIds = []);
+
+    /**
+     * @param int $userId
+     * @param array $resourceIds
+     */
+    public function GetScheduleAdminResourceIds($userId,  $resourceIds = []);
+
+
+    /**
      * @param int $resourceId
      * @param int $groupId
      */

--- a/Domain/Access/ResourceRepository.php
+++ b/Domain/Access/ResourceRepository.php
@@ -365,6 +365,88 @@ class ResourceRepository implements IResourceRepository
     }
 
     /**
+     * Gets the resource ids that the user has permissions to
+     */
+    public function GetUserResourcePermissions($userId, $resourceIds = []){
+        $command = new GetUserPermissionsCommand($userId);
+        $reader = ServiceLocator::GetDatabase()->Query($command);
+
+        while ($row = $reader->GetRow()) {
+            $resourceId = $row[ColumnNames::RESOURCE_ID];
+
+            if (!array_key_exists($resourceId, $resourceIds)) {
+                $resourceIds[$resourceId] = $resourceId;
+            }         
+        }
+        
+        $reader->Free();
+
+        return $resourceIds;
+    }
+
+    /**
+     * Gets the resource ids that the user groups have permissions to
+     */
+    public function GetUserGroupResourcePermissions($userId, $resourceIds = []){
+        $command = new SelectUserGroupPermissions($userId);
+        $reader = ServiceLocator::GetDatabase()->Query($command);
+
+        while ($row = $reader->GetRow()) {
+            $resourceId = $row[ColumnNames::RESOURCE_ID];
+
+            if (!array_key_exists($resourceId, $resourceIds)) {
+                $resourceIds[$resourceId] = $resourceId;
+            } 
+        }
+        $reader->Free();
+
+        return $resourceIds;
+    }
+
+    /**
+     * Gets the resource ids that are under the responsability of the given resource user groups
+     */
+    public function GetResourceAdminResourceIds($userId, $resourceIds = []){
+
+        if (ServiceLocator::GetServer()->GetUserSession()->IsResourceAdmin){    
+            $command = new GetResourceAdminResourcesCommand($userId);
+            $reader = ServiceLocator::GetDatabase()->Query($command);
+
+            while ($row = $reader->GetRow()) {
+                $resourceId = $row[ColumnNames::RESOURCE_ID];
+
+                if (!array_key_exists($resourceId, $resourceIds)) {
+                    $resourceIds[$resourceId] = $resourceId;
+                } 
+            }
+            $reader->Free();
+        }
+        return $resourceIds;
+    }
+
+    /**
+     * Gets the resource ids that are under the responsability of the given schedule user groups
+     */
+    public function GetScheduleAdminResourceIds($userId, $resourceIds = []){
+
+        if (ServiceLocator::GetServer()->GetUserSession()->IsScheduleAdmin){
+            $command = new GetScheduleAdminResourcesCommand($userId);
+            $reader = ServiceLocator::GetDatabase()->Query($command);
+
+            while ($row = $reader->GetRow()) {
+                $resourceId = $row[ColumnNames::RESOURCE_ID];
+
+                if (!array_key_exists($resourceId, $resourceIds)) {
+                    $resourceIds[$resourceId] = $resourceId;
+                } 
+            }
+            $reader->Free();
+        }
+
+        return $resourceIds;
+    }
+
+    /**
      * @param $groups ResourceGroup[]
      * @param $assignments ResourceGroupAssignment[]
      * @param $resourceFilter IResourceFilter|null

--- a/Pages/Ajax/ReservationPopupPage.php
+++ b/Pages/Ajax/ReservationPopupPage.php
@@ -20,6 +20,11 @@ interface IReservationPopupPage
     public function SetName($first, $last);
 
     /**
+     * @param $OwnerId string
+     */
+    public function SetId($OwnerId);
+
+    /**
      * @param $resources ScheduleResource[]
      */
     public function SetResources($resources);
@@ -87,6 +92,21 @@ interface IReservationPopupPage
      * @param DateDiff $duration
      */
     public function SetDuration($duration);
+
+    /**
+     * @param $viewableResourceReservations
+     */
+    public function BindViewableResourceReservations($resourceIds);
+
+     /**
+     * @param $amIParticipating
+     */
+    public function SetCurrentUserParticipating($amIParticipating);
+
+    /**
+     * @param $amIInvited
+     */
+    public function SetCurrentUserInvited($amIInvited);
 }
 
 class PopupFormatter
@@ -206,6 +226,10 @@ class ReservationPopupPage extends Page implements IReservationPopupPage
         $this->Set('fullName', new FullName($first, $last));
     }
 
+    public function SetId($OwnerId){
+        $this->Set('OwnerId', $OwnerId);
+    }
+
     public function SetResources($resources)
     {
         $this->Set('resources', $resources);
@@ -271,6 +295,22 @@ class ReservationPopupPage extends Page implements IReservationPopupPage
     {
         $this->Set('duration', $duration);
     }
+
+    public function BindViewableResourceReservations($resourceIds)
+    {
+        $this->Set('CanViewResourceReservations',$resourceIds);
+    }
+
+    public function SetCurrentUserParticipating($amIParticipating)
+    {
+        $this->Set('IAmParticipating', $amIParticipating);
+    }
+
+    public function SetCurrentUserInvited($amIInvited)
+    {
+        $this->Set('IAmInvited', $amIInvited);
+    }
+
 }
 
 
@@ -346,6 +386,7 @@ class ReservationPopupPresenter
         $startDate = $reservation->StartDate->ToTimezone($tz);
         $endDate = $reservation->EndDate->ToTimezone($tz);
 
+        $this->_page->SetId($reservation->OwnerId);
         $this->_page->SetName($reservation->OwnerFirstName, $reservation->OwnerLastName);
         $this->_page->SetEmail($reservation->OwnerEmailAddress);
         $this->_page->SetPhone($reservation->OwnerPhone);
@@ -363,6 +404,10 @@ class ReservationPopupPresenter
         $user = $this->_userRepository->LoadById(ServiceLocator::GetServer()->GetUserSession()->UserId);
         $owner = $this->_userRepository->LoadById($reservation->OwnerId);
 
+        $this->UserResourcePermissions(ServiceLocator::GetServer()->GetUserSession()->UserId);
+        $this->_page->SetCurrentUserParticipating($this->IsCurrentUserParticipating(ServiceLocator::GetServer()->GetUserSession()->UserId));
+        $this->_page->SetCurrentUserInvited($this->IsCurrentUserInvited(ServiceLocator::GetServer()->GetUserSession()->UserId));
+
         $canViewAdminAttributes = $user->IsAdminFor($owner);
 
         if (!$canViewAdminAttributes) {
@@ -377,5 +422,49 @@ class ReservationPopupPresenter
         $attributeValues = $this->attributeService->GetReservationAttributes($userSession, $reservation);
 
         $this->_page->BindAttributes($attributeValues);
+    }
+
+    /**
+     * Gets the resources the user has permissions (full access and view only permissions)
+     * This is used to block a user from seeing reservation details if he has no permissions to it's resources
+     */
+    private function UserResourcePermissions($userId)
+    {
+        $resourceRepo = new ResourceRepository();
+        $resourceIds = [];
+
+        $resourceIds = $resourceRepo->GetUserResourcePermissions($userId);
+
+        $resourceIds = $resourceRepo->GetUserGroupResourcePermissions($userId,$resourceIds);
+
+        if (ServiceLocator::GetServer()->GetUserSession()->IsResourceAdmin){    
+            $resourceIds = $resourceRepo->GetResourceAdminResourceIds($userId, $resourceIds);
+        }
+
+        if (ServiceLocator::GetServer()->GetUserSession()->IsScheduleAdmin){
+            $resourceIds = $resourceRepo->GetScheduleAdminResourceIds($userId, $resourceIds);
+        }
+
+        $this->_page->BindViewableResourceReservations($resourceIds);
+    }
+
+    private function IsCurrentUserParticipating($currentUserId)
+    {
+        foreach ($this->_reservationRepository->GetReservationForEditing($this->_page->GetReservationId())->Participants as $user) {
+            if ($user->UserId == $currentUserId) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function IsCurrentUserInvited($currentUserId)
+    {
+        foreach ($this->_reservationRepository->GetReservationForEditing($this->_page->GetReservationId())->Invitees as $user) {
+            if ($user->UserId == $currentUserId) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/Pages/Reservation/ExistingReservationPage.php
+++ b/Pages/Reservation/ExistingReservationPage.php
@@ -122,6 +122,12 @@ interface IExistingReservationPage extends IReservationPage
      * @param bool $requiresApproval
      */
     public function SetRequiresApproval($requiresApproval);
+
+    /**
+     * @param $viewableResourceReservations
+     */
+    public function BindViewableResourceReservations($resourceIds);
+
 }
 
 class ExistingReservationPage extends ReservationPage implements IExistingReservationPage
@@ -309,6 +315,11 @@ class ExistingReservationPage extends ReservationPage implements IExistingReserv
     public function SetTermsAccepted($accepted)
     {
         $this->Set('TermsAccepted', $accepted);
+    }
+
+    public function BindViewableResourceReservations($resourceIds)
+    {
+        $this->Set('CanViewResourceReservations',$resourceIds);
     }
 }
 

--- a/Pages/SchedulePage.php
+++ b/Pages/SchedulePage.php
@@ -209,6 +209,11 @@ interface ISchedulePage extends IActionPage
     public function BindScheduleAvailability($availability, $tooEarly);
 
     /**
+     * @param $viewableResourceReservations
+     */
+    public function BindViewableResourceReservations($resourceIds);
+
+    /**
      * @return LoadReservationRequest
      */
     public function GetReservationRequest();
@@ -251,7 +256,7 @@ class SchedulePage extends ActionPage implements ISchedulePage
 
         $this->Set('CanViewUsers', !Configuration::Instance()->GetSectionKey(ConfigSection::PRIVACY, ConfigKeys::PRIVACY_HIDE_USER_DETAILS, new BooleanConverter()));
         $this->Set('AllowParticipation', !Configuration::Instance()->GetSectionKey(ConfigSection::RESERVATION, ConfigKeys::RESERVATION_PREVENT_PARTICIPATION, new BooleanConverter()));
-        $this->Set('ViewPastReservationsButton', ServiceLocator::GetServer()->GetUserSession()->IsAdmin);
+        $this->Set('AllowCreatePastReservationsButton', ServiceLocator::GetServer()->GetUserSession()->IsAdmin);
 
         $permissionServiceFactory = new PermissionServiceFactory();
         $scheduleRepository = new ScheduleRepository();
@@ -585,6 +590,11 @@ class SchedulePage extends ActionPage implements ISchedulePage
         $this->Set('ScheduleAvailabilityStart', $availability->GetBegin());
         $this->Set('ScheduleAvailabilityEnd', $availability->GetEnd());
         $this->Set('HideSchedule', true);
+    }
+
+    public function BindViewableResourceReservations($resourceIds)
+    {
+        $this->Set('CanViewResourceReservations',$resourceIds);
     }
 
     public function GetReservationRequest()

--- a/Presenters/Dashboard/PastReservationsPresenter.php
+++ b/Presenters/Dashboard/PastReservationsPresenter.php
@@ -56,7 +56,10 @@ class PastReservationsPresenter
         $thisWeeks = [];
         $previousWeeks = [];
 
-        /* @var $reservation ReservationItemView */
+        //TimeLessThan($now->ToTimezone($timezone)->GetTime()) -> only when the reservations end does it display 
+        //                                                       (so the reservation doesn't repeat here and in upcoming reservation)
+        //!$start->DateEquals($today) -> today is always GreaterThan($startOfPreviousWeek->AddDays(7)) so if a reservation hasn't ended it won't appear on ($todays)
+        //                              but it also can't show in any other section (can't just use an else) 
         foreach ($consolidated as $reservation) {
             $start = $reservation->EndDate->ToTimezone($timezone);
 
@@ -73,9 +76,9 @@ class PastReservationsPresenter
                 }
             } elseif ($start->DateEquals($yesterday)) {
                 $yesterdays[] = $reservation;
-            } elseif ($start->GreaterThan($startOfPreviousWeek->AddDays(7))) {
+            } elseif ($start->GreaterThan($startOfPreviousWeek->AddDays(7)) && !$start->DateEquals($today)) {
                 $thisWeeks[] = $reservation;
-            } else {
+            } else if  (!$start->DateEquals($today)){
                 $previousWeeks[] = $reservation;
             }
         }

--- a/Web/css/booked.css
+++ b/Web/css/booked.css
@@ -1061,7 +1061,7 @@ input[type="radio"] .styled:checked + label::after {
 }
 .upcomingReservationsDashboard .reservation.hover {
   cursor: pointer;
-  background-color: #eaf2f2;
+  background-color: #eaf2f2 !important;
   color: #222;
 }
 .upcomingReservationsDashboard .reservation.clicked {

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -1028,6 +1028,10 @@ class ar extends en_us
         $strings['LaterThisYear'] = 'في وقت لاحق هذا العام';
         $strings['Remaining'] = 'المتبقي';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'لا يمكن رؤية تفاصيل الحجز لأن ليس لديك أذونات لأي من الموارد في هذا الحجز';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/bg_bg.php
+++ b/lang/bg_bg.php
@@ -521,6 +521,10 @@ class bg_bg extends en_gb
         $strings['LaterThisYear'] = 'По-късно тази година';
         $strings['Remaining'] = 'Оставащи';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Не можете да видите подробности за резервацията, защото нямате права за нито един от ресурсите в тази резервация';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/ca.php
+++ b/lang/ca.php
@@ -417,6 +417,10 @@ class ca extends en_gb
         $strings['LaterThisYear'] = 'Més endavant aquest any';
         $strings['Remaining'] = 'Restant';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'No es poden veure els detalls de la reserva perquè no teniu permisos per a cap dels recursos d\'aquesta reserva';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/cz.php
+++ b/lang/cz.php
@@ -836,6 +836,10 @@ class cz extends en_us
         $strings['LaterThisYear'] = 'Později letos';
         $strings['Remaining'] = 'Zbývající';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Nemůžete vidět podrobnosti rezervace, protože nemáte oprávnění k žádným zdrojům v této rezervaci';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/da_da.php
+++ b/lang/da_da.php
@@ -1023,6 +1023,10 @@ class da_da extends en_gb
         $strings['LaterThisYear'] = 'Senere på året';
         $strings['Remaining'] = 'Resterende';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Kan ikke se reservationsoplysninger, fordi du ikke har tilladelser til nogen af ressourcerne i denne reservation';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -996,6 +996,10 @@ class de_de extends en_gb
         $strings['LaterThisYear'] = 'Später in diesem Jahr';
         $strings['Remaining'] = 'Verbleibend';  
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'U kunt geen details van de reservering zien omdat u geen toestemming heeft voor een van de bronnen in deze reservering';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/du_be.php
+++ b/lang/du_be.php
@@ -417,6 +417,10 @@ class du_be extends en_gb
         $strings['LaterThisYear'] = 'Later dit jaar';
         $strings['Remaining'] = 'Resterend';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'U kunt geen details van de reservering zien omdat u geen toestemming heeft voor een van de bronnen in deze reservering';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/du_nl.php
+++ b/lang/du_nl.php
@@ -1019,6 +1019,10 @@ class du_nl extends en_gb
         $strings['LaterThisYear'] = 'Later dit jaar';
         $strings['Remaining'] = 'Resterend';     
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'U kunt geen details van de reservering zien omdat u geen toestemming heeft voor een of meer bronnen in deze reservering';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/ee_ee.php
+++ b/lang/ee_ee.php
@@ -785,6 +785,10 @@ class ee_ee extends en_gb
         $strings['LaterThisYear'] = 'Hiljem sel aastal';
         $strings['Remaining'] = 'Jäänud';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Üksikasju ei saa näha, kuna teil pole selles broneeringus ühegi ressursi jaoks luba';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/el_gr.php
+++ b/lang/el_gr.php
@@ -1042,6 +1042,10 @@ class el_gr extends en_gb
         $strings['LaterThisYear'] = 'Αργότερα φέτος';
         $strings['Remaining'] = 'Υπολειπόμενο';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Δεν μπορείτε να δείτε λεπτομέρειες κράτησης επειδή δεν έχετε άδειες για κανένα από τους πόρους σε αυτήν την κράτηση';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -1038,11 +1038,15 @@ class en_us extends Language
 
         //Pending Approval Reservations in Dashboard
         $strings['NoPendingApprovalReservations'] = 'You have no reservations pending approval';
-        $strings['PendingApprovalReservations'] = 'Reservations Pending Approval';
+        $strings['PendingApprovalReservations'] = 'Pending Approval Reservations';
         $strings['LaterThisMonth'] = 'Later This Month';
         $strings['LaterThisYear'] = 'Later This Year';
         $strings['Remaining'] = 'Remaining';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Can\'t see reservation details because you don\'t have permissions to any of the resources in this reservation';
+        //End Schedule Resource Permissions
 
         $this->Strings = $strings;
 

--- a/lang/es.php
+++ b/lang/es.php
@@ -1006,6 +1006,10 @@ class es extends en_gb
         $strings['Remaining'] = 'Restante';
         //End Pending Approval Reservations in Dashboard
 
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'No se pueden ver los detalles de la reserva porque no tienes permisos para ninguno de los recursos en esta reserva';
+        //End Schedule Resource Permissions
+        //END NEEDS CHECKING
 
         $this->Strings = $strings;
 

--- a/lang/eu_es.php
+++ b/lang/eu_es.php
@@ -744,6 +744,10 @@ class eu_es extends en_gb
         $strings['LaterThisYear'] = 'Aurten geroago';
         $strings['Remaining'] = 'Geratzen dena';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Ezinezkoa da erreserbaaren xehetasunak ikustea, erreserba honetan dagoen edozein baliabideen baimenik ez delako';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/fi_fi.php
+++ b/lang/fi_fi.php
@@ -937,6 +937,10 @@ class fi_fi extends en_gb
         $strings['LaterThisYear'] = 'Myöhemmin tänä vuonna';
         $strings['Remaining'] = 'Jäljellä oleva';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Et voi nähdä varauksen tietoja, koska sinulla ei ole oikeuksia mihinkään tämän varauksen resursseista';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         $this->Strings = $strings;

--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -1007,6 +1007,10 @@ class fr_fr extends en_gb
         $strings['LaterThisYear'] = 'Plus tard cette année';
         $strings['Remaining'] = 'Restant';    
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Impossible de voir les détails de la réservation car vous n\'avez pas les autorisations pour l\'un des ressources dans cette réservation';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/he.php
+++ b/lang/he.php
@@ -755,6 +755,10 @@ class he extends en_gb
         $strings['LaterThisYear'] = 'מאוחר יותר השנה';
         $strings['Remaining'] = 'יתרה';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'לא ניתן לראות פרטי ההזמנה מכיוון שאין לך הרשאות לאף אחת מהמשאבים בהזמנה זו';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/hr_hr.php
+++ b/lang/hr_hr.php
@@ -645,6 +645,10 @@ class hr_hr extends en_gb
         $strings['LaterThisYear'] = 'Kasnije ove godine';
         $strings['Remaining'] = 'Preostalo';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Ne možete vidjeti pojedinosti o rezervaciji jer nemate dozvole za nijedan od resursa u ovoj rezervaciji';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/hu_hu.php
+++ b/lang/hu_hu.php
@@ -1000,6 +1000,10 @@ class hu_hu extends en_us
         $strings['LaterThisYear'] = 'Később idén';
         $strings['Remaining'] = 'Megmaradt';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'A foglalás részleteit nem lehet látni, mert nincs jogosultságod egyik erőforráshoz sem ebben a foglalásban';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/id_id.php
+++ b/lang/id_id.php
@@ -601,6 +601,10 @@ class id_id extends en_gb
         $strings['LaterThisYear'] = 'Nanti Tahun Ini';
         $strings['Remaining'] = 'Sisa';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Tidak dapat melihat detail pemesanan karena Anda tidak memiliki izin untuk salah satu dari sumber daya dalam pemesanan ini';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -1043,6 +1043,10 @@ class it_it extends en_us
         $strings['LaterThisYear'] = 'Più tardi quest\'anno';
         $strings['Remaining'] = 'Rimanenti';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Impossibile visualizzare i dettagli della prenotazione perché non hai le autorizzazioni per nessuna delle risorse in questa prenotazione';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -1019,6 +1019,10 @@ class ja_jp extends en_gb
         $strings['LaterThisYear'] = '今年の後で';
         $strings['Remaining'] = '残り';
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'この予約に含まれるいずれかのリソースへの権限がないため、予約の詳細を表示できません';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/lt.php
+++ b/lang/lt.php
@@ -1007,6 +1007,10 @@ class lt extends en_gb
         $strings['LaterThisYear'] = 'Vėliau šiais metais';
         $strings['Remaining'] = 'Liko';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Dėl neturėtų teisių į šioje rezervacijoje esančius išteklius negalite matyti rezervacijos informacijos';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/no_no.php
+++ b/lang/no_no.php
@@ -659,6 +659,10 @@ class no_no extends en_gb
         $strings['LaterThisYear'] = 'Senere i år';
         $strings['Remaining'] = 'Gjenstående';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Kan ikke se reservasjonsdetaljer fordi du ikke har tillatelser til noen av ressursene i denne reservasjonen';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/pl.php
+++ b/lang/pl.php
@@ -1048,6 +1048,10 @@ class pl extends en_gb
         $strings['LaterThisYear'] = 'Później w tym roku';
         $strings['Remaining'] = 'Pozostałe';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Nie można zobaczyć szczegółów rezerwacji, ponieważ nie masz uprawnień do żadnych zasobów w tej rezerwacji';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/pt_br.php
+++ b/lang/pt_br.php
@@ -1030,6 +1030,10 @@ class pt_br extends en_gb
         $strings['LaterThisYear'] = 'Mais tarde neste ano';
         $strings['Remaining'] = 'Restante';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Não é possível ver os detalhes da reserva porque você não tem permissões para nenhum dos recursos nesta reserva';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
         // Currently unused strings

--- a/lang/pt_pt.php
+++ b/lang/pt_pt.php
@@ -1018,6 +1018,10 @@ class pt_pt extends en_gb
         $strings['LaterThisYear'] = 'Ainda este ano';
         $strings['Remaining'] = 'Restantes';
         //End Pending Approval Reservations in Dashboard
+        
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Não é possível ver os detalhes da reserva uma vez que não tem permissões para um ou mais recursos nesta reserva';
+        //End Schedule Resource Permissions
 
         $this->Strings = $strings;
 

--- a/lang/ro_ro.php
+++ b/lang/ro_ro.php
@@ -517,6 +517,10 @@ class ro_ro extends en_gb
         $strings['LaterThisYear'] = 'Mai târziu în acest an';
         $strings['Remaining'] = 'Rămase';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Nu puteți vedea detaliile rezervării deoarece nu aveți permisiuni pentru niciunul dintre resursele din această rezervare';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/ru_ru.php
+++ b/lang/ru_ru.php
@@ -830,6 +830,10 @@ class ru_ru extends en_gb
         $strings['LaterThisYear'] = 'Позже в этом году';
         $strings['Remaining'] = 'Осталось';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Невозможно просмотреть детали бронирования, потому что у вас нет разрешений на ни один из ресурсов в этом бронировании';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/si_si.php
+++ b/lang/si_si.php
@@ -670,6 +670,10 @@ class si_si extends en_gb
         $strings['LaterThisYear'] = 'Kasneje letos';
         $strings['Remaining'] = 'Preostalo';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Podrobnosti rezervacije ni mogoče videti, ker nimate dovoljenj za nobenega od virov v tej rezervaciji';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/sk.php
+++ b/lang/sk.php
@@ -656,6 +656,10 @@ class sk extends en_gb
         $strings['LaterThisYear'] = 'Neskôr tento rok';
         $strings['Remaining'] = 'Zostáva';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Nie je možné zobraziť podrobnosti o rezervácii, pretože nemáte oprávnenie k žiadnym zdrojom v tejto rezervácii';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/sr_sr.php
+++ b/lang/sr_sr.php
@@ -671,6 +671,10 @@ class sr_sr extends en_gb
         $strings['LaterThisYear'] = 'Kasnije ove godine';
         $strings['Remaining'] = 'Preostalo';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Ne možete videti detalje rezervacije jer nemate dozvole za nijedan od resursa u ovoj rezervaciji';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/sv_sv.php
+++ b/lang/sv_sv.php
@@ -585,6 +585,10 @@ class sv_sv extends en_gb
         $strings['LaterThisYear'] = 'Senare i år';
         $strings['Remaining'] = 'Återstående';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Kan inte se detaljer om bokningen eftersom du inte har behörighet för någon av resurserna i denna bokning';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/th_th.php
+++ b/lang/th_th.php
@@ -863,6 +863,10 @@ class th_th extends en_gb
         $strings['LaterThisYear'] = 'ในภายหลังปีนี้';
         $strings['Remaining'] = 'ที่เหลือ';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'ไม่สามารถดูรายละเอียดการจองเนื่องจากคุณไม่มีสิทธิ์ที่เพียงพอที่จะเข้าถึงทรัพยากรใด ๆ ในการจองนี้';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/tr_tr.php
+++ b/lang/tr_tr.php
@@ -803,6 +803,10 @@ class tr_tr extends en_gb
         $strings['LaterThisYear'] = 'Bu yılın ilerisinde';
         $strings['Remaining'] = 'Kalan';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Bu rezervasyondaki hiçbir kaynağa izinleriniz olmadığından rezervasyon ayrıntılarını göremiyorsunuz';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/vn_vn.php
+++ b/lang/vn_vn.php
@@ -760,6 +760,10 @@ class vn_vn extends en_gb
         $strings['LaterThisYear'] = 'Sau này trong năm nay';
         $strings['Remaining'] = 'Còn lại';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = 'Không thể xem chi tiết đặt phòng vì bạn không có quyền truy cập vào bất kỳ nguồn tài nguyên nào trong đặt phòng này';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/zh_cn.php
+++ b/lang/zh_cn.php
@@ -558,6 +558,10 @@ class zh_cn extends en_us
         $strings['LaterThisYear'] = '本年晚些时候';
         $strings['Remaining'] = '剩余';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = '由于您在此预订中的任何资源都没有权限，因此无法查看预订详细信息';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lang/zh_tw.php
+++ b/lang/zh_tw.php
@@ -641,6 +641,10 @@ class zh_tw extends en_us
         $strings['LaterThisYear'] = '本年晚些時候';
         $strings['Remaining'] = '剩餘';        
         //End Pending Approval Reservations in Dashboard
+
+        //Schedule Resource Permissions
+        $strings['NoResourcePermissions'] = '由於您在此預訂中的任何資源都沒有權限，因此無法查看預訂詳細信息';
+        //End Schedule Resource Permissions
         //END NEEDS CHECKING
 
 

--- a/lib/Common/Date.php
+++ b/lib/Common/Date.php
@@ -747,21 +747,21 @@ class Date
     /**
      * Implements bubble sort algorithm to sort dates from array
      */
-    public static function BubbleSort($array) {
+    public static function BubbleSort($array, $sortBy = 'StartDate') {
         for ($i = 0; $i < count($array); $i++){
             $swapped = false;
             for ($j = 0; $j < count($array) - $i - 1; $j++)
             {
 
-                if ($array[$j]->StartDate->DateCompare($array[$j+1]->StartDate) == 1) {
+                if ($array[$j]->$sortBy->DateCompare($array[$j+1]->$sortBy) == 1) {
                     $t = $array[$j];
                     $array[$j] = $array[$j+1];
                     $array[$j+1] = $t;
                     $swapped = True;
                 }
 
-                else if($array[$j]->StartDate->DateCompare($array[$j+1]->StartDate) == 0){
-                    if ($array[$j]->StartDate->CompareTime($array[$j+1]->StartDate) == 1) {
+                else if($array[$j]->$sortBy->DateCompare($array[$j+1]->$sortBy) == 0){
+                    if ($array[$j]->$sortBy->CompareTime($array[$j+1]->$sortBy) == 1) {
                         $t = $array[$j];
                         $array[$j] = $array[$j+1];
                         $array[$j+1] = $t;

--- a/lib/Database/Commands/Commands.php
+++ b/lib/Database/Commands/Commands.php
@@ -1630,6 +1630,30 @@ class GetGroupSchedulesId extends SqlCommand{
     }
 }
 
+class GetResourceAdminResourcesCommand extends SqlCommand {
+    public function __construct($userId)
+    {
+        parent::__construct(Queries::GET_RESOURCE_ADMIN_RESOURCES);
+        $this->AddParameter(new Parameter(ParameterNames::USER_ID, $userId));
+    }
+}
+
+class GetScheduleAdminSchedulesCommand extends SqlCommand {
+    public function __construct($userId)
+    {
+        parent::__construct(Queries::GET_SHCEDULE_ADMIN_SCHEDULES);
+        $this->AddParameter(new Parameter(ParameterNames::USER_ID, $userId));
+    }
+}
+
+class GetScheduleAdminResourcesCommand extends SqlCommand {
+    public function __construct($userId)
+    {
+        parent::__construct(Queries::GET_SCHEDULE_ADMIN_RESOURCES);
+        $this->AddParameter(new Parameter(ParameterNames::USER_ID, $userId));
+    }
+}
+
 class GetGroupsIManageCommand extends SqlCommand
 {
     public function __construct($userId)

--- a/lib/Database/Commands/Queries.php
+++ b/lib/Database/Commands/Queries.php
@@ -596,12 +596,50 @@ class Queries
 		FROM `group_resource_permissions`
 		WHERE `group_id` = @groupid';
 
-	public const GET_GROUP_RESOURCES_ID = 'SELECT `resource_id` FROM `resources` 
-			WHERE `admin_group_id` = @groupid';
+	public const GET_GROUP_RESOURCES_ID = 
+		'SELECT `resource_id` FROM `resources` 
+		WHERE `admin_group_id` = @groupid';
 
-	public const GET_GROUP_SCHEDULES_ID = 'SELECT `schedule_id` FROM `schedules`
-			WHERE `admin_group_id` = @groupid';
+	public const GET_GROUP_SCHEDULES_ID =
+		'SELECT `schedule_id` FROM `schedules`
+		WHERE `admin_group_id` = @groupid';
 
+	public const GET_RESOURCE_ADMIN_RESOURCES = 
+		'SELECT `resource_id`, `name` , `schedule_id`, `admin_group_id`
+		FROM `resources` 
+		WHERE `admin_group_id` 
+		IN (
+			SELECT `g`.group_id
+			FROM `user_groups` `ug`
+			INNER JOIN `groups` `g` ON `ug`.`group_id` = `g`.`group_id`
+			WHERE `user_id` = @userid
+			)';
+
+	public const GET_SHCEDULE_ADMIN_SCHEDULES = 
+		'SELECT `schedule_id`, `name` , `admin_group_id`
+		FROM `schedules`
+		WHERE `admin_group_id`
+		IN (
+			SELECT `g`.group_id
+			FROM `user_groups` `ug`
+			INNER JOIN `groups` `g` ON `ug`.`group_id` = `g`.`group_id`
+			WHERE `user_id` = @userid
+			);';
+
+	public const GET_SCHEDULE_ADMIN_RESOURCES = 
+		'SELECT `resource_id`, `name` , `schedule_id`, `admin_group_id`
+		FROM `resources`
+		WHERE `schedule_id` 
+		IN
+			(SELECT `schedule_id`
+			FROM `schedules`
+			WHERE `admin_group_id`
+			IN (
+				SELECT `g`.group_id
+				FROM `user_groups` `ug`
+				INNER JOIN `groups` `g` ON `ug`.`group_id` = `g`.`group_id`
+				WHERE `user_id` = @userid
+				))';
 
     public const GET_GROUP_ROLES =
         'SELECT `r`.*

--- a/tpl/Ajax/respopup.tpl
+++ b/tpl/Ajax/respopup.tpl
@@ -1,9 +1,24 @@
 {if $authorized}
+    {*CHECK IF USER HAS PERMISSIONS TO THE RESOURCES OF THE RESERVATIONS, HIDE DETAILS IF HE DOESN'T HAVE PERMISSIONS TO ALL OF THEM*}
+    {assign var=isResourcePermitted value=false}
+    {foreach from=$resources item=checkResourcePermission}
+        {if in_array($checkResourcePermission->Id(), $CanViewResourceReservations)}
+            {assign var=isResourcePermitted value=true}
+            {break};
+        {/if}
+    {{/foreach}}
+    {*HOWEVER THE USER CAN SEE THE RESERVATION IF HE IS A OWNER, PARTICIPANT OR INVITEE*}
+    {if $isResourcePermitted == false}
+        {if $UserId == $OwnerId || $IAmParticipating || $IAmInvited}
+            {assign var=isResourcePermitted value=true}
+        {/if}
+    {/if}
+
     <div class="res_popup_details" style="margin:0">
 
         {capture "name"}
             <div class="user">
-                {if $hideUserInfo || $hideDetails}
+                {if ($hideUserInfo || $hideDetails) || !$isResourcePermitted}
                     {translate key=Private}
                 {else}
                     {$fullName}
@@ -14,7 +29,7 @@
 
         {capture "email"}
             <div class="email">
-                {if !$hideUserInfo && !$hideDetails}
+                {if !$hideUserInfo && !$hideDetails && $isResourcePermitted}
                     {$email}
                 {/if}
             </div>
@@ -23,7 +38,7 @@
 
         {capture "phone"}
             <div class="phone">
-                {if !$hideUserInfo && !$hideDetails}
+                {if !$hideUserInfo && !$hideDetails && $isResourcePermitted}
                     {$phone}
                 {/if}
             </div>
@@ -40,7 +55,7 @@
         {$formatter->Add('dates', $smarty.capture.dates)}
 
         {capture "title"}
-            {if !$hideDetails}
+            {if !$hideDetails && $isResourcePermitted}
                 <div class="title">{if $title neq ''}{$title}{else}{translate key=NoTitleLabel}{/if}</div>
             {/if}
         {/capture}
@@ -51,14 +66,18 @@
                 {translate key="Resources"} ({$resources|@count}):
                 {foreach from=$resources item=resource name=resource_loop}
                     {$resource->Name()}
+                    
                     {if !$smarty.foreach.resource_loop.last}, {/if}
                 {/foreach}
+                {if !$isResourcePermitted}
+                    <p class="text-danger">{translate key='NoResourcePermissions'}</p>
+                {/if}
             </div>
         {/capture}
         {$formatter->Add('resources', $smarty.capture.resources)}
 
         {capture "participants"}
-            {if !$hideUserInfo && !$hideDetails}
+            {if !$hideUserInfo && !$hideDetails && $isResourcePermitted}
                 <div class="users">
                     {translate key="Participants"} ({$participants|@count}):
                     {foreach from=$participants item=user name=participant_loop}
@@ -73,7 +92,7 @@
         {$formatter->Add('participants', $smarty.capture.participants)}
 
         {capture "accessories"}
-            {if !$hideDetails}
+            {if !$hideDetails && $isResourcePermitted}
                 <div class="accessories">
                     {translate key="Accessories"} ({$accessories|@count}):
                     {foreach from=$accessories item=accessory name=accessory_loop}
@@ -86,14 +105,14 @@
         {$formatter->Add('accessories', $smarty.capture.accessories)}
 
         {capture "description"}
-            {if !$hideDetails}
+            {if !$hideDetails && $isResourcePermitted}
                 <div class="summary">{if $summary neq ''}{$summary|truncate:300:"..."|nl2br}{else}{translate key=NoDescriptionLabel}{/if}</div>
             {/if}
         {/capture}
         {$formatter->Add('description', $smarty.capture.description)}
 
         {capture "attributes"}
-            {if !$hideDetails}
+            {if !$hideDetails && $isResourcePermitted}
                 {if $attributes|default:array()|count > 0}
                     <br/>
                     {foreach from=$attributes item=attribute}

--- a/tpl/Dashboard/dashboard_reservation.tpl
+++ b/tpl/Dashboard/dashboard_reservation.tpl
@@ -2,7 +2,7 @@
 {assign var=checkout value=$reservation->IsCheckinEnabled() && $reservation->RequiresCheckout()}
 {assign var=class value=""}
 {if $reservation->RequiresApproval}{assign var=class value="pending"}{/if}
-<div class="reservation row {$class}" id="{$reservation->ReferenceNumber}" {if isset($orangePending)}style="background-color:white;"{/if}> {*doesn't show pending reservations as orange Pending Approval Reservations1 in the dashboard*}
+<div class="reservation row {$class}" id="{$reservation->ReferenceNumber}" {if isset($orangePending)}style="background-color:white;"{/if}> {*doesn't show pending approval reservations as orange in the Pending Approval Reservations displayer in the dashboard*}
     <div class="col-sm-3 col-xs-12">{$reservation->Title|default:$DefaultTitle}</div>
     <div class="col-sm-2 col-xs-12">{fullname first=$reservation->FirstName last=$reservation->LastName ignorePrivacy=$reservation->IsUserOwner($UserId)} {if !$reservation->IsUserOwner($UserId)}{html_image src="users.png" altKey=Participant}{/if}</div>
     <div class="col-sm-2 col-xs-6">{formatdate date=$reservation->StartDate->ToTimezone($Timezone) key=dashboard}</div>

--- a/tpl/Dashboard/dashboard_reservation.tpl
+++ b/tpl/Dashboard/dashboard_reservation.tpl
@@ -2,7 +2,7 @@
 {assign var=checkout value=$reservation->IsCheckinEnabled() && $reservation->RequiresCheckout()}
 {assign var=class value=""}
 {if $reservation->RequiresApproval}{assign var=class value="pending"}{/if}
-<div class="reservation row {$class}" id="{$reservation->ReferenceNumber}">
+<div class="reservation row {$class}" id="{$reservation->ReferenceNumber}" {if isset($orangePending)}style="background-color:white;"{/if}> {*doesn't show pending reservations as orange Pending Approval Reservations1 in the dashboard*}
     <div class="col-sm-3 col-xs-12">{$reservation->Title|default:$DefaultTitle}</div>
     <div class="col-sm-2 col-xs-12">{fullname first=$reservation->FirstName last=$reservation->LastName ignorePrivacy=$reservation->IsUserOwner($UserId)} {if !$reservation->IsUserOwner($UserId)}{html_image src="users.png" altKey=Participant}{/if}</div>
     <div class="col-sm-2 col-xs-6">{formatdate date=$reservation->StartDate->ToTimezone($Timezone) key=dashboard}</div>

--- a/tpl/Dashboard/pending__approval_reservations.tpl
+++ b/tpl/Dashboard/pending__approval_reservations.tpl
@@ -13,46 +13,47 @@
 		{assign var=colspan value="5"}
 		{if $Total > 0}
 			<div>
+				{assign var=orangePending value=false}
 				<div class="timespan">
 					{translate key="Today"} ({$TodaysReservations|default:array()|count})
 				</div>
 				{foreach from=$TodaysReservations item=reservation}
-                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+					{include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout orangePending=$orangePending}
 				{/foreach}
 
 				<div class="timespan">
 					{translate key="Tomorrow"} ({$TomorrowsReservations|default:array()|count})
 				</div>
 				{foreach from=$TomorrowsReservations item=reservation}
-                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+					{include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout orangePending=$orangePending}
 				{/foreach}
 
 				<div class="timespan">
 					{translate key="LaterThisWeek"} ({$ThisWeeksReservations|default:array()|count})
 				</div>
 				{foreach from=$ThisWeeksReservations item=reservation}
-                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+					{include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout orangePending=$orangePending}
 				{/foreach}
 
 				<div class="timespan">
 					{translate key="LaterThisMonth"} ({$T|default:array()|count})
 				</div>
 				{foreach from=$ThisMonthsReservations item=reservation}
-                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+					{include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout orangePending=$orangePending}				
 				{/foreach}
 
 				<div class="timespan">
 					{translate key="LaterThisYear"} ({$T|default:array()|count})
 				</div>
 				{foreach from=$ThisYearsReservations item=reservation}
-                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+					{include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout orangePending=$orangePending}
 				{/foreach}
 
 				<div class="timespan">
 					{translate key="Remaining"} ({$T|default:array()|count})
 				</div>
 				{foreach from=$RemainingReservations item=reservation}
-                    {include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout}
+					{include file='Dashboard/dashboard_reservation.tpl' reservation=$reservation allowCheckin=$allowCheckin allowCheckout=$allowCheckout orangePending=$orangePending}
 				{/foreach}
 			</div>
 		{else}

--- a/tpl/Dashboard/resource_availability.tpl
+++ b/tpl/Dashboard/resource_availability.tpl
@@ -14,37 +14,36 @@
         {foreach from=$Schedules item=s}
             {assign var=availability value=$Available[$s->GetId()]}
             {if is_array($availability) && $availability|default:array()|count > 0}
-            <h5>{$s->GetName()}</h5>
-            {foreach from=$availability item=i}
-                <div class="availabilityItem">
-                    <div class="col-xs-12 col-sm-5">
-                        <i resource-id="{$i->ResourceId()}" class="resourceNameSelector fa fa-info-circle"></i>
-                        <div class="resourceName" style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};">
-                            <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
-                               resource-id="{$i->ResourceId()}"
-                               class="resourceNameSelector" style="color:{$i->GetTextColor()}">{$i->ResourceName()}</a>
+                <h5>{$s->GetName()}</h5>
+                {foreach from=$availability item=i}
+                    <div class="availabilityItem">
+                        <div class="col-xs-12 col-sm-5">
+                            <i resource-id="{$i->ResourceId()}" class="resourceNameSelector fa fa-info-circle"></i>
+                            <div class="resourceName" style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};">
+                                <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
+                                resource-id="{$i->ResourceId()}"
+                                class="resourceNameSelector" style="color:{$i->GetTextColor()}">{$i->ResourceName()}</a>
+                            </div>
                         </div>
+                        <div class="availability col-xs-12 col-sm-4">
+                            {if $i->NextTime() != null}
+                                {translate key=AvailableUntil}
+                                {format_date date=$i->NextTime() timezone=$Timezone key=dashboard}
+                            {else}
+                                <span class="no-data">{translate key=AllNoUpcomingReservations args=30}</span>
+                            {/if}
+                        </div>
+                        <div class="reserveButton col-xs-12 col-sm-3">
+                            <a class="btn btn-xs col-xs-12"
+                            href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}">{translate key=Reserve}</a>
+                        </div>
+                        <div class="clearfix"></div>
                     </div>
-                    <div class="availability col-xs-12 col-sm-4">
-                        {if $i->NextTime() != null}
-                            {translate key=AvailableUntil}
-                            {format_date date=$i->NextTime() timezone=$Timezone key=dashboard}
-                        {else}
-                            <span class="no-data">{translate key=AllNoUpcomingReservations args=30}</span>
-                        {/if}
-                    </div>
-                    <div class="reserveButton col-xs-12 col-sm-3">
-                        <a class="btn btn-xs col-xs-12"
-                           href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}">{translate key=Reserve}</a>
-                    </div>
-                    <div class="clearfix"></div>
-                </div>
-                {foreachelse}
-                <div class="no-data">{translate key=None}</div>
-            {/foreach}
+                {/foreach}
             {/if}
         {/foreach}
-        {if empty($availability)}
+
+        {if empty($Available)}
             <div class="no-data" style="text-align: center;">{translate key=None}</div>
         {/if}
 
@@ -53,32 +52,31 @@
         {foreach from=$Schedules item=s}
             {assign var=availability value=$Unavailable[$s->GetId()]}
             {if is_array($availability) && $availability|default:array()|count > 0}
-            <h5>{$s->GetName()}</h5>
-            {foreach from=$availability item=i}
-                <div class="availabilityItem">
-                    <div class="col-xs-12 col-sm-5">
-                        <i resource-id="{$i->ResourceId()}" class="resourceNameSelector fa fa-info-circle"></i>
-                        <div class="resourceName" style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};">
-                            <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
-                               resource-id="{$i->ResourceId()}"
-                               class="resourceNameSelector" style="color:{$i->GetTextColor()}">{$i->ResourceName()}</a>
+                <h5>{$s->GetName()}</h5>
+                {foreach from=$availability item=i}
+                    <div class="availabilityItem">
+                        <div class="col-xs-12 col-sm-5">
+                            <i resource-id="{$i->ResourceId()}" class="resourceNameSelector fa fa-info-circle"></i>
+                            <div class="resourceName" style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};">
+                                <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
+                                resource-id="{$i->ResourceId()}"
+                                class="resourceNameSelector" style="color:{$i->GetTextColor()}">{$i->ResourceName()}</a>
+                            </div>
+                        </div>
+                        <div class="availability col-xs-12 col-sm-4">
+                            {translate key=AvailableBeginningAt} {format_date date=$i->ReservationEnds() timezone=$Timezone key=dashboard}
+                        </div>
+                        <div class="reserveButton col-xs-12 col-sm-3">
+                            <a class="btn btn-xs col-xs-12"
+                            href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}&{QueryStringKeys::START_DATE}={format_date date=$i->ReservationEnds() timezone=$Timezone key=url_full}">{translate key=Reserve}</a>
                         </div>
                     </div>
-                    <div class="availability col-xs-12 col-sm-4">
-                        {translate key=AvailableBeginningAt} {format_date date=$i->ReservationEnds() timezone=$Timezone key=dashboard}
-                    </div>
-                    <div class="reserveButton col-xs-12 col-sm-3">
-                        <a class="btn btn-xs col-xs-12"
-                           href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}&{QueryStringKeys::START_DATE}={format_date date=$i->ReservationEnds() timezone=$Timezone key=url_full}">{translate key=Reserve}</a>
-                    </div>
-                </div>
-                <div class="clearfix"></div>
-                {foreachelse}
-                <div class="no-data">{translate key=None}</div>
-            {/foreach}
+                    <div class="clearfix"></div>
+                {/foreach}
             {/if}
         {/foreach}
-        {if empty($availability)}
+
+        {if empty($Unavailable)}
             <div class="no-data" style="text-align: center;">{translate key=None}</div>
         {/if}
 
@@ -106,13 +104,12 @@
                         </div>
                     </div>
                     <div class="clearfix"></div>
-                    {foreachelse}
-                    <div class="no-data">{translate key=None}</div>
                 {/foreach}
             {/if}
         {/foreach}
-        {if empty($availability)}
-            <div class="no-data" style="text-align: center;">{translate key=None}</div>
+        
+        {if empty($UnavailableAllDay)}
+            <div class="no-data" style="text-align:center;">{translate key=None}</div>
         {/if}
     </div>
 </div>

--- a/tpl/Schedule/schedule-week-condensed.tpl
+++ b/tpl/Schedule/schedule-week-condensed.tpl
@@ -124,7 +124,7 @@
                                 data-start="{$date->Format('Y-m-d H:i:s')|escape:url}"
                                 data-end="{$date->Format('Y-m-d H:i:s')|escape:url}">
 
-                                {assign var=addButton value=$TodaysDate->LessThanOrEqual($date) || $TodaysDate->DateEquals($date) || $ViewPastReservationsButton}
+                                {assign var=addButton value=$TodaysDate->LessThanOrEqual($date) || $TodaysDate->DateEquals($date) || $AllowCreatePastReservationsButton}
                                 {if $addButton}
                                     <div class="reservable clickres" ref="{$href}&rd={formatdate date=$date key=url}"
                                         data-href="{$href}" data-start="{$date->Format('Y-m-d H:i:s')|escape:url}"


### PR DESCRIPTION
Implemented a new feature that checks for user resource permissions when they want to see a reservation (issue #46). If the user doesn't have permissions to a resource, all reservation details will be hidden to him (including the schedule label and pop-up), except if he his invited, a guest or the owner of the reservation. If a reservation includes multiple resources then the user must have permissions to at least one of them to check the details. The feature takes into account both user and group permissions. If the user or group of the user doesn't have permissions to a resource but is a resource admin or schedule admin in charge of it, it will be able to see the details.

This feature is basically a more specific implementation of the hide.user.details / hide.reservation.details in the config file but instead of hiding all reservations for all users indiscriminately, it checks the logged in user and its respective resource permissions.

This feature comes with the all the translations for the existing languages, but they should be checked by native speakers.
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Also, refactored some of the code of my previous pull requests for better presentation and performance and fixed some minor errors.