### PR TITLE
chore: fix calling `get_class()` without arguments

### DIFF
--- a/lib/external/pear/PEAR.php
+++ b/lib/external/pear/PEAR.php
@@ -147,7 +147,7 @@ class PEAR
             );
         }
         return call_user_func_array(
-            array(get_class(), '_' . $method),
+            array(__CLASS__, '_' . $method),
             array_merge(array(null), $arguments)
         );
     }
@@ -663,7 +663,7 @@ class PEAR
             );
         }
         return call_user_func_array(
-            array(get_class(), '_' . $method),
+            array(__CLASS__, '_' . $method),
             array_merge(array($this), $arguments)
         );
     }


### PR DESCRIPTION
Backport: https://github.com/pear/pear-core/pull/135