### PR TITLE
fix(api): restrict resources seen by non-Admin users

### DIFF
--- a/Domain/Access/IResourceRepository.php
+++ b/Domain/Access/IResourceRepository.php
@@ -50,6 +50,21 @@ interface IResourceRepository
     public function GetResourceList();
 
     /**
+     * @return array|$resourceIds[] array of all resource IDs
+     */
+    public function GetResourceIdList(): array;
+
+    /**
+     * @return array|BookableResource[] array of user accessible resources
+     */
+    public function GetUserResourceList();
+
+    /**
+     * @return array|$resourceIds[] array of user accessible resources IDs
+     */
+    public function GetUserResourceIdList();
+
+    /**
      * @param int $pageNumber
      * @param int $pageSize
      * @param string|null $sortField
@@ -95,7 +110,7 @@ interface IResourceRepository
      * @param array $resourceIds
      */
     public function GetUserGroupResourcePermissions($userId, $resourceIds = []);
-    
+
     /**
      * @param int $userId
      * @param array $resourceIds

--- a/Domain/Access/ResourceRepository.php
+++ b/Domain/Access/ResourceRepository.php
@@ -49,6 +49,9 @@ class ResourceRepository implements IResourceRepository
         return $resources;
     }
 
+    /**
+     * Gets all the resources
+     */
     public function GetResourceList()
     {
         $resources = [];
@@ -61,6 +64,73 @@ class ResourceRepository implements IResourceRepository
         $reader->Free();
 
         return $resources;
+    }
+
+    /**
+     * Gets the resource IDs for all the resources
+     */
+    public function GetResourceIdList(): array {
+        $resourceIds = [];
+        $reader = ServiceLocator::GetDatabase()->Query(new GetAllResourcesCommand());
+        while ($row = $reader->GetRow()) {
+            $resourceId = $row[ColumnNames::RESOURCE_ID];
+
+            if (!array_key_exists($resourceId, $resourceIds)) {
+                $resourceIds[$resourceId] = $resourceId;
+            }
+        }
+        $reader->Free();
+        return $resourceIds;
+    }
+
+    /**
+     * Gets, for the logged in user, the resources that the user and the user groups
+     * have permissions to. Admin user will return all resources.
+     */
+    public function GetUserResourceList()
+    {
+        $userSession = ServiceLocator::GetUserSession();
+        if (is_null($userSession)) {
+            return [];
+        }
+        if ($userSession->IsAdmin){
+            return $this->GetResourceList();
+        }
+        $resourceIds = $this->GetUserResourceIdList();
+        $resources = [];
+        foreach($resourceIds as $resourceId){
+            $resource = $this->LoadById($resourceId);
+            if($resource->GetStatusId() != ResourceStatus::HIDDEN){
+                $resources[$resourceId] = $resource;
+            }
+        }
+        return $resources;
+    }
+
+    /**
+     * Gets the resource IDs that the logged in user has permissions (full access and view only permissions)
+     * This is used to block a user from seeing a resource if they don't have permissions to it.
+     */
+    public function GetUserResourceIdList() {
+        $userSession = ServiceLocator::GetUserSession();
+        if (is_null($userSession)) {
+            return [];
+        }
+        if ($userSession->IsAdmin){
+            return $this->GetResourceIdList();
+        }
+        $resourceIds = $this->GetUserResourcePermissions(userId: $userSession->UserId);
+        $resourceIds = $this->GetUserGroupResourcePermissions(userId: $userSession->UserId, resourceIds: $resourceIds);
+
+
+        if ($userSession->IsResourceAdmin){
+            $resourceIds = $this->GetResourceAdminResourceIds(userId: $userSession->UserId, resourceIds: $resourceIds);
+        }
+
+        if ($userSession->IsScheduleAdmin){
+            $resourceIds = $this->GetScheduleAdminResourceIds(userId: $userSession->UserId, resourceIds: $resourceIds);
+        }
+        return $resourceIds;
     }
 
     public function GetResourceGroupsList()
@@ -388,9 +458,9 @@ class ResourceRepository implements IResourceRepository
 
             if (!array_key_exists($resourceId, $resourceIds)) {
                 $resourceIds[$resourceId] = $resourceId;
-            }         
+            }
         }
-        
+
         $reader->Free();
 
         return $resourceIds;
@@ -408,7 +478,7 @@ class ResourceRepository implements IResourceRepository
 
             if (!array_key_exists($resourceId, $resourceIds)) {
                 $resourceIds[$resourceId] = $resourceId;
-            } 
+            }
         }
         $reader->Free();
 
@@ -419,8 +489,11 @@ class ResourceRepository implements IResourceRepository
      * Gets the resource ids that are under the responsability of the given resource user groups
      */
     public function GetResourceAdminResourceIds($userId, $resourceIds = []){
-
-        if (ServiceLocator::GetServer()->GetUserSession()->IsResourceAdmin){    
+        $userSession = ServiceLocator::GetUserSession();
+        if (is_null($userSession)) {
+            return $resourceIds;
+        }
+        if ($userSession->IsResourceAdmin){
             $command = new GetResourceAdminResourcesCommand($userId);
             $reader = ServiceLocator::GetDatabase()->Query($command);
 
@@ -429,7 +502,7 @@ class ResourceRepository implements IResourceRepository
 
                 if (!array_key_exists($resourceId, $resourceIds)) {
                     $resourceIds[$resourceId] = $resourceId;
-                } 
+                }
             }
             $reader->Free();
         }
@@ -440,8 +513,11 @@ class ResourceRepository implements IResourceRepository
      * Gets the resource ids that are under the responsability of the given schedule user groups
      */
     public function GetScheduleAdminResourceIds($userId, $resourceIds = []){
-
-        if (ServiceLocator::GetServer()->GetUserSession()->IsScheduleAdmin){
+        $userSession = ServiceLocator::GetUserSession();
+        if (is_null($userSession)) {
+            return $resourceIds;
+        }
+        if ($userSession->IsScheduleAdmin){
             $command = new GetScheduleAdminResourcesCommand($userId);
             $reader = ServiceLocator::GetDatabase()->Query($command);
 
@@ -450,7 +526,7 @@ class ResourceRepository implements IResourceRepository
 
                 if (!array_key_exists($resourceId, $resourceIds)) {
                     $resourceIds[$resourceId] = $resourceId;
-                } 
+                }
             }
             $reader->Free();
         }

--- a/Web/Services/index.php
+++ b/Web/Services/index.php
@@ -30,6 +30,7 @@ if (!Configuration::Instance()->GetSectionKey(ConfigSection::API, ConfigKeys::AP
 $app = new \Slim\Slim();
 
 $server = new SlimServer($app);
+ServiceLocator::SetApiServer(apiServer: $server);
 
 $registry = new SlimWebServiceRegistry($app);
 

--- a/WebServices/ResourcesWebService.php
+++ b/WebServices/ResourcesWebService.php
@@ -56,7 +56,7 @@ class ResourcesWebService
      */
     public function GetAll()
     {
-        $resources = $this->resourceRepository->GetResourceList();
+        $resources = $this->resourceRepository->GetUserResourceList();
         $resourceIds = [];
         foreach ($resources as $resource) {
             $resourceIds[] = $resource->GetId();

--- a/lib/Common/ServiceLocator.php
+++ b/lib/Common/ServiceLocator.php
@@ -13,6 +13,11 @@ class ServiceLocator
     private static $_server = null;
 
     /**
+     * @var IRestServer
+     */
+    private static IRestServer|null $_apiServer = null;
+
+    /**
      * @var IEmailService
      */
     private static $_emailService = null;
@@ -38,6 +43,19 @@ class ServiceLocator
     public static function SetDatabase(Database $database)
     {
         self::$_database = $database;
+    }
+
+    /**
+     * @return Server
+     */
+    public static function GetApiServer(): IRestServer|null
+    {
+        return self::$_apiServer;
+    }
+
+    public static function SetApiServer(IRestServer $apiServer)
+    {
+        self::$_apiServer = $apiServer;
     }
 
     /**

--- a/lib/Common/ServiceLocator.php
+++ b/lib/Common/ServiceLocator.php
@@ -119,4 +119,19 @@ class ServiceLocator
     {
         self::$_fileSystem = $fileSystem;
     }
+
+    public static function GetUserSession(): UserSession|null
+    {
+        if (!is_null(self::$_server)) {
+            $userSession = self::$_server->GetUserSession();
+            if (!$userSession instanceof NullUserSession) {
+                return $userSession;
+            }
+        }
+        if (is_null(self::$_apiServer)) {
+            return null;
+        }
+        return self::$_apiServer->GetSession();
+    }
+
 }


### PR DESCRIPTION
Previously API users could see all the resources, even if the user was not given permission to some of the resources.

Now non-Admin users will only see the resources that they have access to via their direct access or group access.