### PR TITLE
fix: handle no resources case in schedule

### DIFF
--- a/Pages/SchedulePage.php
+++ b/Pages/SchedulePage.php
@@ -283,6 +283,9 @@ class SchedulePage extends ActionPage implements ISchedulePage
 
         $user = ServiceLocator::GetServer()->GetUserSession();
 
+        // ensure Smarty $ResourceIds is an empty array to prevent an error if no
+        // resources. Will be overridden if there are resources.
+        $this->Set('ResourceIds', []);
         $this->_presenter->PageLoad($user);
 
         $endLoad = microtime(true);


### PR DESCRIPTION
The user would see "Unknown error" on the page. With this fix they now see the correct message of "You do not have permission to access one or more of the requested resources"

Had got this error in the log when the user did not have access to any resources:

```
  Uncaught exception: TypeError: implode(): Argument #1 ($array) must be of type array, string given in /var/www/librebooking/lib/Common/SmartyPage.php:907
  #0 /var/www/librebooking/lib/Common/SmartyPage.php(907): implode()
  #1 /var/www/librebooking/tpl_c/bdc8821f0b14313eaf56b1ea126646d5b4ea5097_0.file.schedule.tpl.php(506): SmartyPage->Implode()
  #2 /var/www/librebooking/vendor/smarty/smarty/libs/sysplugins/smarty_template_resource_base.php(123): content_669e13d3aee330_23010540()
  #3 /var/www/librebooking/vendor/smarty/smarty/libs/sysplugins/smarty_template_compiled.php(114): Smarty_Template_Resource_Base->getRenderedTemplateCode()
  #4 /var/www/librebooking/vendor/smarty/smarty/libs/sysplugins/smarty_internal_template.php(217): Smarty_Template_Compiled->render()
  #5 /var/www/librebooking/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatebase.php(238): Smarty_Internal_Template->render()
  #6 /var/www/librebooking/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatebase.php(134): Smarty_Internal_TemplateBase->_execute()
  #7 /var/www/librebooking/Pages/Page.php(375): Smarty_Internal_TemplateBase->display()
  #8 /var/www/librebooking/Pages/SchedulePage.php(317): Page->Display()
  #9 /var/www/librebooking/Pages/ActionPage.php(32): SchedulePage->ProcessPageLoad()
  #10 /var/www/librebooking/Pages/SecurePage.php(171): ActionPage->PageLoad()
  #11 /var/www/librebooking/Web/schedule.php(8): SecurePageDecorator->PageLoad()
  #12 {main}
```