### PR TITLE
fix: passing null to `explode()` function

### DIFF
--- a/Domain/CustomAttribute.php
+++ b/Domain/CustomAttribute.php
@@ -76,7 +76,7 @@ class CustomAttribute
     protected $adminOnly = false;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $possibleValues;
 
@@ -134,6 +134,9 @@ class CustomAttribute
      */
     public function PossibleValueList()
     {
+        if (is_null($this->possibleValues)) {
+            return [];
+        }
         return explode(',', $this->possibleValues);
     }
 


### PR DESCRIPTION
When calling the `GetCategoryAttributes` API, got an error:

The application could not run because of the following error:
    Details
    Code: 8192
    Message: explode(): Passing null to parameter #2 ($string) of type string is deprecated
    File: /var/www/html/Domain/CustomAttribute.php
    Line: 137