### PR TITLE
fix: cast UserSession class from session object

### DIFF
--- a/lib/Server/Server.php
+++ b/lib/Server/Server.php
@@ -210,7 +210,15 @@ class Server
         $userSession = $this->GetSession(SessionKeys::USER_SESSION);
 
         if (!empty($userSession)) {
-            return $userSession;
+            // return (UserSession) $userSession;
+            $class = 'UserSession';
+            return unserialize(
+                preg_replace(
+                    '/^O:\d+:"[^"]++"/',
+                    'O:'.strlen($class).':"'.$class.'"',
+                    serialize($userSession)
+                )
+            );
         }
 
         return new NullUserSession();


### PR DESCRIPTION
UserSession is saved in session:
+ When we put it to session, it is UserSession object
+ When we get it from session, we need to cast it to UserSession class