### PR TITLE
chore: add return types to fix deprecation warnings

### DIFF
--- a/lib/external/Slim/Environment.php
+++ b/lib/external/Slim/Environment.php
@@ -192,7 +192,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->properties[$offset]);
     }
@@ -200,7 +200,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Get
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         if (isset($this->properties[$offset])) {
             return $this->properties[$offset];
@@ -212,7 +212,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Set
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->properties[$offset] = $value;
     }
@@ -220,7 +220,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Unset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->properties[$offset]);
     }
@@ -230,7 +230,7 @@ class Environment implements \ArrayAccess, \IteratorAggregate
      *
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->properties);
     }

--- a/lib/external/Slim/Http/Headers.php
+++ b/lib/external/Slim/Http/Headers.php
@@ -92,7 +92,7 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->headers[$this->canonical($offset)]);
     }
@@ -100,7 +100,7 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Array Access: Offset Get
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         $canonical = $this->canonical($offset);
         if (isset($this->headers[$canonical])) {
@@ -113,7 +113,7 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Array Access: Offset Set
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $canonical = $this->canonical($offset);
         $this->headers[$canonical] = $value;
@@ -123,7 +123,7 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Array Access: Offset Unset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $canonical = $this->canonical($offset);
         unset($this->headers[$canonical], $this->map[$canonical]);
@@ -132,7 +132,7 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Countable: Count
      */
-    public function count()
+    public function count(): int
     {
         return count($this->headers);
     }
@@ -140,7 +140,7 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Iterator: Rewind
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->headers);
     }
@@ -148,7 +148,7 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Iterator: Current
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->headers);
     }
@@ -156,7 +156,7 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Iterator: Key
      */
-    public function key()
+    public function key(): mixed
     {
         $key = key($this->headers);
 
@@ -166,15 +166,15 @@ class Headers implements \ArrayAccess, \Iterator, \Countable
     /**
      * Iterator: Next
      */
-    public function next()
+    public function next(): void
     {
-        return next($this->headers);
+        next($this->headers);
     }
 
     /**
      * Iterator: Valid
      */
-    public function valid()
+    public function valid(): bool
     {
         return current($this->headers) !== false;
     }

--- a/lib/external/Slim/Http/Response.php
+++ b/lib/external/Slim/Http/Response.php
@@ -390,7 +390,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists( $offset )
+    public function offsetExists( $offset ): bool
     {
         return isset($this->header[$offset]);
     }
@@ -398,7 +398,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Get
      */
-    public function offsetGet( $offset )
+    public function offsetGet( $offset ): mixed
     {
         if (isset($this->header[$offset])) {
             return $this->header[$offset];
@@ -410,7 +410,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Set
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->header[$offset] = $value;
     }
@@ -418,7 +418,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Array Access: Offset Unset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->header[$offset]);
     }
@@ -426,7 +426,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
     /**
      * Countable: Count
      */
-    public function count()
+    public function count(): int
     {
         return count($this->header);
     }
@@ -439,7 +439,7 @@ class Response implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return \Slim\Http\Headers
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return $this->header;
     }

--- a/lib/external/Slim/Middleware/Flash.php
+++ b/lib/external/Slim/Middleware/Flash.php
@@ -156,7 +156,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Exists
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         $messages = $this->getMessages();
 
@@ -166,7 +166,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Get
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         $messages = $this->getMessages();
 
@@ -176,7 +176,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Set
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->now($offset, $value);
     }
@@ -184,7 +184,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
     /**
      * Array Access: Offset Unset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->messages['prev'][$offset], $this->messages['now'][$offset]);
     }
@@ -193,7 +193,7 @@ class Flash extends \Slim\Middleware implements \ArrayAccess, \IteratorAggregate
      * Iterator Aggregate: Get Iterator
      * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         $messages = $this->getMessages();
 

--- a/lib/external/Slim/Router.php
+++ b/lib/external/Slim/Router.php
@@ -295,7 +295,7 @@ class Router implements \Iterator
     /**
      * Iterator Interface: Rewind
      */
-    public function rewind()
+    public function rewind(): void
     {
         reset($this->matchedRoutes);
     }
@@ -304,7 +304,7 @@ class Router implements \Iterator
      * Iterator Interface: Current
      * @return \Slim\Route|false
      */
-    public function current()
+    public function current(): mixed
     {
         return current($this->matchedRoutes);
     }
@@ -313,7 +313,7 @@ class Router implements \Iterator
      * Iterator Interface: Key
      * @return int|null
      */
-    public function key()
+    public function key(): mixed
     {
         return key($this->matchedRoutes);
     }
@@ -321,7 +321,7 @@ class Router implements \Iterator
     /**
      * Iterator Interface: Next
      */
-    public function next()
+    public function next(): void
     {
         next($this->matchedRoutes);
     }
@@ -330,6 +330,8 @@ class Router implements \Iterator
      * Iterator Interface: Valid
      * @return boolean
      */
+    // FIXME: 2024-05-31: This should return a `bool` but doesn't
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->current();


### PR DESCRIPTION
With PHP 8.3, was getting deprecation warnings/errors about return types. Add return types to resolve the issue.