### PR TITLE
fix: Undefined array key 2

### DIFF
--- a/Domain/ReservationItemView.php
+++ b/Domain/ReservationItemView.php
@@ -487,7 +487,7 @@ class ReservationItemView implements IReservedItemView
                     # more than just one first and one last name
                     $lastIndex = count($name_parts) - 1;
                     $firstnames = implode(' ', array_splice($name_parts, 0, $lastIndex));
-                    $lastnames = $name_parts[$lastIndex];
+                    $lastnames = $name_parts[0];
                     // could be extended to guess which is a middle name etc.
                 }
                 $this->ParticipantIds[] = $id;


### PR DESCRIPTION
Was seeing the following errors in the log:
  PHP Warning:  Undefined array key 2 in /var/www/html/Domain/ReservationItemView.php on line 490

The issue was caused by `array_splice()`

After using `array_splice` then `$name_parts` is now only a single element array, as all other elements have been removed and used to generate `$firstnames`