### PR TITLE
fix: urlencode error with PHP 8.3

### DIFF
--- a/lib/Server/Url.php
+++ b/lib/Server/Url.php
@@ -49,7 +49,7 @@ class Url
         }
 
         $this->hasQuestionMark = true;
-        $this->url .= sprintf("$char%s=%s", $name, urlencode($value));
+        $this->url .= sprintf("$char%s=%s", $name, urlencode($value ?? ""));
 
         return $this;
     }


### PR DESCRIPTION
Got the following error:

```
  Slim Application Error
  The application could not run because of the following error:
  Details
  Code: 8192
  Message:urlencode(): Passing null to parameter #1 ($string) of type string is deprecated
  File:/var/www/html/lib/Server/Url.php
  Line: 52
  Trace:
  #0 [internal function]: Slim\Slim::handleErrors()
  #1 /var/www/html/lib/Server/Url.php(52): urlencode()
  #2 /var/www/html/lib/Application/Schedule/CalendarSubscriptionUrl.php(26): Url->AddQueryString()
  #3 /var/www/html/WebServices/Responses/ResourceResponse.php(82): CalendarSubscriptionUrl->__construct()
  #4 /var/www/html/WebServices/Responses/ResourcesResponse.php(20): ResourceResponse->__construct()
  #5 /var/www/html/WebServices/ResourcesWebService.php(65): ResourcesResponse->__construct()
  #6 [internal function]: ResourcesWebService->GetAll()
  #7 /var/www/html/lib/external/Slim/Router.php(200): call_user_func_array()
  #8 /var/www/html/lib/external/Slim/Slim.php(1218): Slim\Router->dispatch()
  #9 /var/www/html/lib/external/Slim/Middleware/Flash.php(86): Slim\Slim->call()
  #10 /var/www/html/lib/external/Slim/Middleware/MethodOverride.php(94): Slim\Middleware\Flash->call()
  #11 /var/www/html/lib/external/Slim/Middleware/PrettyExceptions.php(67): Slim\Middleware\MethodOverride->call()
  #12 /var/www/html/lib/external/Slim/Slim.php(1167): Slim\Middleware\PrettyExceptions->call()
  #13 /var/www/html/Web/Services/index.php(72): Slim\Slim->run()
  #14 {main}</pre></body></html>
```