### PR TITLE
chore: fix dynamic property error

### DIFF
--- a/lib/external/pear/PEAR.php
+++ b/lib/external/pear/PEAR.php
@@ -833,6 +833,7 @@ class PEAR_Error
     var $message              = '';
     var $userinfo             = '';
     var $backtrace            = null;
+    public $callback          = null;
 
 //    /**
 //     * Only here for backwards compatibility.


### PR DESCRIPTION
Error was:
  Creation of dynamic property PEAR_Error::$callback is deprecated