### PR TITLE
feat: new algorithm for fast loading reservations

### DIFF
--- a/Pages/SchedulePage.php
+++ b/Pages/SchedulePage.php
@@ -302,6 +302,7 @@ class SchedulePage extends ActionPage implements ISchedulePage
         $this->Set('UserIdFilter', $this->GetOwnerId());
         $this->Set('ParticipantIdFilter', $this->GetParticipantId());
         $this->Set('ShowWeekNumbers', Configuration::Instance()->GetSectionKey(ConfigSection::SCHEDULE, ConfigKeys::SCHEDULE_SHOW_WEEK_NUMBERS, new BooleanConverter()));
+        $this->Set('FastReservationLoad', Configuration::Instance()->GetSectionKey(ConfigSection::SCHEDULE, ConfigKeys::SCHEDULE_FAST_RESERVATION_LOAD, new BooleanConverter()) ?? false);
 
         if ($this->IsMobile && !$this->IsTablet) {
             if ($this->ScheduleStyle == ScheduleStyle::Tall) {

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -41,6 +41,7 @@ $conf['settings']['schedule']['reservation.label'] = '{name}';          // forma
 $conf['settings']['schedule']['hide.blocked.periods'] = 'false';        // if blocked periods should be hidden or shown
 $conf['settings']['schedule']['update.highlight.minutes'] = '0';    // if set, will show reservations as 'updated' for a certain amount of time
 $conf['settings']['schedule']['show.week.numbers'] = 'false';
+$conf['settings']['schedule']['fast.reservation.load'] = 'false';  // Experimental: Use new algorithm to load reservations faster in the schedule. Currently does not support concurrent reservations. With larger number of resources this can be 10x or 100x faster. Only runs with the StandardSchedule otherwise will fall back to legacy mode.
 /**
  * ical integration configuration
  */

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -41,6 +41,7 @@ $conf['settings']['schedule']['reservation.label'] = '{name}';    		// format fo
 $conf['settings']['schedule']['hide.blocked.periods'] = 'false';    	// if blocked periods should be hidden or shown
 $conf['settings']['schedule']['update.highlight.minutes'] = '0';    // if set, will show reservations as 'updated' for a certain amount of time
 $conf['settings']['schedule']['show.week.numbers'] = 'false';
+$conf['settings']['schedule']['fast.reservation.load'] = 'false';  // Experimental: Use new algorithm to load reservations faster in the schedule. Currently does not support concurrent reservations. With larger number of resources this can be 10x or 100x faster. Only runs with the StandardSchedule otherwise will fall back to legacy mode.
 /**
  * ical integration configuration
  */

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -33,6 +33,7 @@ class ConfigKeys
     public const SCHEDULE_HIDE_BLOCKED_PERIODS = 'hide.blocked.periods';
     public const SCHEDULE_UPDATE_HIGHLIGHT_MINUTES = 'update.highlight.minutes';
     public const SCHEDULE_SHOW_WEEK_NUMBERS = 'show.week.numbers';
+    public const SCHEDULE_FAST_RESERVATION_LOAD = 'fast.reservation.load';
 
     public const DATABASE_TYPE = 'type';
     public const DATABASE_USER = 'user';

--- a/tpl/Schedule/schedule-reservations-grid.tpl
+++ b/tpl/Schedule/schedule-reservations-grid.tpl
@@ -30,7 +30,7 @@
         {foreach from=$Resources item=resource name=resource_loop}
             {assign var=resourceId value=$resource->Id}
             {assign var=href value="{$CreateReservationPage}?rid={$resource->Id}&sid={$ScheduleId}&rd={formatdate date=$date key=url}"}
-            <tr class="slots">
+            <tr class="slots" data-resourceid="{$resource->GetId()}">
                 <td class="resourcename"
                     {if $resource->HasColor()}style="background-color:{$resource->GetColor()} !important"{/if}>
                     {if $resource->CanAccess && $DailyLayout->IsDateReservable($date)}

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -431,6 +431,7 @@ let resourceMaxConcurrentReservations = {};
         updatedLabel: "{translate key=Updated}",
         isReservable: 1,
         autocompleteUrl: "{$Path}ajax/autocomplete.php?type={AutoCompleteType::User}",
+        fastReservationLoad: "{$FastReservationLoad}",
         resourceMaxConcurrentReservations,
     };
 


### PR DESCRIPTION
Add a new algorithm for fast loading reservations in the schedule.

Marking it as "experimental" and users will have to explicitly enable it.

Limitations:
  * Only supports the ScheduleStandard style. Otherwise it will use the default legacy algorithm.
  * Has not been setup for concurrent reservations. So behavior is undefined for concurrent reservation.

The performance gain is very significant when loading larger schedules.  On a one day schedule with 332 resources. The legacy algorithm took 23 seconds to "Load Reservations". While the new algorithm took 0.6 seconds. "Load Reservations" is the time for the renderEvents() method to run. It does not count the time for the web page to be fetched from the server.

The more resources / days in the schedule the larger the difference in timing becomes.

Closes: #370