### PR TITLE
User Resource and Schedule Views

### DIFF
--- a/Domain/Access/IResourceRepository.php
+++ b/Domain/Access/IResourceRepository.php
@@ -60,6 +60,17 @@ interface IResourceRepository
     public function GetList($pageNumber, $pageSize, $sortField = null, $sortDirection = null, $filter = null);
 
     /**
+     * @param array $resourceIds
+     * @param int $pageNumber
+     * @param int $pageSize
+     * @param string|null $sortField
+     * @param string|null $sortDirection
+     * @param ISqlFilter $filter
+     * @return PageableData|BookableResource[]
+     */
+    public function GetUserList($resourceIds,$pageNumber, $pageSize, $sortField = null, $sortDirection = null, $filter = null);
+
+    /**
      * @param null|string $sortField
      * @param null|string $sortDirection
      * @return AccessoryDto[]|array all accessories

--- a/Domain/Access/ResourceRepository.php
+++ b/Domain/Access/ResourceRepository.php
@@ -93,6 +93,18 @@ class ResourceRepository implements IResourceRepository
         return PageableDataStore::GetList($command, $builder, $pageNumber, $pageSize);
     }
 
+    public function GetUserList($resourceIds, $pageNumber, $pageSize, $sortField = null, $sortDirection = null, $filter = null)
+    {
+        $command = new GetUserResourcesCommand($resourceIds);
+
+        if ($filter != null) {
+            $command = new FilterCommand($command, $filter);
+        }
+
+        $builder = ['BookableResource', 'Create'];
+        return PageableDataStore::GetList($command, $builder, $pageNumber, $pageSize);
+    }
+
     /**
      * @param int $resourceId
      * @return BookableResource

--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -71,6 +71,13 @@ abstract class Page implements IPage
         $this->smarty->assign('CanViewResponsibilities', !$userSession->IsAdmin && ($userSession->IsGroupAdmin || $userSession->IsResourceAdmin || $userSession->IsScheduleAdmin));
         $allowAllUsersToReports = Configuration::Instance()->GetSectionKey(ConfigSection::REPORTS, ConfigKeys::REPORTS_ALLOW_ALL, new BooleanConverter());
         $this->smarty->assign('CanViewReports', ($allowAllUsersToReports || $userSession->IsAdmin || $userSession->IsGroupAdmin || $userSession->IsResourceAdmin || $userSession->IsScheduleAdmin));
+
+        /*
+        VIEW ROLES (RESOURCES E SCHEDULES)
+        $this->smarty->assign('CanViewResources', (bla bla bla));
+        $this->smarty->assign('CanViewSchedules', (bla bla bla));
+        */
+
         $timeout = Configuration::Instance()->GetKey(ConfigKeys::INACTIVITY_TIMEOUT);
         if (!empty($timeout)) {
             $this->smarty->assign('SessionTimeoutSeconds', max($timeout, 1) * 60);

--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -72,12 +72,6 @@ abstract class Page implements IPage
         $allowAllUsersToReports = Configuration::Instance()->GetSectionKey(ConfigSection::REPORTS, ConfigKeys::REPORTS_ALLOW_ALL, new BooleanConverter());
         $this->smarty->assign('CanViewReports', ($allowAllUsersToReports || $userSession->IsAdmin || $userSession->IsGroupAdmin || $userSession->IsResourceAdmin || $userSession->IsScheduleAdmin));
 
-        /*
-        VIEW ROLES (RESOURCES E SCHEDULES)
-        $this->smarty->assign('CanViewResources', (bla bla bla));
-        $this->smarty->assign('CanViewSchedules', (bla bla bla));
-        */
-
         $timeout = Configuration::Instance()->GetKey(ConfigKeys::INACTIVITY_TIMEOUT);
         if (!empty($timeout)) {
             $this->smarty->assign('SessionTimeoutSeconds', max($timeout, 1) * 60);

--- a/Pages/ResourceViewerViewResourcesPage.php
+++ b/Pages/ResourceViewerViewResourcesPage.php
@@ -1,0 +1,129 @@
+<?php
+
+require_once(ROOT_DIR . 'Presenters/ViewResourcesPresenter.php');
+require_once(ROOT_DIR . 'Pages/Admin/ManageResourcesPage.php');     //AttributeService
+
+class ResourceViewerViewResourcesPage extends Page implements IPageable
+{
+    private $presenter;
+    protected $pageablePage;
+
+    public function __construct()
+    {
+        parent::__construct('CheckResources');
+        $this->presenter = new ViewResourcesPresenter($this,new ResourceRepository(), new ScheduleRepository(), new GroupRepository(), new AttributeService(new AttributeRepository()));
+        $this->pageablePage = new PageablePage($this);
+
+        $this->Set(
+            'YesNoOptions',
+            [
+                           '1' => Resources::GetInstance()->GetString('Yes'),
+                           '0' => Resources::GetInstance()->GetString('No')]
+        );
+    }
+
+    public function PageLoad(){
+        $this->presenter->PageLoad();
+        $this->Display(ROOT_DIR.'tpl/Admin/Resources/view_resources.tpl');
+    }
+
+    public function BindResources($resources){
+        $this->Set("Resources",$resources);
+    }
+
+    public function BindSchedule($scheduleNames){
+        $this->Set("Schedules",$scheduleNames);
+    }
+
+    public function BindResourceAdminGroup($resourceAdminGroupNames){
+        $this->Set("ResourceAdminGroup",$resourceAdminGroupNames);
+    }
+
+    public function BindResourceGroups($resourceGroupNames){
+        $this->Set("ResourceGroup",$resourceGroupNames);
+    }
+
+    public function BindResourceStatusReasons($resourceStatusReasons){
+        $this->Set("StatusReasons",$resourceStatusReasons);
+    }
+
+    public function BindResourceTypes($resourceTypes){
+        $this->Set("ResourceTypes",$resourceTypes);
+    }
+
+    public function BindResourcePermissionTypes($resourcePermissionTypes){
+        $this->Set("ResourcePermissionTypes",$resourcePermissionTypes);
+    }
+
+    public function AllSchedules($schedules)
+    {
+        $this->Set('AllSchedules', $schedules);
+    }
+
+    public function BindAttributeFilters($attributeFilters)
+    {
+        $this->Set('AttributeFilters', $attributeFilters);
+    }
+
+    /**
+     * @param PageInfo $pageInfo
+     * @return void
+     */
+    public function BindPageInfo(PageInfo $pageInfo)
+    {
+        $this->pageablePage->BindPageInfo($pageInfo);
+    }
+
+        /**
+     * @return int
+     */
+    public function GetPageNumber()
+    {
+        return $this->pageablePage->GetPageNumber();
+    }
+
+    /**
+     * @return int
+     */
+    public function GetPageSize()
+    {
+        $pageSize = $this->pageablePage->GetPageSize();
+
+        if ($pageSize > 10) {
+            return 10;
+        }
+        return $pageSize;
+    }
+    
+
+    public function SetFilterValues($values)
+    {
+        $this->Set('ResourceNameFilter', $values->ResourceNameFilter);
+        $this->Set('ScheduleIdFilter', $values->ScheduleIdFilter);
+        $this->Set('ResourceTypeFilter', $values->ResourceTypeFilter);
+        $this->Set('ResourceStatusFilterId', $values->ResourceStatusFilterId == '' ? '' : intval($values->ResourceStatusFilterId));
+        $this->Set('ResourceStatusReasonFilterId', $values->ResourceStatusReasonFilterId == '' ? '' : intval($values->ResourceStatusReasonFilterId));
+        $this->Set('CapacityFilter', $values->CapacityFilter);
+        $this->Set('RequiresApprovalFilter', $values->RequiresApprovalFilter);
+        $this->Set('AutoPermissionFilter', $values->AutoPermissionFilter);
+        $this->Set('AllowMultiDayFilter', $values->AllowMultiDayFilter);
+    }
+
+    public function GetFilterValues()
+    {
+        $filterValues = new ResourceFilterValues();
+
+        $filterValues->ResourceNameFilter = $this->GetQuerystring(FormKeys::RESOURCE_NAME);
+        $filterValues->ScheduleIdFilter = $this->GetQuerystring(FormKeys::SCHEDULE_ID);
+        $filterValues->ResourceTypeFilter = $this->GetQuerystring(FormKeys::RESOURCE_TYPE_ID);
+        $filterValues->ResourceStatusFilterId = $this->GetQuerystring(FormKeys::RESOURCE_STATUS_ID);
+        $filterValues->ResourceStatusReasonFilterId = $this->GetQuerystring(FormKeys::RESOURCE_STATUS_REASON_ID);
+        $filterValues->CapacityFilter = $this->GetQuerystring(FormKeys::MAX_PARTICIPANTS);
+        $filterValues->RequiresApprovalFilter = $this->GetQuerystring(FormKeys::REQUIRES_APPROVAL);
+        $filterValues->AutoPermissionFilter = $this->GetQuerystring(FormKeys::AUTO_ASSIGN);
+        $filterValues->AllowMultiDayFilter = $this->GetQuerystring(FormKeys::ALLOW_MULTIDAY);
+        $filterValues->SetAttributes(AttributeFormParser::GetAttributes($this->GetQuerystring(FormKeys::ATTRIBUTE_PREFIX)));
+
+        return $filterValues;
+    }
+}

--- a/Pages/ScheduleViewerViewSchedulesPage.php
+++ b/Pages/ScheduleViewerViewSchedulesPage.php
@@ -1,0 +1,103 @@
+<?php
+
+require_once(ROOT_DIR . 'Pages/IPageable.php');
+require_once(ROOT_DIR . 'Presenters/ViewSchedulesPresenter.php');
+require_once(ROOT_DIR . 'Presenters/Admin/ManageSchedulesPresenter.php'); //ManageScheduleService
+
+class ScheduleViewerViewSchedulesPage extends Page implements IPageable
+{
+    /**
+     * @var ViewSchedulesPresenter
+     */
+    protected $presenter;
+
+    protected $pageablePage;
+
+    public function __construct()
+    {
+        parent::__construct('CheckSchedules');
+        $resourceRepository = new ResourceRepository();
+        
+        $this->presenter = new ViewSchedulesPresenter(
+            $this, 
+            $resourceRepository, 
+            new ManageScheduleService(new ScheduleRepository(), $resourceRepository),
+            new GroupRepository());
+
+        $this->pageablePage = new PageablePage($this);
+    }
+
+    public function PageLoad()
+    {
+        $this->presenter->PageLoad();
+
+        $resources = Resources::GetInstance();
+        $this->Set('DayNames', $resources->GetDays('full'));
+        $this->Set('Today', Resources::GetInstance()->GetString('Today'));
+        $this->Set('Months', Resources::GetInstance()->GetMonths('full'));
+        $this->Set('StyleNames', [
+                ScheduleStyle::Standard => $resources->GetString('Standard'),
+                ScheduleStyle::Wide => $resources->GetString('Wide'),
+                ScheduleStyle::Tall => $resources->GetString('Tall'),
+                ScheduleStyle::CondensedWeek => $resources->GetString('Week'),
+        ]);
+
+        $this->Display(ROOT_DIR.'tpl/Admin/Schedules/view_schedules.tpl');
+    }
+
+    public function BindSchedules($schedules, $layouts, $sourceSchedules)
+    {
+        $this->Set('Schedules', $schedules);
+        $this->Set('Layouts', $layouts);
+        $this->Set('SourceSchedules', $sourceSchedules);
+    }
+
+    public function BindResources($resources)
+    {
+        $this->Set('Resources', $resources);
+    }
+
+
+    /**
+     * @param GroupItemView[] $groups
+     */
+    public function BindGroups($groups)
+    {
+        $this->Set('AdminGroups', $groups);
+        $groupLookup = [];
+        foreach ($groups as $group) {
+            $groupLookup[$group->Id] = $group;
+        }
+        $this->Set('GroupLookup', $groupLookup);
+    }
+
+    /**
+     * @return int
+     */
+    public function GetPageNumber()
+    {
+        return $this->pageablePage->GetPageNumber();
+    }
+
+    /**
+     * @return int
+     */
+    public function GetPageSize()
+    {
+        $pageSize = $this->pageablePage->GetPageSize();
+
+        if ($pageSize > 10) {
+            return 10;
+        }
+        return $pageSize;
+    }
+
+    /**
+     * @param PageInfo $pageInfo
+     * @return void
+     */
+    public function BindPageInfo(PageInfo $pageInfo)
+    {
+        $this->pageablePage->BindPageInfo($pageInfo);
+    }
+}

--- a/Presenters/ViewResourcesPresenter.php
+++ b/Presenters/ViewResourcesPresenter.php
@@ -1,0 +1,197 @@
+<?php
+
+class ViewResourcesPresenter{
+    
+    /**
+     * @var ResourceViewerViewResourcesPage;
+     */
+    private $page;
+
+    /**
+     * @var IResourceRepository;
+     */
+    private $resourceRepo;
+
+    /**
+     * @var IScheduleRepository;
+     */
+    private $scheduleRepo;
+
+    /**
+     * @var IGroupRepository;
+     */
+    private $groupRepo;
+
+    /**
+    * @var IAttributeService
+    */
+    private $attributeService;
+
+    /**
+     * @var int;
+     */
+    private $userId;
+
+    public function __construct(
+        ResourceViewerViewResourcesPage $page,
+        IResourceRepository $resourceRepo,
+        IScheduleRepository $scheduleRepo,
+        IGroupRepository $groupRepo,
+        IAttributeService $attributeService,
+        )
+    {
+    
+       $this->page = $page;
+       $this->resourceRepo = $resourceRepo;
+       $this->scheduleRepo = $scheduleRepo;
+       $this->groupRepo = $groupRepo;
+       $this->attributeService = $attributeService;
+
+       $this->userId = ServiceLocator::GetServer()->GetUserSession()->UserId;
+    }
+
+    public function PageLoad(){
+        $resources = $this->GetUserResources();
+        $resourceAttributes = $this->attributeService->GetByCategory(CustomAttributeCategory::RESOURCE);
+
+        $this->page->BindSchedule($this->GetSchedules());
+        $this->page->BindResourceAdminGroup($this->GetResourceAdminGroup());
+        $this->page->BindResourceGroups($this->GetResourceGroup());
+        $this->page->BindResourceStatusReasons($this->GetResourceStatusReasons());
+        $this->page->BindResourceTypes($this->GetResourceTypes());
+        $this->page->BindResourcePermissionTypes($this->GetUserResourcePermissionTypes());
+
+        $this->page->AllSchedules($this->scheduleRepo->GetAll());
+
+        $this->page->BindAttributeFilters($resourceAttributes);
+
+        $filterValues = $this->page->GetFilterValues();
+
+        foreach($resources as $resource){
+            $resourceIds[] = $resource->GetId();
+        }
+
+        $results = $this->resourceRepo->GetUserList(
+            $resourceIds,
+            $this->page->GetPageNumber(),
+            $this->page->GetPageSize(),
+            null,
+            null,
+            $filterValues->AsFilter($resourceAttributes)
+        );
+        $resources = $results->Results();
+
+        $this->page->BindResources($resources);
+        $this->page->BindPageInfo($results->PageInfo());
+    }
+
+    private function GetUserResources(){
+        $resources = [];
+
+        $resourceIds = [];
+
+        $resourceIds = $this->resourceRepo->GetUserResourcePermissions($this->userId);
+
+        $resourceIds = $this->resourceRepo->GetUserGroupResourcePermissions($this->userId,$resourceIds);
+
+        foreach($resourceIds as $resourceId){
+            $resource = $this->resourceRepo->LoadById($resourceId);
+            if($resource->GetStatusId() != 0){
+                $resources[$resourceId] = $resource;
+            }
+        }
+
+        return $resources;
+    }
+
+    private function GetSchedules(){
+        $scheduleNames = [];
+        $schedules = $this->scheduleRepo->GetAll();
+        foreach($schedules as $schedule){
+            $scheduleNames[$schedule->GetId()] = $schedule;
+        }
+        return $scheduleNames;
+    }
+
+    private function GetResourceAdminGroup(){
+        $resourceAdminGroupNames = [];
+
+        $resourceAdminGroups = $this->groupRepo->GetGroupsByRole(3); //RESOURCE ADMINS
+
+        foreach($resourceAdminGroups as $resourceAdminGroup){
+            $resourceAdminGroupNames[$resourceAdminGroup->Id] = $resourceAdminGroup;
+        }
+
+        return $resourceAdminGroupNames;    
+    }
+
+    private function GetResourceGroup(){
+        $resourceGroupNames = [];
+        
+        $resourceGroups = $this->resourceRepo->GetResourceGroupsList();
+
+        foreach($resourceGroups as $resourceGroup){
+            $resourceGroupNames[$resourceGroup->id] = $resourceGroup;
+        }
+
+        return $resourceGroupNames;    
+    }
+
+    private function GetResourceStatusReasons(){
+        $resourceStatusReasons = [];
+
+        $resourceStatusReasonsList = $this->resourceRepo->GetStatusReasons();
+
+        foreach($resourceStatusReasonsList as $resourceStatusReason){
+            $resourceStatusReasons[$resourceStatusReason->Id()] = $resourceStatusReason;
+        }
+
+        return $resourceStatusReasons;  
+    }
+
+    private function GetResourceTypes(){
+        $resourceTypes = [];
+
+        $resourceTypesList = $this->resourceRepo->GetResourceTypes();
+
+        foreach($resourceTypesList as $resourceType){
+            $resourceTypes[$resourceType->Id()]  = $resourceType;
+        }
+
+        return $resourceTypes;
+    }
+
+    //To show user what type of permission he has to the resource (view only or full access)
+    private function GetUserResourcePermissionTypes(){
+        //USER
+        $resourcePermissionTypes = [];
+
+        $command = new GetUserPermissionsCommand($this->userId);
+        $reader = ServiceLocator::GetDatabase()->Query($command);
+        
+        while ($row = $reader->GetRow()) {
+                $resourcePermissionTypes[$row[ColumnNames::RESOURCE_ID]] = $row[ColumnNames::PERMISSION_TYPE];
+                $resourcePermissionTypes[$row[ColumnNames::RESOURCE_ID]] = $row[ColumnNames::PERMISSION_TYPE];
+        }
+            
+        $reader->Free();
+
+        //USER GROUPS
+        $command = new SelectUserGroupPermissions($this->userId);
+        $reader = ServiceLocator::GetDatabase()->Query($command);
+
+        while ($row = $reader->GetRow()) {
+            $resourceId = $row[ColumnNames::RESOURCE_ID];
+            $permissionType = $row[ColumnNames::PERMISSION_TYPE];
+
+            if (!array_key_exists($resourceId,$resourcePermissionTypes)){
+                $resourceId = $permissionType;
+            }
+            else if (array_key_exists($resourceId,$resourcePermissionTypes) && $resourcePermissionTypes[$resourceId] == 1 &&  $permissionType == 0){
+                $resourcePermissionTypes[$resourceId] = $permissionType;
+            }
+        }
+
+        return $resourcePermissionTypes;
+    }
+}

--- a/Presenters/ViewSchedulesPresenter.php
+++ b/Presenters/ViewSchedulesPresenter.php
@@ -1,0 +1,75 @@
+<?php
+
+require_once(ROOT_DIR . 'config/timezones.php');        //NEEDED?
+
+class ViewSchedulesPresenter
+{
+    /**
+     * @var ResourceViewerViewResourcesPage;
+     */
+    private $page;
+
+    /**
+     * @var IResourceRepository;
+     */
+    private $resourceRepo;
+
+    /**
+     * @var ManageScheduleService
+     */
+    private $manageSchedulesService;
+
+    /**
+     * @var IGroupViewRepository
+     */
+    private $groupViewRepository;
+
+    public function __construct(
+        ScheduleViewerViewSchedulesPage $page,
+        ResourceRepository $resourceRepo,
+        ManageScheduleService $manageSchedulesService,
+        IGroupViewRepository $groupViewRepository
+    ) {
+        $this->page = $page;
+        $this->resourceRepo = $resourceRepo;
+        $this->manageSchedulesService = $manageSchedulesService;
+        $this->groupViewRepository = $groupViewRepository;
+    }
+
+    public function PageLoad()
+    {
+        $results = $this->manageSchedulesService->GetList($this->page->GetPageNumber(), $this->page->GetPageSize());
+        $schedules = $results->Results();
+
+        $sourceSchedules = $this->manageSchedulesService->GetSourceSchedules();
+
+        $layouts = [];
+        foreach ($schedules as $schedule) {
+            $layout = $this->manageSchedulesService->GetLayout($schedule);
+            $layouts[$schedule->GetId()] = $layout;
+        }
+
+        $this->page->BindResources($this->GetResources());
+        $this->page->BindSchedules($schedules, $layouts, $sourceSchedules);
+        $this->page->BindGroups($this->groupViewRepository->GetGroupsByRole(RoleLevel::SCHEDULE_ADMIN));
+        $this->page->BindPageInfo($results->PageInfo());
+    }
+
+    /**
+     * @return BookableResource[] resources indexed by scheduleId
+     */
+    public function GetResources()
+    {
+        $resources = [];
+
+        $all = $this->resourceRepo->GetResourceList();
+        /** @var BookableResource $resource */
+        foreach ($all as $resource) {
+            if($resource->GetStatusId() != 0){
+                $resources[$resource->GetScheduleId()][] = $resource;
+            }
+        }
+
+        return $resources;
+    }
+}

--- a/Web/view_resources.php
+++ b/Web/view_resources.php
@@ -1,0 +1,8 @@
+<?php
+
+define('ROOT_DIR', '../');
+
+require_once(ROOT_DIR . 'Pages/ResourceViewerViewResourcesPage.php');
+
+$page = new ResourceViewerViewResourcesPage(new SmartyPage());
+$page->PageLoad();

--- a/Web/view_schedules.php
+++ b/Web/view_schedules.php
@@ -1,0 +1,9 @@
+<?php
+
+define('ROOT_DIR', '../');
+
+require_once(ROOT_DIR . 'Pages/ScheduleViewerViewSchedulesPage.php');
+require_once(ROOT_DIR . 'Presenters/Admin/ManageSchedulesPresenter.php');
+
+$page = new ScheduleViewerViewSchedulesPage(new SmartyPage());
+$page->PageLoad();

--- a/Web/view_schedules.php
+++ b/Web/view_schedules.php
@@ -3,7 +3,6 @@
 define('ROOT_DIR', '../');
 
 require_once(ROOT_DIR . 'Pages/ScheduleViewerViewSchedulesPage.php');
-require_once(ROOT_DIR . 'Presenters/Admin/ManageSchedulesPresenter.php');
 
 $page = new ScheduleViewerViewSchedulesPage(new SmartyPage());
 $page->PageLoad();

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -952,6 +952,8 @@ class en_us extends Language
         $strings['ViewCalendar'] = 'View Calendar';
         $strings['DataCleanup'] = 'Data Cleanup';
         $strings['ManageEmailTemplates'] = 'Manage Email Templates';
+        $strings['CheckResources'] = 'Check Resources';
+        $strings['CheckSchedules'] = 'Check Schedules';
         // End Page Titles
 
         // Day representations
@@ -1052,6 +1054,12 @@ class en_us extends Language
         //Schedule Resource Permissions
         $strings['NoResourcePermissions'] = 'Can\'t see reservation details because you don\'t have permissions to any of the resources in this reservation';
         //End Schedule Resource Permissions
+
+        //View Resource
+        $strings['Check'] = 'Check';
+        $strings['PermissionType'] = 'Permission Type';
+        $strings['NoResourcesToView'] = 'No available resources';
+        //End View Resource
 
         $this->Strings = $strings;
 

--- a/lang/pt_pt.php
+++ b/lang/pt_pt.php
@@ -200,6 +200,8 @@ class pt_pt extends en_gb
         $strings['CheckingIn'] = 'Efetuando o check-in';
         $strings['CheckingOut'] = 'Efetuando o check-out';
         $strings['Checkout'] = 'Check-out';
+        $strings['CheckResources'] = 'Consultar Recursos';
+        $strings['CheckSchedules'] = 'Consultar Horários';
         $strings['Choose'] = 'Escolher';
         $strings['ChooseOrDropFile'] = 'Escolha um ficheiro ou arraste-o para aqui';
         $strings['ClearFilter'] = 'Limpar filtro';
@@ -1027,6 +1029,12 @@ class pt_pt extends en_gb
         //Schedule Resource Permissions
         $strings['NoResourcePermissions'] = 'Não é possível ver os detalhes da reserva uma vez que não tem permissões para um ou mais recursos nesta reserva';
         //End Schedule Resource Permissions
+
+        //View Resource
+        $strings['Check'] = 'Consultar';
+        $strings['PermissionType'] = 'Tipo de Permissão';
+        $strings['NoResourcesToView'] = 'Sem recursos disponíveis';
+        //End View Resource
 
         $this->Strings = $strings;
 

--- a/lib/Database/Commands/Commands.php
+++ b/lib/Database/Commands/Commands.php
@@ -1438,6 +1438,15 @@ class GetAllResourcesCommand extends SqlCommand
     }
 }
 
+class GetUserResourcesCommand extends SqlCommand
+{
+    public function __construct($resourceIds)
+    {
+        parent::__construct(Queries::GET_USER_RESOURCES);
+        $this->AddParameter(new Parameter(ParameterNames::RESOURCE_IDS, $resourceIds));
+    }
+}
+
 class GetAllResourceGroupsCommand extends SqlCommand
 {
     public function __construct()

--- a/lib/Database/Commands/Queries.php
+++ b/lib/Database/Commands/Queries.php
@@ -428,6 +428,17 @@ class Queries
 		INNER JOIN `schedules` as `s` ON `r`.`schedule_id` = `s`.`schedule_id`
 		ORDER BY COALESCE(`r`.`sort_order`,0), `r`.`name`';
 
+	public const GET_USER_RESOURCES =
+		'SELECT `r`.*, `s`.`admin_group_id` as `s_admin_group_id`,
+		(SELECT GROUP_CONCAT(CONCAT(`cav`.`custom_attribute_id`, \'=\', `cav`.`attribute_value`) SEPARATOR "!sep!")
+						FROM `custom_attribute_values` `cav` WHERE `cav`.`entity_id` = `r`.`resource_id` AND `cav`.`attribute_category` = 4) as `attribute_list`,
+		(SELECT GROUP_CONCAT(`rga`.`resource_group_id` SEPARATOR "!sep!") FROM `resource_group_assignment` `rga` WHERE `rga`.`resource_id` = `r`.`resource_id`) AS `group_list`,
+		(SELECT GROUP_CONCAT(`ri`.`image_name` SEPARATOR "!sep!") FROM `resource_images` `ri` WHERE `ri`.`resource_id` = `r`.`resource_id`) AS `image_list`
+		FROM `resources` as `r`
+		INNER JOIN `schedules` as `s` ON `r`.`schedule_id` = `s`.`schedule_id`
+		WHERE resource_id IN (@resourceids)
+		ORDER BY COALESCE(`r`.`sort_order`,0), `r`.`name`';
+
     public const GET_ALL_RESOURCE_GROUPS = 'SELECT * FROM `resource_groups` ORDER BY `parent_id`, `resource_group_name`';
 
     public const GET_ALL_RESOURCE_GROUP_ASSIGNMENTS = 'SELECT `r`.*, `a`.`resource_group_id`

--- a/tpl/Admin/Resources/view_resources.tpl
+++ b/tpl/Admin/Resources/view_resources.tpl
@@ -1,0 +1,362 @@
+{include file='globalheader.tpl' InlineEdit=true Owl=true}
+
+<div id="page-manage-resources" class="admin-page">
+	<div>
+		<h1>{translate key='Resources'}</h1>
+	</div>
+
+    <div class="panel panel-default filterTable" id="filter-resources-panel">
+		<form id="filterForm" class="horizontal-list" role="form" method="get">
+			<div class="panel-heading"><span
+						class="glyphicon glyphicon-filter"></span> {translate key="Filter"} {showhide_icon}
+			</div>
+			<div class="panel-body">
+
+                {assign var=groupClass value="col-xs-12 col-sm-4 col-md-3"}
+
+				<div class="form-group {$groupClass}">
+					<label for="filterResourceName" class="no-show">{translate key=Resource}</label>
+					<input type="text" id="filterResourceName" class="form-control" {formname key=RESOURCE_NAME}
+						   value="{$ResourceNameFilter}" placeholder="{translate key=Name}"/>
+					<span class="searchclear glyphicon glyphicon-remove-circle" ref="filterResourceName"></span>
+				</div>
+				<div class="form-group {$groupClass}">
+					<label for="filterScheduleId" class="no-show">{translate key=Schedule}</label>
+					<select id="filterScheduleId" {formname key=SCHEDULE_ID} class="form-control">
+						<option value="">{translate key=AllSchedules}</option>
+                        {object_html_options options=$AllSchedules key='GetId' label="GetName" selected=$ScheduleIdFilter}
+					</select>
+				</div>
+
+				<div class="form-group {$groupClass}">
+					<label for="filterResourceType" class="no-show">{translate key=ResourceType}</label>
+					<select id="filterResourceType" class="form-control" {formname key=RESOURCE_TYPE_ID}>
+						<option value="">{translate key=AllResourceTypes}</option>
+                        {object_html_options options=$ResourceTypes key='Id' label="Name" selected=$ResourceTypeFilter}
+					</select>
+				</div>
+				<div class="form-group {$groupClass}">
+					<label for="resourceStatusIdFilter" class="no-show">{translate key=ResourceStatus}</label>
+					<select id="resourceStatusIdFilter" style="width:auto;" class="form-control inline" {formname key=RESOURCE_STATUS_ID}>
+						<option value="">{translate key=AllResourceStatuses}</option>
+						<option value="{ResourceStatus::AVAILABLE}">{translate key=Available}</option>
+						<option value="{ResourceStatus::UNAVAILABLE}">{translate key=Unavailable}</option>
+					</select>
+                    {*  NOT WORKING
+					<label for="resourceReasonIdFilter" class="no-show">{translate key=Reason}</label>
+					<select id="resourceReasonIdFilter" style="width:auto;" class="form-control inline" {formname key=RESOURCE_STATUS_REASON_ID}>
+						<option value="">-</option>
+					</select>
+                    *}
+				</div>
+				<div class="form-group {$groupClass}">
+					<label for="filterCapacity" class="no-show">{translate key=MinimumCapacity}</label>
+					<input type="number" min="0" id="filterCapacity" class="form-control" {formname key=MAX_PARTICIPANTS}
+						   value="{$CapacityFilter}" placeholder="{translate key=MinimumCapacity}"/>
+					<span class="searchclear glyphicon glyphicon-remove-circle" ref="filterCapacity"></span>
+				</div>
+				<div class="form-group {$groupClass}">
+					<label for="filterRequiresApproval" class="no-show">{translate key=ResourceRequiresApproval}</label>
+					<select id="filterRequiresApproval" class="form-control" {formname key=REQUIRES_APPROVAL}
+							title="{translate key='ResourceRequiresApproval'}">
+						<option value="">{translate key='ResourceRequiresApproval'}</option>
+                        {html_options options=$YesNoOptions selected=$RequiresApprovalFilter}
+					</select>
+				</div>
+				<div class="form-group {$groupClass}">
+					<label for="filterAutoAssign" class="no-show">{translate key=ResourcePermissionAutoGranted}</label>
+					<select id="filterAutoAssign" class="form-control" {formname key=AUTO_ASSIGN} title="{translate key='ResourcePermissionAutoGranted'}">
+						<option value="">{translate key='ResourcePermissionAutoGranted'}</option>
+                        {html_options options=$YesNoOptions selected=$AutoPermissionFilter}
+					</select>
+				</div>
+				<div class="form-group {$groupClass}">
+					<label for="filterAllowMultiDay" class="no-show">{translate key=ResourceAllowMultiDay}</label>
+					<select id="filterAllowMultiDay" class="form-control" {formname key=ALLOW_MULTIDAY} title="{translate key=ResourceAllowMultiDay}">
+						<option value="">{translate key=ResourceAllowMultiDay}</option>
+                        {html_options options=$YesNoOptions selected=$AllowMultiDayFilter}
+					</select>
+				</div>
+				<div class="clearfix"></div>
+                {foreach from=$AttributeFilters item=attribute}
+                    {control type="AttributeControl" idPrefix="search" attribute=$attribute searchmode=true class="customAttribute filter-customAttribute{$attribute->Id()} {$groupClass}"}
+                {/foreach}
+
+			</div>
+			<div class="panel-footer">
+                {filter_button id="filter" class="btn-sm"}
+                {reset_button id="clearFilter" class="btn-sm"}
+			</div>
+		</form>
+	</div>
+
+    {pagination pageInfo=$PageInfo showCount=true}
+
+	<div id="globalError" class="error no-show"></div>
+
+    {if !empty($Resources)}
+        <div class="panel panel-default admin-panel" id="list-resources-panel">
+            <div class="panel-body no-padding" id="resourceList" style="margin-top:20px">
+                {foreach from=$Resources item=resource}
+                    {assign var=id value=$resource->GetResourceId()}
+                    <div class="resourceDetails" data-resourceId="{$id}">
+                        <div class="col-xs-12 col-sm-5">
+                            <input type="hidden" class="id" value="{$id}"/>
+
+                            <div class="col-sm-3 col-xs-6 resourceImage">
+                                <div class="margin-bottom-25">
+                                    {if $resource->HasImage()}
+                                        <div class="owl-carousel owl-theme">
+                                            <div class="item">
+                                                <img src="{resource_image image=$resource->GetImage()}" alt="Resource Image" class="image"/>
+                                            </div>
+                                            {foreach from=$resource->GetImages() item=image}
+                                                <div class="item">
+                                                    <img src="{resource_image image=$image}" alt="Resource Image" class="image"/>
+                                                </div>
+                                            {/foreach}
+                                        </div>
+                                        <br/>
+                                    {else}
+                                        <div class="noImage"><span class="fa fa-image"></span></div>
+                                    {/if}
+                                </div>
+                                <div>
+                                    {translate key=ResourceColor}
+                                    <input class="resourceColorPicker" type="color"
+                                        value='{if $resource->HasColor()}{$resource->GetColor()}{else}#ffffff{/if}'
+                                        alt="{translate key=ResourceColor}"
+                                        title="{translate key=ResourceColor}"/>
+                                </div>
+                            </div>
+
+                            <div class="col-sm-9 col-xs-6">
+                                <div>
+                                <span class="title resourceName" data-type="text" data-pk="{$id}"
+                                    data-name="{FormKeys::RESOURCE_NAME}">{$resource->GetName()}</span>
+                                </div>
+                                <div>
+                                    {translate key='Status'}
+                                    {if $resource->IsAvailable()}
+                                        {html_image src="status.png"}
+                                        <b>{translate key='Available'}</b>
+                                    {elseif $resource->IsUnavailable()}
+                                        {html_image src="status-away.png"}
+                                        <b>{translate key='Unavailable'}</b>
+                                    {else}
+                                        {html_image src="status-busy.png"}
+                                        <b>{translate key='Hidden'}</b>
+                                    {/if}
+
+                                    {if array_key_exists($resource->GetStatusReasonId(),$StatusReasons)}
+                                        <span class="statusReason">{$StatusReasons[$resource->GetStatusReasonId()]->Description()}</span>
+                                    {/if}
+                                </div>
+
+                                <div>
+                                    {translate key='Schedule'}
+                                    <span class="propertyValue scheduleName"
+                                        data-type="select" data-pk="{$id}" data-value="{$resource->GetScheduleId()}"
+                                        data-name="{FormKeys::SCHEDULE_ID}">{$Schedules[$resource->GetScheduleId()]->GetName()}</span>
+                                </div>
+
+                                <div>
+                                    {translate key='ResourceType'}
+                                    <span class="propertyValue resourceTypeName"
+                                        data-type="select" data-pk="{$id}" data-value="{$resource->GetResourceTypeId()}"
+                                        data-name="{FormKeys::RESOURCE_TYPE_ID}">
+                                        {if $resource->HasResourceType()}
+                                            {$ResourceTypes[$resource->GetResourceTypeId()]->Name()}
+                                        {else}
+                                            {translate key='NoResourceTypeLabel'}
+                                        {/if}
+                                    </span>
+                                </div>
+                                <div>
+                                    {translate key=SortOrder}
+                                    <span class="propertyValue sortOrderValue"
+                                        data-type="number" data-pk="{$id}" data-name="{FormKeys::RESOURCE_SORT_ORDER}">
+                                        {$resource->GetSortOrder()|default:"0"}
+                                    </span>
+                                </div>
+                                <div>
+                                    {translate key='Location'}
+                                    <span class="propertyValue locationValue"
+                                        data-type="text" data-pk="{$id}" data-value="{$resource->GetLocation()}"
+                                        data-name="{FormKeys::RESOURCE_LOCATION}">
+                                        {if $resource->HasLocation()}
+                                            {$resource->GetLocation()}
+                                        {else}
+                                            {translate key='NoLocationLabel'}
+                                        {/if}
+                                    </span>
+                                </div>
+                                <div>
+                                    {translate key='Contact'}
+                                    <span class="propertyValue contactValue"
+                                        data-type="text" data-pk="{$id}" data-value="{$resource->GetContact()}"
+                                        data-name="{FormKeys::RESOURCE_CONTACT}">
+                                        {if $resource->HasContact()}
+                                            {$resource->GetContact()}
+                                        {else}
+                                            {translate key='NoContactLabel'}
+                                        {/if}
+                                    </span>
+                                </div>
+                                <div>
+                                    {translate key='Description'}
+                                    {if $resource->HasDescription()}
+                                        {assign var=description value=$resource->GetDescription()}
+                                    {else}
+                                        {assign var=description value=''}
+                                    {/if}
+                                    {strip}
+                                        <div class="descriptionValue"
+                                            data-type="textarea" data-pk="{$id}" data-value="{$description|escape}"
+                                            data-name="{FormKeys::RESOURCE_DESCRIPTION}">
+                                            {if $resource->HasDescription()}
+                                                {$description}
+                                            {else}
+                                                {translate key='NoDescriptionLabel'}
+                                            {/if}
+                                        </div>
+                                    {/strip}
+                                </div>
+                                <div>
+                                    {translate key='Notes'}
+                                    {if $resource->HasNotes()}
+                                        {assign var=notes value=$resource->GetNotes()}
+                                    {else}
+                                        {assign var=notes value=''}
+                                    {/if}
+                                    {strip}
+                                        <div class="notesValue"
+                                            data-type="textarea" data-pk="{$id}" data-value="{$notes|escape}"
+                                            data-name="{FormKeys::RESOURCE_NOTES}">
+                                            {if $resource->HasNotes()}
+                                                {$notes}
+                                            {else}
+                                                {translate key='NoNotesLabel'}
+                                            {/if}
+                                        </div>
+                                    {/strip}
+                                </div>
+                                <div>
+                                    {translate key='ResourceAdministrator'}
+                                    <span class="propertyValue resourceAdminValue"
+                                        data-type="select" data-pk="{$id}" data-value="{$resource->GetAdminGroupId()}"
+                                        data-name="{FormKeys::RESOURCE_ADMIN_GROUP_ID}">{$ResourceAdminGroup[$resource->GetAdminGroupId()]->Name}</span>
+                                </div>
+                                
+                            </div>
+
+                        </div>
+
+
+                        <div class="col-xs-12 col-sm-7">
+                            <div class="col-sm-6 col-xs-12">
+                                <h5 class="inline">{translate key=Duration}</h5>
+
+                                <div class="durationPlaceHolder">
+                                    {include file="Admin/Resources/manage_resources_duration.tpl" resource=$resource}
+                                </div>
+
+                                {if $CreditsEnabled}
+                                    <div>
+                                        <h5 class="inline">{translate key='Credits'}</h5>
+
+                                        <div class="creditsPlaceHolder">
+                                            {include file="Admin/Resources/manage_resources_credits.tpl" resource=$resource}
+                                        </div>
+                                    </div>
+                                {/if}
+
+                                <div style="margin-top: 10px;">
+                                    <h5 class="inline">{translate key='Capacity'}</h5>
+
+                                    <div class="capacityPlaceHolder">
+                                        {include file="Admin/Resources/manage_resources_capacity.tpl" resource=$resource}
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="col-sm-6 col-xs-12">
+                                <h5 class="inline">{translate key=Access}</h5>
+
+                                <div class="accessPlaceHolder">
+                                    {include file="Admin/Resources/manage_resources_access.tpl" resource=$resource}
+                                </div>
+                            </div>
+
+                            <div class="col-sm-6 col-xs-12">
+                                <h5 class="inline">{translate key='PermissionType'}</h5>
+                                <div class="resourcePermissionTypePlaceHolder">
+                                    {if $ResourcePermissionTypes[$resource->GetId()] == 0}
+                                        {translate key=FullAccess}
+                                    {else}
+                                        {translate key=ViewOnly}
+                                    {/if}
+                                </div>
+                            </div>
+
+
+                            <div class="col-sm-6 col-xs-12" style="margin-top:10px">
+                                <h5 class="inline">{translate key='ResourceGroups'}</h5>
+                                <div class="resourceGroupsPlaceHolder">
+                                    {if $resource->GetResourceGroupIds()|default:array()|count == 0}
+                                        {translate key=None}
+                                    {/if}
+                                    {foreach from=$resource->GetResourceGroupIds() item=resourceGroupId name=eachGroup}
+                                        <span class="resourceGroupId" data-value="{$resourceGroupId}">{$ResourceGroup[$resourceGroupId]->name}</span>{if !$smarty.foreach.eachGroup.last}, {/if}
+                                    {/foreach}
+                                </div>
+                                <div class="clearfix">&nbsp;</div>
+                            </div>
+                            
+                            <div class="col-sm-6 col-xs-12">&nbsp;</div>
+                            
+
+                        </div>
+
+                        <div class="clearfix"></div>
+                        <div class="customAttributes">
+                            {if $AttributeList|default:array()|count > 0}
+                                {foreach from=$AttributeList item=attribute}
+                                    {include file='Admin/InlineAttributeEdit.tpl' id=$id attribute=$attribute value=$resource->GetAttributeValue($attribute->Id())}
+                                {/foreach}
+                            {/if}
+                        </div>
+                        <div class="clearfix"></div>
+                    </div>
+                {/foreach}
+            </div>
+        </div>
+    {else}
+		<h3 style="text-align:center">{translate key='NoResourcesToView'}</h3>
+    {/if}
+
+    {csrf_token}
+
+    {include file="javascript-includes.tpl" InlineEdit=true Owl=true Clear=true}
+    {jsfile src="ajax-helpers.js"}
+    {jsfile src="autocomplete.js"}
+    {jsfile src="js/tree.jquery.js"}
+    {jsfile src="admin/resource.js"}
+    {jsfile src="dropzone.js"}
+
+	<script type="text/javascript">
+
+		$(document).ready(function () {
+		    $('#filter-resources-panel').showHidePanel();
+
+			$(".owl-carousel").owlCarousel({
+				items: 1
+			});
+		});
+
+	</script>
+</div>
+
+{pagination pageInfo=$PageInfo showCount=true}
+
+{include file='globalfooter.tpl'}

--- a/tpl/Admin/Schedules/view_schedules.tpl
+++ b/tpl/Admin/Schedules/view_schedules.tpl
@@ -1,0 +1,176 @@
+{include file='globalheader.tpl' InlineEdit=true Fullcalendar=true Timepicker=true}
+
+<div id="page-manage-schedules" class="admin-page">
+
+	<h1>{translate key=ManageSchedules}</h1>
+
+	{pagination pageInfo=$PageInfo}
+
+	<div class="panel panel-default admin-panel" id="list-schedules-panel">
+		<div class="panel-body no-padding" id="scheduleList">
+            {foreach from=$Schedules item=schedule}
+                {assign var=id value=$schedule->GetId()}
+                {capture name=daysVisible}<span class='propertyValue daysVisible inlineUpdate' data-type='number'
+												data-pk='{$id}'
+												data-name='{FormKeys::SCHEDULE_DAYS_VISIBLE}'
+												data-min='0'>{$schedule->GetDaysVisible()}</span>{/capture}
+                {assign var=dayOfWeek value=$schedule->GetWeekdayStart()}
+                {capture name=dayName}<span class='propertyValue dayName inlineUpdate' data-type='select'
+											data-pk='{$id}'
+											data-name='{FormKeys::SCHEDULE_WEEKDAY_START}'
+											data-value='{$dayOfWeek}'>{if $dayOfWeek == Schedule::Today}{$Today}{else}{$DayNames[$dayOfWeek]}{/if}</span>{/capture}
+				<div class="scheduleDetails" data-schedule-id="{$id}">
+					<div class="col-xs-12 col-sm-6">
+						<input type="hidden" class="id" value="{$id}"/>
+						<input type="hidden" class="daysVisible" value="{$daysVisible}"/>
+						<input type="hidden" class="dayOfWeek" value="{$dayOfWeek}"/>
+
+						<div>
+					        <span class="title scheduleName" data-type="text" data-pk="{$id}"
+						        data-name="{FormKeys::SCHEDULE_NAME}">{$schedule->GetName()}</span>
+						</div>
+
+						<div>{translate key="LayoutDescription" args="{$smarty.capture.dayName}, {$smarty.capture.daysVisible}"}</div>
+
+						<div>{translate key='ScheduleAdministrator'}
+							<span class="propertyValue scheduleAdmin"
+								  data-type="select" data-pk="{$id}" data-value="{$schedule->GetAdminGroupId()}"
+								  data-name="{FormKeys::SCHEDULE_ADMIN_GROUP_ID}">{($GroupLookup[$schedule->GetAdminGroupId()]) ? $GroupLookup[$schedule->GetAdminGroupId()]->Name : 'None'}
+							</span>
+						</div>
+
+						<div>
+							<div class="availabilityPlaceHolder inline-block">
+                                {include file="Admin/Schedules/manage_availability.tpl" schedule=$schedule timezone=$Timezone}
+							</div>
+						</div>
+
+						<div class="maximumConcurrentContainer" data-concurrent="{$schedule->GetTotalConcurrentReservations()}">
+                            {if $schedule->EnforceConcurrentReservationMaximum()}
+                                {translate key=ScheduleConcurrentMaximum args=$schedule->GetTotalConcurrentReservations()}
+                            {else}
+                                {translate key=ScheduleConcurrentMaximumNone}
+                            {/if}
+						</div>
+
+						<div class="resourcesPerReservationContainer" data-maximum="{$schedule->GetMaxResourcesPerReservation()}">
+                            {if $schedule->EnforceMaxResourcesPerReservation()}
+                                {translate key=ScheduleResourcesPerReservationMaximum args=$schedule->GetMaxResourcesPerReservation()}
+                            {else}
+                                {translate key=ScheduleResourcesPerReservationNone}
+                            {/if}
+						</div>
+
+						<div>
+                            {translate key=DefaultStyle}
+							<span class="propertyValue defaultScheduleStyle inlineUpdate" data-type="select"
+								  data-pk="{$id}"
+								  data-name="{FormKeys::SCHEDULE_DEFAULT_STYLE}"
+								  data-value="{$schedule->GetDefaultStyle()}">{$StyleNames[$schedule->GetDefaultStyle()]}</span>
+						</div>
+
+                        {if $CreditsEnabled}
+							<span>{translate key=PeakTimes}</span>
+							<div class="peakPlaceHolder">
+                                {include file="Admin/Schedules/manage_peak_times.tpl" Layout=$Layouts[$id] Months=$Months DayNames=$DayNames}
+							</div>
+                        {/if}
+
+						<div>{translate key=Resources}
+							<span class="propertyValue">
+                            {if array_key_exists($id, $Resources)}
+                                {foreach from=$Resources[$id] item=r name=resources_loop}
+                                    {$r->GetName()|escape}{if !$smarty.foreach.resources_loop.last}, {/if}
+                                {/foreach}
+                            {else}
+                                {translate key=None}
+                            {/if}
+                            </span>
+						</div>
+
+                        {if $schedule->GetIsCalendarSubscriptionAllowed()}
+							<div>
+								<span>{translate key=PublicId}</span>
+								<span class="propertyValue">{$schedule->GetPublicId()}</span>
+							</div>
+                        {/if}
+
+					</div>
+
+					<div class="layout col-xs-12 col-sm-6">
+                        {function name="display_periods"}
+                            {foreach from=$Layouts[$id]->GetSlots($day) item=period name=layouts}
+                                {if $period->IsReservable() == $showReservable}
+                                    {$period->Start->Format("H:i")} - {$period->End->Format("H:i")}
+                                    {if $period->IsLabelled()}
+                                        {$period->Label}
+                                    {/if}
+                                    {if !$smarty.foreach.layouts.last}, {/if}
+                                {/if}
+                                {foreachelse}
+                                {translate key=None}
+                            {/foreach}
+                        {/function}
+
+						<div>
+                            {translate key=ScheduleLayout args=$schedule->GetTimezone()}
+						</div>
+						<input type="hidden" class="timezone" value="{$schedule->GetTimezone()}"/>
+
+                        {if $Layouts[$id]->UsesDailyLayouts()}
+							<input type="hidden" class="usesDailyLayouts" value="true"/>
+                            {translate key=LayoutVariesByDay} -
+							<div class="allDailyLayouts">
+                                {foreach from=DayOfWeek::Days() item=day}
+                                    {$DayNames[$day]}
+									<div class="reservableSlots" id="reservableSlots_{$day}"
+										 ref="reservableEdit_{$day}">
+                                        {display_periods showReservable=true day=$day}
+									</div>
+									<div class="blockedSlots" id="blockedSlots_{$day}" ref="blockedEdit_{$day}">
+                                        {display_periods showReservable=false day=$day}
+									</div>
+                                {/foreach}
+							</div>
+							<div class="margin-top-25"><strong>{translate key=ThisScheduleUsesAStandardLayout}</strong>
+							</div>
+                        {elseif $Layouts[$id]->UsesCustomLayout()}
+							<div><strong>{translate key=ThisScheduleUsesACustomLayout}</strong></div>
+                        {else}
+							<input type="hidden" class="usesDailyLayouts" value="false"/>
+                            {translate key=ReservableTimeSlots}
+							<div class="reservableSlots" id="reservableSlots" ref="reservableEdit">
+                                {display_periods showReservable=true day=null}
+							</div>
+                            {translate key=BlockedTimeSlots}
+							<div class="blockedSlots" id="blockedSlots" ref="blockedEdit">
+                                {display_periods showReservable=false day=null}
+							</div>
+							<div class="margin-top-25"><strong>{translate key=ThisScheduleUsesAStandardLayout}</strong>
+							</div>
+                        {/if}
+					</div>
+					<div class="actions col-xs-12">
+                        {if $schedule->GetIsDefault()}
+							<span class="note">{translate key=ThisIsTheDefaultSchedule}</span>
+                        {else}
+                            <span class="note">¯\_(ツ)_/¯</span>
+                        {/if}
+                        {indicator id="action-indicator"}
+						<div class="clear"></div>
+					</div>
+				</div>
+            {/foreach}
+		</div>
+	</div>
+
+    {pagination pageInfo=$PageInfo}
+
+    {csrf_token}
+    {include file="javascript-includes.tpl" InlineEdit=true Fullcalendar=true Timepicker=true}
+    {jsfile src="ajax-helpers.js"}
+    {jsfile src="admin/schedule.js"}
+    {jsfile src="js/jquery.form-3.09.min.js"}
+</div>
+
+{include file='globalfooter.tpl'}

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -171,6 +171,18 @@
                                 </li>
                             </ul>
                         </li>
+                        <li class="dropdown" id="navReportsDropdown">
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">{translate key="Check"}<b
+                                        class="caret"></b></a>
+                            <ul class="dropdown-menu">
+                                <li id="CheckResources">
+                                    <a href="{$Path}view_resources.php">{translate key=Resources}</a>
+                                </li>
+                                <li id="CheckSchedules">
+                                    <a href="{$Path}view_schedules.php">{translate key=Schedules}</a>
+                                </li>
+                            </ul>
+                        </li>
                         {if isset($CanViewAdmin) && $CanViewAdmin}
                             <li class="dropdown" id="navApplicationManagementDropdown">
                                 <a href="#" class="dropdown-toggle"


### PR DESCRIPTION
Added a new feature that enables users to check resources and schedules without requiring administrator privileges. This feature mirrors the capabilities of the manage resources and schedules functions, but doesn't allow edits and displays only those resources and schedules accessible to the user or groups they belong to, based on their permissions (view or full access). If a resource is hidden, it remains invisible to the user, even if they possess the necessary permissions (Issue #90).

This feature only has the English and Portuguese translations implemented.