### PR TITLE
Provide ScheduleId in reservation email

### DIFF
--- a/lib/Email/Messages/ReservationEmailMessage.php
+++ b/lib/Email/Messages/ReservationEmailMessage.php
@@ -95,6 +95,7 @@ abstract class ReservationEmailMessage extends EmailMessage
         $this->Set('UserName', $this->reservationOwner->FullName());
         $this->Set('StartDate', $currentInstance->StartDate()->ToTimezone($this->timezone));
         $this->Set('EndDate', $currentInstance->EndDate()->ToTimezone($this->timezone));
+        $this->Set('ScheduleId', $this->reservationSeries->ScheduleId());
         $this->Set('ResourceName', $this->reservationSeries->Resource()->GetName());
         $img = $this->reservationSeries->Resource()->GetImage();
         if (!empty($img)) {


### PR DESCRIPTION
Provide `ScheduleId` for reservation templates. So it's possible to add schedule dependent information in the email template.

```smarty
{if $ScheduleId == 18 }
    Important schedule information
{/if}
```