### PR TITLE
fix(api): API calls were broken due to abstract method

### DIFF
--- a/WebServices/SchedulesWebService.php
+++ b/WebServices/SchedulesWebService.php
@@ -524,6 +524,11 @@ class ScheduleWebServiceView implements ISchedulePage
         $this->available = false;
     }
 
+    public function BindViewableResourceReservations($resourceIds)
+    {
+        // no-op
+    }
+
     public function SetAllowConcurrent($allowConcurrentReservations)
     {
         $this->allowConcurrentReservations = $allowConcurrentReservations;


### PR DESCRIPTION
The class `ScheduleWebServiceView` had an abstract method `BindViewableResourceReservation` which was not implemented. This caused API access to fail with an error like:
```
[php:error] [pid 84] [client 10.89.0.25:59502] PHP Fatal error:  Class ScheduleWebServiceView contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (ISchedulePage::BindViewableResourceReservations) in /var/www/html/WebServices/SchedulesWebService.php on line 169
```

Implement the missing method as a `no-op` method.

Closes: #343