### PR TITLE
Make request method configurable

### DIFF
--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -141,6 +141,7 @@ $conf['settings']['api']['allow.self.registration'] = 'false';
 $conf['settings']['recaptcha']['enabled'] = 'false';
 $conf['settings']['recaptcha']['public.key'] = '';
 $conf['settings']['recaptcha']['private.key'] = '';
+$conf['settings']['recaptcha']['request.method'] = 'curl'; // options are curl, post or socket. default: post
 /**
  * Email
  */

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -141,6 +141,7 @@ $conf['settings']['api']['allow.self.registration'] = 'false';
 $conf['settings']['recaptcha']['enabled'] = 'false';
 $conf['settings']['recaptcha']['public.key'] = '';
 $conf['settings']['recaptcha']['private.key'] = '';
+$conf['settings']['recaptcha']['request.method'] = 'curl'; // options are curl, post or socket. default: post
 /**
  * Email
  */

--- a/lib/Application/Authentication/CaptchaService.php
+++ b/lib/Application/Authentication/CaptchaService.php
@@ -110,8 +110,11 @@ class ReCaptchaService implements ICaptchaService
         $recap = new \ReCaptcha\ReCaptcha($privatekey);
         $resp = $recap->verify($server->GetForm('g-recaptcha-response'),$server->GetRemoteAddress());
 
-        Log::Debug('ReCaptcha IsValid: %s', $resp->isSuccess());
+        $success = $resp->isSuccess();
+        Log::Debug('ReCaptcha IsValid: %s', $success ? 'TRUE' : 'FALSE');
+        if (!$success)
+            Log::Debug('ReCaptcha error codes: %s', join(', ', $resp->getErrorCodes()));
 
-        return $resp->isSuccess();
+        return $success;
     }
 }

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -107,6 +107,7 @@ class ConfigKeys
     public const RECAPTCHA_ENABLED = 'enabled';
     public const RECAPTCHA_PUBLIC_KEY = 'public.key';
     public const RECAPTCHA_PRIVATE_KEY = 'private.key';
+    public const RECAPTCHA_REQUEST_METHOD = 'request.method';
 
     public const DEFAULT_FROM_ADDRESS = 'default.from.address';
     public const DEFAULT_FROM_NAME = 'default.from.name';


### PR DESCRIPTION
The default request method of recaptcha is _post_. This uses the method `file_get_contents` to execute the request. This [might be blocked](https://stackoverflow.com/questions/55978690/recaptcha-error-code-connection-failed-on-verification).

This PR makes the request method configurable. The default is still _post_. However I changed it to curl in the default config file.

I also fixed the logging.