### PR TITLE
fix: use empty string if value null in a str_replace

### DIFF
--- a/Domain/Values/FullName.php
+++ b/Domain/Values/FullName.php
@@ -13,8 +13,8 @@ class FullName
         if (empty($formatter)) {
             $this->fullName = "$firstName $lastName";
         } else {
-            $this->fullName = str_replace('{first}', $firstName, $formatter);
-            $this->fullName = str_replace('{last}', $lastName, $this->fullName);
+            $this->fullName = str_replace('{first}', $firstName ?? "", $formatter);
+            $this->fullName = str_replace('{last}', $lastName ?? "", $this->fullName);
         }
     }
 


### PR DESCRIPTION
Received a warning/error about null being used in `str_replace`. Now pass in empty string if value is null.