### PR TITLE
ci: create an initial CI that runs a syntax check

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -1,0 +1,91 @@
+name: Lint and analyse php files
+
+# If a pull-request is pushed then cancel all previously running jobs related
+# to that pull-request
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+on:
+  # push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  lint-php-files:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ["8.1"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      # TODO: Enable this after resolving issues
+      # - name: Validate composer.json and composer.lock
+      #   run: composer validate --strict
+
+      - name: Install Composer dependencies
+        # Allow the previous check to fail but not abort
+        if: always()
+        uses: ramsey/composer-install@v2
+        with:
+          # Ignore zip for php-webdriver/webdriver
+          composer-options: "--ignore-platform-req=ext-zip"
+
+      # TODO: Enable this after resolving issues
+      # - name: Cache coding-standard
+      #   # Allow the previous check to fail but not abort
+      #   if: always()
+      #   uses: actions/cache@v4
+      #   with:
+      #     path: .phpcs-cache
+      #     key: phpcs-cache
+
+      - name: Lint PHP files
+        # Allow the previous check to fail but not abort
+        if: always()
+        run: ./ci/ci-phplint
+
+      # TODO: Enable this after resolving issues
+      # - name: Check coding-standard
+      #   # Allow the previous check to fail but not abort
+      #   if: always()
+      #   run: composer phpcs
+
+# TODO: Enable this after resolving issues
+#  analyse-php:
+#    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+#        php-version: ["8.1"]
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v4
+#
+#      - name: Set up PHP ${{ matrix.php-version }}
+#        uses: shivammathur/setup-php@v2
+#        with:
+#          php-version: ${{ matrix.php-version }}
+#          extensions: mbstring, iconv, mysqli, zip, gd, bz2
+#
+#      - name: Install Composer dependencies
+#        uses: ramsey/composer-install@v2
+#
+#      - name: Analyse files with PHPStan
+#        run: composer phpstan -- --memory-limit 2G
+#
+#      - name: Analyse files with Psalm
+#        # Allow the previous check to fail but not abort
+#        if: always()
+#        run: composer psalm -- --shepherd

--- a/ci/ci-phplint
+++ b/ci/ci-phplint
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+FILES=$(find . -name '*.php' -not -path './vendor/*' -not -path './tmp/*' -not -path './node_modules/*')
+
+result=0
+for FILE in $FILES ; do
+    if [ -f "$FILE" ] ; then
+        php -l "$FILE"
+        ret=$?
+        if [ $ret != 0 ] ; then
+            result=$ret
+        fi
+    fi
+done
+
+exit $result

--- a/lib/external/FeedWriter/FeedWriter.php
+++ b/lib/external/FeedWriter/FeedWriter.php
@@ -429,7 +429,6 @@
  } // end of class FeedWriter
  
 // autoload classes
-function __autoload($class_name) 
-{
+spl_autoload_register(function ($class_name) {
 	require_once $class_name . '.php';
-}
+});

--- a/lib/external/pear/Config/Container/IniCommented.php
+++ b/lib/external/pear/Config/Container/IniCommented.php
@@ -164,7 +164,7 @@ class Config_Container_IniCommented {
         $pos = 0; // position in $text
 
         do {
-            $char = $text{$pos};
+            $char = $text[$pos];
             $state = $this->_getQACEvent($stack);
 
             if ($tokens[$state]) {

--- a/lib/external/pear/Config/Container/XML.php
+++ b/lib/external/pear/Config/Container/XML.php
@@ -131,7 +131,7 @@ class Config_Container_XML extends XML_Parser
     */
     function startHandler($xp, $elem, &$attribs)
     {
-        $container =& new Config_Container('section', $elem, null, $attribs);
+        $container = new Config_Container('section', $elem, null, $attribs);
         $this->containers[] =& $container;
         return null;
     } // end func startHandler

--- a/lib/external/pear/Event/Dispatcher.php
+++ b/lib/external/pear/Event/Dispatcher.php
@@ -246,7 +246,7 @@ class Event_Dispatcher
      */
     function &post(&$object, $nName, $info = array(), $pending = true, $bubble = true)
     {
-        $notification =& new $this->_notificationClass($object, $nName, $info);
+        $notification =& $this->_notificationClass($object, $nName, $info);
         return $this->postNotification($notification, $pending, $bubble);
     }
 

--- a/lib/external/pear/System.php
+++ b/lib/external/pear/System.php
@@ -235,7 +235,7 @@ class System
             } elseif($opt[0] == 'm') {
                 // if the mode is clearly an octal number (starts with 0)
                 // convert it to decimal
-                if (strlen($opt[1]) && $opt[1]{0} == '0') {
+                if (strlen($opt[1]) && $opt[1][0] == '0') {
                     $opt[1] = octdec($opt[1]);
                 } else {
                     // convert to int
@@ -545,7 +545,7 @@ class System
                     break;
                 case '-name':
                     if (OS_WINDOWS) {
-                        if ($args[$i+1]{0} == '\\') {
+                        if ($args[$i+1][0] == '\\') {
                             // prepend drive
                             $args[$i+1] = addslashes(substr(getcwd(), 0, 2) . $args[$i + 1]);
                         }


### PR DESCRIPTION
This was inspired by:
https://github.com/phpmyadmin/phpmyadmin/blob/b094f337466a1188ad755b33be5a7b7b25a70916/.github/workflows/lint-and-analyse-php.yml

Resolve issues flagged by the syntax error checker:
```
    PHP Parse error:  syntax error, unexpected token "new" in ./lib/external/pear/Event/Dispatcher.php on line 249
    Errors parsing ./lib/external/pear/Event/Dispatcher.php
    PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in ./lib/external/pear/System.php on line 238
    Errors parsing ./lib/external/pear/System.php
    PHP Parse error:  syntax error, unexpected token "new" in ./lib/external/pear/Config/Container/XML.php on line 134
    Errors parsing ./lib/external/pear/Config/Container/XML.php
    PHP Fatal error:  Array and string offset access syntax with curly braces is no longer supported in ./lib/external/pear/Config/Container/IniCommented.php on line 167
    Errors parsing ./lib/external/pear/Config/Container/IniCommented.php
    PHP Fatal error:  __autoload() is no longer supported, use spl_autoload_register() instead in ./lib/external/FeedWriter/FeedWriter.php on line 432
    Errors parsing ./lib/external/FeedWriter/FeedWriter.php
```