### PR TITLE
fix: no delete reason when rejecting reservation

### DIFF
--- a/tpl/Reservation/approve.tpl
+++ b/tpl/Reservation/approve.tpl
@@ -43,7 +43,7 @@
                     <div>{translate key=DeleteReminderWarning}</div>
                     <div>
                         <label for="deleteReason">{translate key=Reason} ({translate key=Optional})</label>
-                        <textarea id="deleteReason" class="form-control"></textarea>
+                        <textarea id="deleteReason" class="deleteReason form-control"></textarea>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/tpl/Reservation/edit.tpl
+++ b/tpl/Reservation/edit.tpl
@@ -142,7 +142,7 @@
                 <div>{translate key=DeleteReminderWarning}</div>
                 <div>
                     <label for="deleteReason">{translate key=Reason} ({translate key=Optional})</label>
-                    <textarea class="deleteReason form-control"></textarea>
+                    <textarea id="deleteReason" class="deleteReason form-control"></textarea>
                 </div>
              </div>
             <div class="modal-footer">


### PR DESCRIPTION
Possibly connected with issue #265.

Currently, when administrator deletes a reservation, there is a pop-up form which allows to add a deletion reason which is sent as a notification.
The same form appears when admin wants to reject a pending reservation. But unlike deleting an approved appointment, the template for the text field misses a `deleteReason` class, which results in empty delete reason in notification e-mail.

This PR fixes that behaviour, making it work in both cases.