### PR TITLE
API: Restrict user access to reservations and resources that they are allowed to see

### DIFF
--- a/WebServices/ResourcesWebService.php
+++ b/WebServices/ResourcesWebService.php
@@ -74,9 +74,14 @@ class ResourcesWebService
      */
     public function GetResource($resourceId)
     {
-        $resource = $this->resourceRepository->LoadById($resourceId);
-
-        $resourceId = $resource->GetResourceId();
+        $allowedResourceIds = $this->resourceRepository->GetUserResourceIdList();
+        if (!in_array($resourceId, $allowedResourceIds)) {
+            $resourceId = null;
+            $resource = null;
+        } else {
+            $resource = $this->resourceRepository->LoadById($resourceId);
+            $resourceId = $resource->GetResourceId();
+        }
         if (empty($resourceId)) {
             $this->server->WriteResponse(RestResponse::NotFound(), RestResponse::NOT_FOUND_CODE);
         } else {
@@ -139,10 +144,14 @@ class ResourcesWebService
             $requestedTime = Date::Now();
         }
 
+        $resources = [];
         if (empty($resourceId)) {
-            $resources = $this->resourceRepository->GetResourceList();
+            $resources = $this->resourceRepository->GetUserResourceList();
         } else {
-            $resources[] = $this->resourceRepository->LoadById($resourceId);
+            $allowedResourceIds = $this->resourceRepository->GetUserResourceIdList();
+            if (in_array($resourceId, $allowedResourceIds)) {
+                $resources[] = $this->resourceRepository->LoadById($resourceId);
+            }
         }
 
         $lastDateSearched = $requestedTime->AddDays(7);


### PR DESCRIPTION
In the API, only show reservations to the user that are on systems that they have the permission to see.

In the API, only allow fetching a resource that the user has permission to see. Also only show availability of resources that the user has permission to see.