### PR TITLE
Standard schedule lag when loading reservations

### DIFF
--- a/Pages/SchedulePage.php
+++ b/Pages/SchedulePage.php
@@ -214,6 +214,11 @@ interface ISchedulePage extends IActionPage
     public function BindViewableResourceReservations($resourceIds);
 
     /**
+     *
+     */
+    public function ShowFullLabel();
+
+    /**
      * @return LoadReservationRequest
      */
     public function GetReservationRequest();
@@ -490,6 +495,10 @@ class SchedulePage extends ActionPage implements ISchedulePage
         }
 
         return array_filter($resourceIds, 'intval');
+    }
+
+    public function ShowFullLabel() {
+        $this->Set('ShowFullLabel', Configuration::Instance()->GetSectionKey(ConfigSection::RESERVATION, ConfigKeys::SHOW_FULL_LABEL));
     }
 
     public function SetResourceGroupTree(ResourceGroupTree $resourceGroupTree)

--- a/Presenters/Schedule/SchedulePresenter.php
+++ b/Presenters/Schedule/SchedulePresenter.php
@@ -100,6 +100,7 @@ class SchedulePresenter extends ActionPresenter implements ISchedulePresenter
         $this->_builder->BindResourceFilter($this->_page, $filter, $resourceAttributes, $resourceTypeAttributes);
 
         $this->UserResourcePermissions();
+        $this->_page->ShowFullLabel();
 
         $resources = $this->_resourceService->GetScheduleResources($activeScheduleId, $showInaccessibleResources, $user, $filter);
 

--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -236,7 +236,7 @@ function Schedule(opts, resourceGroups) {
             });
 
             //--------GET ROW AND LABELS HEIGHT TO ALLOW FULL LABEL TEXT TO SHOW IN STANDARD SCHEDULE--------
-            if (opts.scheduleStyle === ScheduleStandard) {
+            if (opts.scheduleStyle === ScheduleStandard && scheduleOpts.showFullLabel) {
                 var trHeights = {};                         //row height to be implemented
                 var trAdjusted = {};                        //check if row height has already been adjusted
                 
@@ -397,10 +397,15 @@ function Schedule(opts, resourceGroups) {
                             }
 
                             if (overlap) {
-                                if(opts.scheduleStyle === ScheduleStandard && typeof trHeights[currentTrId] !== "undefined"){
-                                    top += trHeights[currentTrId];
+                                if(opts.scheduleStyle === ScheduleStandard && scheduleOpts.showFullLabel){
+                                    if (typeof trHeights[currentTrId] !== "undefined") {
+                                        top += trHeights[currentTrId];
+                                    }
+                                    else {
+                                        top += height;
+                                    }
                                 }
-                                else{
+                                else {
                                     top += height;
                                 }
                                 numberOfConflicts++;
@@ -410,7 +415,7 @@ function Schedule(opts, resourceGroups) {
                     };
 
                     //----------CHANGE HEIGTH OF ROWS TO ALLOW FULL LABEL TEXT TO SHOW------------
-                    if (opts.scheduleStyle === ScheduleStandard) {
+                    if (opts.scheduleStyle === ScheduleStandard && scheduleOpts.showFullLabel) {
                         let current_TD = t.find('td[data-resourceid="' + res.ResourceId + '"]:first');
 
                         var current_TR = current_TD.parent();
@@ -465,7 +470,7 @@ function Schedule(opts, resourceGroups) {
                         adjustOverlap();
                         if (numberOfConflicts > 0) {
                             //CHANGE ROW SIZE BASED ON NUMBER OF CONCURRENT RESERVATIONS ALLOWING SPACE IN SLOT IF NOT REACHED THE MAX NUMBER
-                            if (opts.scheduleStyle === ScheduleStandard) {
+                            if (opts.scheduleStyle === ScheduleStandard && scheduleOpts.showFullLabel) {
                                 if (scheduleOpts.resourceMaxConcurrentReservations[res.ResourceId] !== numberOfConflicts + 1 && scheduleOpts.resourceMaxConcurrentReservations[res.ResourceId] > 2) {
                                     startTd.css('height', trHeights[currentTrId] * (numberOfConflicts + 2) + "px");
                                 }
@@ -480,13 +485,15 @@ function Schedule(opts, resourceGroups) {
 
                     let divHeight;
                     //SLOT LABEL HEIGHT TO ALLOW FULL TEXT TO SHOW IN STANDARD SCHEDULE
-                    if (opts.scheduleStyle === ScheduleStandard && typeof trHeights[currentTrId] !== "undefined") {
-                        if (className == "reserved") {
-                            divHeight = trHeights[currentTrId];
-                        }
-                        //BLACKOUTS SHOULD OCUPPY ENTIRE ROW AND THERE'S NO NEED TO WORRY ABOUT CHANGES TO ROW HEIGHT BECAUSE THEY ARE ALWAYS THE LAST TO BE PUT IN EACH
-                        else if (className == "unreservable") {
-                            divHeight = current_TR.height();
+                    if (opts.scheduleStyle === ScheduleStandard & scheduleOpts.showFullLabel) {
+                        if (typeof trHeights[currentTrId] !== "undefined") {
+                            if (className == "reserved") {
+                                divHeight = trHeights[currentTrId];
+                            }
+                            //BLACKOUTS SHOULD OCUPPY ENTIRE ROW AND THERE'S NO NEED TO WORRY ABOUT CHANGES TO ROW HEIGHT BECAUSE THEY ARE ALWAYS THE LAST TO BE PUT IN EACH
+                            else if (className == "unreservable") {
+                                divHeight = current_TR.height();
+                            }
                         }
                     }
                     else {

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -210,3 +210,9 @@ $conf['settings']['registration']['require.organization'] = 'false';
 $conf['settings']['logging']['folder'] = '/var/log/librebooking/log'; //Absolute path to folder were the log will be written, writing permissions to the folder are required
 $conf['settings']['logging']['level'] = 'debug'; //Set to none disable logs, error to only log errors or debug to log all messages to the app.log file 
 $conf['settings']['logging']['sql'] = 'false'; //Set to true no enable the creation of and sql.log file
+
+/**
+ * Adjust labels in standard schedule to show full text (true) or not (false)
+ * Not recommended if there are to many reservations being shown because it can take a while to load them all
+ */
+$conf['settings']['reservation']['show.full.label'] = 'false';

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -242,3 +242,9 @@ $conf['settings']['delete.old.data']['years.old.data'] = '3';               //Ch
 $conf['settings']['delete.old.data']['delete.old.announcements'] = 'false'; //Choose if this feature deletes old announcements from database
 $conf['settings']['delete.old.data']['delete.old.blackouts'] = 'false';     //Choose if this feature deletes old blackouts from database
 $conf['settings']['delete.old.data']['delete.old.reservations'] = 'false';  //Choose if this feature deletes old reservations from database
+
+/**
+ * Adjust labels in standard schedule to show full text (true) or not (false)
+ * Not recommended if there are to many reservations being shown because it can take a while to load them all
+ */
+$conf['settings']['reservation']['show.full.label'] = 'false';

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -177,6 +177,8 @@ class ConfigKeys
     public const DELETE_OLD_ANNOUNCEMENTS = 'delete.old.announcements'; 
     public const DELETE_OLD_BLACKOUTS = 'delete.old.blackouts'; 
     public const DELETE_OLD_RESERVATIONS = 'delete.old.reservations'; 
+
+    public const SHOW_FULL_LABEL = 'show.full.label';
 }
 
 class ConfigSection

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -431,6 +431,7 @@ let resourceMaxConcurrentReservations = {};
         updatedLabel: "{translate key=Updated}",
         isReservable: 1,
         autocompleteUrl: "{$Path}ajax/autocomplete.php?type={AutoCompleteType::User}",
+        showFullLabel: "{$ShowFullLabel}",
         resourceMaxConcurrentReservations,
     };
 


### PR DESCRIPTION
Previous pull request (#323) may be causing the system to lag when there are to many reservations to load on the standard schedule (#370).

A new configuration is now available that lets the admin choose if he wishes to have the full label with all the text shown (true) or not (false).

With the full label it will take more time to load than the default 41px sized label. The admin should choose the preferred way based on the possible/max number of reservations the schedules have.

$conf['settings']['reservation']['show.full.label'] = 'false';