### PR TITLE
fix: ldap_close with boolean parameter

### DIFF
--- a/plugins/Authentication/Ldap/LDAP2.php
+++ b/plugins/Authentication/Ldap/LDAP2.php
@@ -705,7 +705,9 @@ class Net_LDAP2 extends PEAR
     */
     public function _Net_LDAP2()
     {
-        @ldap_close($this->_link);
+        if ($this->_link) {
+            @ldap_close($this->_link);
+        }
     }
 
     /**

--- a/plugins/Authentication/Ldap/Ldap2Wrapper.php
+++ b/plugins/Authentication/Ldap/Ldap2Wrapper.php
@@ -133,6 +133,7 @@ class Ldap2Wrapper
                 return false;
             }
 
+            $userGroups = [];
             if ($loadGroups) {
                 $userGroups = $currentResult->getValue('memberof', 'all');
                 $userGroups = array_map('trim', $userGroups);


### PR DESCRIPTION
- When destruct object, this function will be called, we will get issue if `this->_link` is False value
- Fix warning `userGroups` un-init value if `loadGroups` is False

