### PR TITLE
Update config.dist.php

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -208,5 +208,5 @@ $conf['settings']['registration']['require.organization'] = 'false';
  * Error logging
  */
 $conf['settings']['logging']['folder'] = '/var/log/librebooking/log'; //Absolute path to folder were the log will be written, writing permissions to the folder are required
-$conf['settings']['logging']['level'] = 'debug'; //Set to none disable logs, error to only log errors or debug to log all messages to the app.log file 
+$conf['settings']['logging']['level'] = 'none'; //Set to none disable logs, error to only log errors or debug to log all messages to the app.log file 
 $conf['settings']['logging']['sql'] = 'false'; //Set to true no enable the creation of and sql.log file


### PR DESCRIPTION
set default logging level to 'none' instead of  'debug' it breaks the config-update process cause the default logging folder set does not exist in all environments