### PR TITLE
chore(ldap): fix deprecation warnings about return types

### DIFF
--- a/plugins/Authentication/Ldap/LDAP2/Search.php
+++ b/plugins/Authentication/Ldap/LDAP2/Search.php
@@ -560,7 +560,7 @@ class Net_LDAP2_Search extends PEAR implements Iterator
     *
     * @return Net_LDAP2_Entry|false
     */
-    public function current()
+    public function current(): mixed
     {
         if (count($this->_iteratorCache) == 0) {
             $this->next();
@@ -576,7 +576,7 @@ class Net_LDAP2_Search extends PEAR implements Iterator
     * @see current()
     * @return string|false DN of the current entry; false in case no entry is returned by current()
     */
-    public function key()
+    public function key(): mixed
     {
         $entry = $this->current();
         return ($entry instanceof Net_LDAP2_Entry) ? $entry->dn() : false;
@@ -591,7 +591,7 @@ class Net_LDAP2_Search extends PEAR implements Iterator
     * @see current()
     * @return void
     */
-    public function next()
+    public function next(): void
     {
         // fetch next entry.
         // if we have no entrys anymore, we add false (which is
@@ -614,7 +614,7 @@ class Net_LDAP2_Search extends PEAR implements Iterator
     * @see current()
     * @return boolean FALSE if there's nothing more to iterate over
     */
-    public function valid()
+    public function valid(): bool
     {
         return ($this->current() instanceof Net_LDAP2_Entry);
     }
@@ -627,7 +627,7 @@ class Net_LDAP2_Search extends PEAR implements Iterator
     * @see current()
     * @return void
     */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->_iteratorCache);
     }


### PR DESCRIPTION
When using Ldap authentication, these deprecation warnings were being sent as part of the API response. This corrupted the expected JSON response.