### PR TITLE
fix: if an attribute is not required, allow it to not be set

### DIFF
--- a/lib/Application/Attributes/AttributeService.php
+++ b/lib/Application/Attributes/AttributeService.php
@@ -175,6 +175,10 @@ class AttributeService implements IAttributeService
                 continue;
             }
 
+            if (!$attribute->Required() && !array_key_exists($attribute->Id(), $values)) {
+                continue;
+            }
+
             $value = trim($values[$attribute->Id()]);
             $label = $attribute->Label();
 


### PR DESCRIPTION
When using the API would get "Undefinedarray key" errors on missing custom attributes, even though those attributes were not required.

Now allow the custom attribute to be missing if not a required custom attribute.