### PR TITLE
chore: declare property `$name` in `SlimWebServiceRegistryCategory`

### DIFF
--- a/lib/WebService/Slim/SlimWebServiceRegistryCategory.php
+++ b/lib/WebService/Slim/SlimWebServiceRegistryCategory.php
@@ -2,6 +2,7 @@
 
 class SlimWebServiceRegistryCategory
 {
+    private $name;
     private $gets = [];
     private $posts = [];
     private $deletes = [];


### PR DESCRIPTION
PHP 8.3 was raising a Deprecation warning about dynamic property