### PR TITLE
fix: deprecated each() function

### DIFF
--- a/lib/external/pear/PEAR.php
+++ b/lib/external/pear/PEAR.php
@@ -778,7 +778,7 @@ function _PEAR_call_destructors()
             $_PEAR_destructor_object_list = array_reverse($_PEAR_destructor_object_list);
         }
 
-        while (list($k, $objref) = each($_PEAR_destructor_object_list)) {
+        foreach ($_PEAR_destructor_object_list as $k => $objref) {
             $classname = get_class($objref);
             while ($classname) {
                 $destructor = "_$classname";


### PR DESCRIPTION
This function has been DEPRECATED as of PHP 7.2.0, and REMOVED as of PHP 8.0.0. Relying on this function is highly discouraged.

```
PHP Fatal error:  Uncaught Error: Call to undefined function each() in lib/external/pear/PEAR.php:781\nStack trace:\n#0 [internal function]: _PEAR_call_destructors()\n#1 {main}\n  thrown in lib/external/pear/PEAR.php on line 781
```

Ref: https://www.php.net/manual/en/function.each.php