### PR TITLE
Resurrect unit tests

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -17,6 +17,39 @@ permissions:
   contents: read
 
 jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ["8.2", "8.3"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Set up PHP ${{ matrix.php-version }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - name: Install Composer dependencies
+        # Allow the previous check to fail but not abort
+        if: always()
+        uses: ramsey/composer-install@v2
+        with:
+          # Ignore zip for php-webdriver/webdriver
+          composer-options: "--ignore-platform-req=ext-zip"
+
+      - name: Create config.php for unit tests
+        run: cp config/config.dist.php config/config.php
+
+      - name: Unit Tests
+        run: composer phpunit
+
   lint-php-files:
     runs-on: ubuntu-latest
     strategy:
@@ -41,7 +74,7 @@ jobs:
         uses: ramsey/composer-install@v2
         with:
           # Ignore zip for php-webdriver/webdriver
-          composer-options: "--ignore-platform-req=ext-zip"
+          composer-options: "--ignore-platform-reqs"
 
       # TODO: Enable this after resolving issues
       # - name: Cache coding-standard

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@
 
 # php8 phpcompatibility report
 php8-report.log
+
+# phpunit cache
+.phpunit.cache/test-results

--- a/Domain/CreditCost.php
+++ b/Domain/CreditCost.php
@@ -6,6 +6,7 @@ use Booked\Currency;
 class CreditCost
 {
     /**
+     * Number of Credits for the given cost
      * @var int
      */
     private $count;

--- a/Pages/ResourceDisplayPage.php
+++ b/Pages/ResourceDisplayPage.php
@@ -72,6 +72,12 @@ interface IResourceDisplayPage extends IPage, IActionPage
     public function GetBeginTime();
 
     /**
+     *
+     * @return string
+     */
+    public function GetBeginDate();
+
+    /**
      * @return string
      */
     public function GetEndTime();
@@ -237,7 +243,7 @@ class ResourceDisplayPage extends ActionPage implements IResourceDisplayPage, IR
         }
         return $startDate;
     }
-    
+
     public function BindResource(BookableResource $resource)
     {
         $this->Set('ResourceName', $resource->GetName());

--- a/Presenters/ResourceDisplayPresenter.php
+++ b/Presenters/ResourceDisplayPresenter.php
@@ -248,7 +248,7 @@ class ResourceDisplayPresenter extends ActionPresenter
         $maxDate = Date::Now()->ToTimezone($timezone)->AddDays($maxFutureDays+1)->GetDate();
 
         $resultCollector = new ReservationResultCollector();
-        
+
         if ($date->GetBegin()->GreaterThan($maxDate)) {
             $resultCollector->SetSaveSuccessfulMessage(false);
             $resultCollector->SetErrors(["Unauthorized"]);

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,9 @@
         "build": "./tools/phing",
         "fix": "./tools/php-cs-fixer fix -v",
         "lint": "./tools/php-cs-fixer fix -vv --dry-run",
+        "phpunit": "./vendor/bin/phpunit",
         "test": [
-            "./vendor/bin/phpunit",
+            "@phpunit",
             "@lint"
         ],
         "sniffer:php8": "phpcs -p ./ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --report-full=./php8-report.log --ignore=./vendor/*,./tools/*,./.git/*,./tpl_c/*,./build/*,./.phpdoc/*,./var/*,./Web/scripts/*,./Web/css/* --runtime-set testVersion 8.0"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7.1",
         "phpcompatibility/php-compatibility": "^9.3.5",
-        "kint-php/kint": "^4.2.3"
+        "kint-php/kint": "^4.2.3",
+        "phpunit/phpunit": "^11.3"
     },
     "require": {
         "php": ">=8.1",
@@ -36,7 +37,7 @@
         "fix": "./tools/php-cs-fixer fix -v",
         "lint": "./tools/php-cs-fixer fix -vv --dry-run",
         "test": [
-            "./tools/phpunit",
+            "./vendor/bin/phpunit",
             "@lint"
         ],
         "sniffer:php8": "phpcs -p ./ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --report-full=./php8-report.log --ignore=./vendor/*,./tools/*,./.git/*,./tpl_c/*,./build/*,./.phpdoc/*,./var/*,./Web/scripts/*,./Web/css/* --runtime-set testVersion 8.0"

--- a/lib/Common/Date.php
+++ b/lib/Common/Date.php
@@ -510,7 +510,7 @@ class Date
      */
     public function AddHours($hours)
     {
-        return new Date($this->Format(self::SHORT_FORMAT) . " +" . $hours . " hours", $this->timezone);
+        return new Date($this->Format(self::SHORT_FORMAT) . $this->getOperator($hours) . abs($hours) . " hours", $this->timezone);
     }
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,73 +1,52 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- doc: https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <!-- manpage: https://manpages.debian.org/testing/phpunit/phpunit.1.en.html -->
-
-<phpunit bootstrap = "./tests/autoload.php"
-    backupGlobals               = "false"
-    backupStaticAttributes      = "false"
-    colors                      = "true"
-    convertErrorsToExceptions   = "true"
-    convertNoticesToExceptions  = "true"
-    convertWarningsToExceptions = "true"
-    processIsolation            = "false"
-    stopOnFailure               = "false"
-    cacheResultFile             = "./var/cache/.phpunit.result.cache"
-    verbose                     = "false"
-    defaultTestSuite            = "all"
->
-    <!-- organizing tests: https://phpunit.readthedocs.io/en/latest/organizing-tests.html -->
-    <testsuites>
-        <!-- https://phpunit.readthedocs.io/en/latest/configuration.html#the-testsuite-element -->
-        <!-- run only specificed tests: 'phpunit -_-filter [path/to/*Test.php / folder with tests]' -->
-        <!-- run only a specific testsuite: 'phpunit -_-testsuite <testsuite-name>' -->
-        <testsuite name="all">
-            <directory>./tests</directory>
-        </testsuite>
-
-        <testsuite name="application">
-            <directory>./tests/Application</directory>
-        </testsuite>
-
-        <testsuite name="domain">
-            <directory>./tests/Domain</directory>
-        </testsuite>
-
-        <testsuite name="plugins">
-            <directory>./tests/Plugins</directory>
-        </testsuite>
-
-        <testsuite name="presenters">
-            <directory>./tests/Presenters</directory>
-        </testsuite>
-
-        <testsuite name="webservice">
-            <directory>./tests/WebService</directory>
-        </testsuite>
-
-        <testsuite name="webservices">
-            <directory>./tests/WebServices</directory>
-        </testsuite>
-    </testsuites>
-
-<!--  to generate coverage report: phpunit -_-coverage-html ./var/ -->
-      <coverage cacheDirectory="./var/cache/phpunit">
-        <include>
-            <directory suffix=".php">Controls</directory>
-            <directory suffix=".php">Domain</directory>
-            <directory suffix=".php">Jobs</directory>
-            <directory suffix=".php">lib</directory>
-            <directory suffix=".php">Pages</directory>
-            <directory suffix=".php">Plugins</directory>
-            <directory suffix=".php">Presenters</directory>
-            <directory suffix=".php">Web</directory>
-            <directory suffix=".php">WebServices</directory>
-        </include>
-        <exclude>
-            <directory suffix=".php">lib/external</directory>
-        </exclude>
-    </coverage>
-
-    <php>
-        <env name="APP_ENV" value="testing"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" defaultTestSuite="all" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <!-- organizing tests: https://phpunit.readthedocs.io/en/latest/organizing-tests.html -->
+  <testsuites>
+    <!-- https://phpunit.readthedocs.io/en/latest/configuration.html#the-testsuite-element -->
+    <!-- run only specificed tests: 'phpunit -_-filter [path/to/*Test.php / folder with tests]' -->
+    <!-- run only a specific testsuite: 'phpunit -_-testsuite <testsuite-name>' -->
+    <testsuite name="all">
+      <directory>./tests</directory>
+    </testsuite>
+    <testsuite name="application">
+      <directory>./tests/Application</directory>
+    </testsuite>
+    <testsuite name="domain">
+      <directory>./tests/Domain</directory>
+    </testsuite>
+    <testsuite name="plugins">
+      <directory>./tests/Plugins</directory>
+    </testsuite>
+    <testsuite name="presenters">
+      <directory>./tests/Presenters</directory>
+    </testsuite>
+    <testsuite name="webservice">
+      <directory>./tests/WebService</directory>
+    </testsuite>
+    <testsuite name="webservices">
+      <directory>./tests/WebServices</directory>
+    </testsuite>
+  </testsuites>
+  <!--  to generate coverage report: phpunit -_-coverage-html ./var/ -->
+  <php>
+    <env name="APP_ENV" value="testing"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">Controls</directory>
+      <directory suffix=".php">Domain</directory>
+      <directory suffix=".php">Jobs</directory>
+      <directory suffix=".php">lib</directory>
+      <directory suffix=".php">Pages</directory>
+      <directory suffix=".php">Plugins</directory>
+      <directory suffix=".php">Presenters</directory>
+      <directory suffix=".php">Web</directory>
+      <directory suffix=".php">WebServices</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">lib/external</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/tests/Application/Admin/GroupAdminGroupsRepositoryTest.php
+++ b/tests/Application/Admin/GroupAdminGroupsRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
-class GroupAdminGroupsRepositoryTests extends TestBase
+class GroupAdminGroupsRepositoryTest extends TestBase
 {
     public function testGetsListOfGroupsThatThisUserCanAdminister()
     {

--- a/tests/Application/Admin/GroupAdminGroupsRepositoryTest.php
+++ b/tests/Application/Admin/GroupAdminGroupsRepositoryTest.php
@@ -16,7 +16,7 @@ class GroupAdminGroupsRepositoryTest extends TestBase
         $userRepo->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($this->fakeUser->UserId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $groupRepository = new GroupAdminGroupRepository($userRepo, $this->fakeUser);
 

--- a/tests/Application/Admin/GroupAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/GroupAdminManageReservationsServiceTest.php
@@ -19,7 +19,7 @@ class GroupAdminManageReservationsServiceTest extends TestBase
         $userRepo->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($this->fakeUser->UserId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $service = new GroupAdminManageReservationsService($reservationRepo, $userRepo, $reservationAuth, $handler, $persistenceService);
 

--- a/tests/Application/Admin/GroupAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/GroupAdminManageReservationsServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
-class GroupAdminManageReservationsServiceTests extends TestBase
+class GroupAdminManageReservationsServiceTest extends TestBase
 {
     public function testGetsListOfReservationsThatThisUserCanAdminister()
     {

--- a/tests/Application/Admin/ManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ManageReservationsServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
-class ManageReservationsServiceTests extends TestBase
+class ManageReservationsServiceTest extends TestBase
 {
     /**
      * @var IReservationViewRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Admin/ManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ManageReservationsServiceTest.php
@@ -58,7 +58,7 @@ class ManageReservationsServiceTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                 ->method('GetList')
                 ->with($pageNumber, $pageSize, null, null, $filter->GetFilter())
-                ->will($this->returnValue($data));
+                ->willReturn($data);
 
         $actualData = $this->service->LoadFiltered($pageNumber, $pageSize, null, null, $filter, $this->fakeUser);
 
@@ -74,12 +74,12 @@ class ManageReservationsServiceTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                     ->method('GetReservationForEditing')
                     ->with($this->equalTo($referenceNumber))
-                    ->will($this->returnValue($reservation));
+                    ->willReturn($reservation);
 
         $this->reservationAuthorization->expects($this->once())
                     ->method('CanEdit')
                     ->with($this->equalTo($reservation), $this->equalTo($user))
-                    ->will($this->returnValue(true));
+                    ->willReturn(true);
 
         $res = $this->service->LoadByReferenceNumber($referenceNumber, $user);
 
@@ -103,7 +103,7 @@ class ManageReservationsServiceTest extends TestBase
         $this->persistenceService->expects($this->once())
                     ->method('LoadByReferenceNumber')
                     ->with($this->equalTo($referenceNumber))
-                    ->will($this->returnValue($reservation));
+                    ->willReturn($reservation);
 
         $this->reservationHandler->expects($this->once())
                     ->method('Handle')

--- a/tests/Application/Admin/ResourceAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ResourceAdminManageReservationsServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
-class ResourceAdminManageReservationsServiceTests extends TestBase
+class ResourceAdminManageReservationsServiceTest extends TestBase
 {
     /**
      * @var IReservationViewRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Admin/ResourceAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ResourceAdminManageReservationsServiceTest.php
@@ -53,7 +53,7 @@ class ResourceAdminManageReservationsServiceTest extends TestBase
         $this->userRepository->expects($this->once())
                     ->method('LoadGroups')
                     ->with($this->equalTo($this->fakeUser->UserId), $this->equalTo(RoleLevel::RESOURCE_ADMIN))
-                    ->will($this->returnValue($groups));
+                    ->willReturn($groups);
 
         $filter = new ReservationFilter();
         $expectedFilter = $filter->GetFilter();
@@ -63,7 +63,7 @@ class ResourceAdminManageReservationsServiceTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                 ->method('GetList')
                 ->with($pageNumber, $pageSize, null, null, $expectedFilter)
-                ->will($this->returnValue($data));
+                ->willReturn($data);
 
         $actualData = $this->service->LoadFiltered($pageNumber, $pageSize, null, null, $filter, $this->fakeUser);
 

--- a/tests/Application/Admin/ResourceAdminResourceRepositoryTest.php
+++ b/tests/Application/Admin/ResourceAdminResourceRepositoryTest.php
@@ -1,11 +1,13 @@
 <?php
 
+use PHPUnit\Framework\MockObject\MockObject;
+
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
 class ResourceAdminResourceRepositoryTest extends TestBase
 {
     /**
-     * @var IUserRepository|PHPUnit_Framework_MockObject_MockObject
+     * @var IUserRepository|MockObject
      */
     private $userRepository;
 
@@ -21,20 +23,19 @@ class ResourceAdminResourceRepositoryTest extends TestBase
         $this->userRepository->expects($this->once())
                         ->method('LoadById')
                         ->with($this->equalTo($this->fakeUser->UserId))
-                        ->will($this->returnValue($user));
+                        ->willReturn($user);
 
         $ra = new FakeResourceAccess();
-        $this->db->SetRows($ra->GetRows());
+        $this->db->SetRows($ra->Rows());
 
-        $user->expects($this->at(0))
+        $user->expects($this->exactly(2))
                     ->method('IsResourceAdminFor')
-                    ->with($this->equalTo($ra->_Resources[0]))
-                    ->will($this->returnValue(false));
-
-        $user->expects($this->at(1))
-                    ->method('IsResourceAdminFor')
-                    ->with($this->equalTo($ra->_Resources[1]))
-                    ->will($this->returnValue(true));
+                    ->willReturnCallback(function ($resource) use ($ra)
+                    {
+                        return $this
+                            ->equalTo($ra->_Resources[1])
+                            ->evaluate($resource, '', true);
+                    });
 
         $repo = new ResourceAdminResourceRepository($this->userRepository, $this->fakeUser);
         $resources = $repo->GetResourceList();
@@ -58,7 +59,7 @@ class ResourceAdminResourceRepositoryTest extends TestBase
         $this->userRepository->expects($this->once())
                     ->method('LoadGroups')
                     ->with($this->equalTo($this->fakeUser->UserId), $this->equalTo([RoleLevel::SCHEDULE_ADMIN, RoleLevel::RESOURCE_ADMIN]))
-                    ->will($this->returnValue($groups));
+                    ->willReturn($groups);
 
         $repo = new ResourceAdminResourceRepository($this->userRepository, $this->fakeUser);
         $repo->GetList($pageNum, $pageSize, null, null, $existingFilter);
@@ -78,16 +79,16 @@ class ResourceAdminResourceRepositoryTest extends TestBase
         $this->userRepository->expects($this->once())
                         ->method('LoadById')
                         ->with($this->equalTo($this->fakeUser->UserId))
-                        ->will($this->returnValue($user));
+                        ->willReturn($user);
 
         $repo = new ResourceAdminResourceRepository($this->userRepository, $this->fakeUser);
         $resource = new FakeBookableResource(1);
         $resource->SetAdminGroupId(2);
 
-        $user->expects($this->at(0))
+        $user->expects($this->once())
                             ->method('IsResourceAdminFor')
                             ->with($this->equalTo($resource))
-                            ->will($this->returnValue(false));
+                            ->willReturn(false);
 
         $actualEx = null;
         try {
@@ -105,20 +106,19 @@ class ResourceAdminResourceRepositoryTest extends TestBase
         $this->userRepository->expects($this->once())
                         ->method('LoadById')
                         ->with($this->equalTo($this->fakeUser->UserId))
-                        ->will($this->returnValue($user));
+                        ->willReturn($user);
 
         $ra = new FakeResourceAccess();
-        $this->db->SetRows($ra->GetRows());
+        $this->db->SetRows($ra->Rows());
 
-        $user->expects($this->at(0))
+        $user->expects($this->exactly(2))
                     ->method('IsResourceAdminFor')
-                    ->with($this->equalTo($ra->_Resources[0]))
-                    ->will($this->returnValue(false));
-
-        $user->expects($this->at(1))
-                    ->method('IsResourceAdminFor')
-                    ->with($this->equalTo($ra->_Resources[1]))
-                    ->will($this->returnValue(true));
+                    ->willReturnCallback(function ($resource) use ($ra)
+                    {
+                        return $this
+                            ->equalTo($ra->_Resources[1])
+                            ->evaluate($resource, '', true);
+                    });
 
         $repo = new ResourceAdminResourceRepository($this->userRepository, $this->fakeUser);
         $resources = $repo->GetScheduleResources($scheduleId);

--- a/tests/Application/Admin/ResourceAdminResourceRepositoryTest.php
+++ b/tests/Application/Admin/ResourceAdminResourceRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
-class ResourceAdminResourceRepositoryTests extends TestBase
+class ResourceAdminResourceRepositoryTest extends TestBase
 {
     /**
      * @var IUserRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Admin/ScheduleAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ScheduleAdminManageReservationsServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
-class ScheduleAdminManageReservationsServiceTests extends TestBase
+class ScheduleAdminManageReservationsServiceTest extends TestBase
 {
     /**
      * @var IReservationViewRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Admin/ScheduleAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ScheduleAdminManageReservationsServiceTest.php
@@ -53,7 +53,7 @@ class ScheduleAdminManageReservationsServiceTest extends TestBase
         $this->userRepository->expects($this->once())
                     ->method('LoadGroups')
                     ->with($this->equalTo($this->fakeUser->UserId), $this->equalTo(RoleLevel::SCHEDULE_ADMIN))
-                    ->will($this->returnValue($groups));
+                    ->willReturn($groups);
 
         $filter = new ReservationFilter();
         $expectedFilter = $filter->GetFilter();
@@ -63,7 +63,7 @@ class ScheduleAdminManageReservationsServiceTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                 ->method('GetList')
                 ->with($pageNumber, $pageSize, null, null, $expectedFilter)
-                ->will($this->returnValue($data));
+                ->willReturn($data);
 
         $actualData = $this->service->LoadFiltered($pageNumber, $pageSize, null, null, $filter, $this->fakeUser);
 

--- a/tests/Application/Admin/ScheduleAdminScheduleRepositoryTest.php
+++ b/tests/Application/Admin/ScheduleAdminScheduleRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
-class ScheduleAdminScheduleRepositoryTests extends TestBase
+class ScheduleAdminScheduleRepositoryTest extends TestBase
 {
     /**
      * @var IUserRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Admin/ScheduleAdminScheduleRepositoryTest.php
+++ b/tests/Application/Admin/ScheduleAdminScheduleRepositoryTest.php
@@ -34,20 +34,19 @@ class ScheduleAdminScheduleRepositoryTest extends TestBase
         $this->userRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($this->fakeUser->UserId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $ra = new FakeScheduleRepository();
         $this->db->SetRows($ra->GetRows());
 
-        $user->expects($this->at(0))
+        $user->expects($this->exactly(2))
                 ->method('IsScheduleAdminFor')
-                ->with($this->equalTo($ra->_AllRows[0]))
-                ->will($this->returnValue(false));
-
-        $user->expects($this->at(1))
-                ->method('IsScheduleAdminFor')
-                ->with($this->equalTo($ra->_AllRows[1]))
-                ->will($this->returnValue(true));
+                ->willReturnCallback(function ($schedule) use ($ra)
+                {
+                    return $this
+                        ->equalTo($ra->_AllRows[1])
+                        ->evaluate($schedule, '', true);
+                });
 
         $schedules = $this->repo->GetAll();
 
@@ -62,15 +61,14 @@ class ScheduleAdminScheduleRepositoryTest extends TestBase
         $this->userRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($this->fakeUser->UserId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $schedule = new FakeSchedule(1);
         $schedule->SetAdminGroupId(2);
 
-        $user->expects($this->at(0))
+        $user->expects($this->atLeastOnce())
                 ->method('IsScheduleAdminFor')
-                ->with($this->equalTo($schedule))
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
         $actualEx = null;
         try {

--- a/tests/Application/Attributes/AttributeListTest.php
+++ b/tests/Application/Attributes/AttributeListTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Attributes/namespace.php');
 
-class AttributeListTests extends TestBase
+class AttributeListTest extends TestBase
 {
     public function testCanGetLabelsOfAllAttributes()
     {

--- a/tests/Application/Attributes/AttributeServiceTest.php
+++ b/tests/Application/Attributes/AttributeServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Attributes/namespace.php');
 
-class AttributeServiceTests extends TestBase
+class AttributeServiceTest extends TestBase
 {
     /**
      * @var AttributeService

--- a/tests/Application/Attributes/AttributeValidatorTest.php
+++ b/tests/Application/Attributes/AttributeValidatorTest.php
@@ -18,7 +18,7 @@ class AttributeValidatorTest extends TestBase
         $service->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo($category), $this->equalTo($attributes), $this->equalTo($entityId))
-                ->will($this->returnValue($serviceResult));
+                ->willReturn($serviceResult);
 
         $validator = new AttributeValidator($service, $category, $attributes, $entityId);
         $validator->Validate();

--- a/tests/Application/Attributes/AttributeValidatorTest.php
+++ b/tests/Application/Attributes/AttributeValidatorTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Attributes/namespace.php');
 
-class AttributeValidatorTests extends TestBase
+class AttributeValidatorTest extends TestBase
 {
     public function testChecksAttributesAgainstService()
     {

--- a/tests/Application/Authentication/AccountActivationTest.php
+++ b/tests/Application/Authentication/AccountActivationTest.php
@@ -51,7 +51,7 @@ class AccountActivationTest extends TestBase
         $this->activationRepo->expects($this->once())
                 ->method('FindUserIdByCode')
                 ->with($this->equalTo($activationCode))
-                ->will($this->returnValue($userId));
+                ->willReturn($userId);
 
         $this->activationRepo->expects($this->once())
                 ->method('DeleteActivation')
@@ -60,7 +60,7 @@ class AccountActivationTest extends TestBase
         $this->userRepo->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($userId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $this->userRepo->expects($this->once())
                 ->method('Update')
@@ -80,7 +80,7 @@ class AccountActivationTest extends TestBase
         $this->activationRepo->expects($this->once())
                 ->method('FindUserIdByCode')
                 ->with($this->equalTo($activationCode))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $result = $this->activation->Activate($activationCode);
 

--- a/tests/Application/Authentication/AccountActivationTest.php
+++ b/tests/Application/Authentication/AccountActivationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class AccountActivationTests extends TestBase
+class AccountActivationTest extends TestBase
 {
     /**
      * @var IAccountActivationRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Authentication/AuthenticationTest.php
+++ b/tests/Application/Authentication/AuthenticationTest.php
@@ -137,7 +137,7 @@ class AuthenticationTest extends TestBase
         $this->userRepository->expects($this->once())
                 ->method('LoadByUsername')
                 ->with($this->equalTo($this->username))
-                ->will($this->returnValue($this->user));
+                ->willReturn($this->user);
 
         LoginTime::$Now = time();
 
@@ -150,22 +150,22 @@ class AuthenticationTest extends TestBase
         $this->authorization->expects($this->once())
                 ->method('IsApplicationAdministrator')
                 ->with($this->equalTo($this->user))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->authorization->expects($this->once())
                 ->method('IsGroupAdministrator')
                 ->with($this->equalTo($this->user))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->authorization->expects($this->once())
                 ->method('IsResourceAdministrator')
                 ->with($this->equalTo($this->user))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->authorization->expects($this->once())
                 ->method('IsScheduleAdministrator')
                 ->with($this->equalTo($this->user))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $context = new WebLoginContext(new LoginData(false, $language));
         $actualSession = $this->auth->Login($this->username, $context);

--- a/tests/Application/Authentication/AuthenticationTest.php
+++ b/tests/Application/Authentication/AuthenticationTest.php
@@ -6,7 +6,7 @@ require_once(ROOT_DIR . 'lib/Server/namespace.php');
 require_once(ROOT_DIR . 'lib/Config/namespace.php');
 
 
-class AuthenticationTests extends TestBase
+class AuthenticationTest extends TestBase
 {
     private $username;
     private $password;

--- a/tests/Application/Authentication/GuestUserServiceTest.php
+++ b/tests/Application/Authentication/GuestUserServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Authentication/GuestUserService.php');
 
-class GuestUserServiceTests extends TestBase
+class GuestUserServiceTest extends TestBase
 {
     /**
      * @var FakeAuthentication

--- a/tests/Application/Authentication/PasswordEncryptionTest.php
+++ b/tests/Application/Authentication/PasswordEncryptionTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 
-class PasswordEncryptionTests extends TestBase
+class PasswordEncryptionTest extends TestBase
 {
     public function testGeneratesSaltAndHashesPassword()
     {

--- a/tests/Application/Authentication/PasswordMigrationTest.php
+++ b/tests/Application/Authentication/PasswordMigrationTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
-class PasswordMigrationTests extends TestBase
+class PasswordMigrationTest extends TestBase
 {
     /**
      * @var FakeDatabase

--- a/tests/Application/Authentication/PostRegistrationTest.php
+++ b/tests/Application/Authentication/PostRegistrationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class PostRegistrationTests extends TestBase
+class PostRegistrationTest extends TestBase
 {
     /**
      * @var FakeRegistrationPage

--- a/tests/Application/Authentication/RegistrationTest.php
+++ b/tests/Application/Authentication/RegistrationTest.php
@@ -197,7 +197,7 @@ class RegistrationTest extends TestBase
         $this->userRepository->expects($this->once())
             ->method('Add')
             ->with($this->anything())
-            ->will($this->returnValue($expectedUserId));
+            ->willReturn($expectedUserId);
 
         $this->registration->Register(
             $this->login,
@@ -282,17 +282,17 @@ class RegistrationTest extends TestBase
         $this->userRepository->expects($this->once())
             ->method('UserExists')
             ->with($this->equalTo($email), $this->equalTo($username))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->userRepository->expects($this->once())
             ->method('LoadByUsername')
             ->with($this->equalTo($username))
-            ->will($this->returnValue($updatedUser));
+            ->willReturn($updatedUser);
 
         $this->userRepository->expects($this->once())
             ->method('Update')
             ->with($this->equalTo($updatedUser))
-            ->will($this->returnValue($updatedUser));
+            ->willReturn($updatedUser);
 
         $user = new AuthenticatedUser($username, $email, $fname, $lname, 'password', 'en_US', 'UTC', $phone, $inst, $title, ['1', '2']);
         $expectedCommand = new UpdateUserFromLdapCommand($username, $email, $fname, $lname, $encryptedPassword, $salt, $phone, $inst, $title);
@@ -342,7 +342,7 @@ class RegistrationTest extends TestBase
         $this->userRepository->expects($this->once())
             ->method('UserExists')
             ->with($this->equalTo($email), $this->equalTo($username))
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->userRepository->expects($this->once())
             ->method('Add')

--- a/tests/Application/Authentication/RegistrationTest.php
+++ b/tests/Application/Authentication/RegistrationTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 
-class RegistrationTests extends TestBase
+class RegistrationTest extends TestBase
 {
     /**
      * @var Registration

--- a/tests/Application/Authentication/WebAuthenticationTest.php
+++ b/tests/Application/Authentication/WebAuthenticationTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 
-class WebAuthenticationTests extends TestBase
+class WebAuthenticationTest extends TestBase
 {
     /**
      * @var WebLoginContext

--- a/tests/Application/Authentication/WebServiceAuthenticationTest.php
+++ b/tests/Application/Authentication/WebServiceAuthenticationTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 
-class WebServiceAuthenticationTests extends TestBase
+class WebServiceAuthenticationTest extends TestBase
 {
     /**
      * @var FakeAuth

--- a/tests/Application/Authentication/WebServiceAuthenticationTest.php
+++ b/tests/Application/Authentication/WebServiceAuthenticationTest.php
@@ -54,7 +54,7 @@ class WebServiceAuthenticationTest extends TestBase
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($expectedSession->SessionToken))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('Add')
@@ -74,7 +74,7 @@ class WebServiceAuthenticationTest extends TestBase
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($expectedSession->SessionToken))
-                ->will($this->returnValue(new WebServiceUserSession(123)));
+                ->willReturn(new WebServiceUserSession(123));
 
         $this->userSessionRepository->expects($this->once())
                 ->method('Update')
@@ -96,7 +96,7 @@ class WebServiceAuthenticationTest extends TestBase
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($sessionToken))
-                ->will($this->returnValue($userSession));
+                ->willReturn($userSession);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('Delete')
@@ -117,7 +117,7 @@ class WebServiceAuthenticationTest extends TestBase
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($sessionToken))
-                ->will($this->returnValue($userSession));
+                ->willReturn($userSession);
 
         $this->webAuth->Logout($userId, $sessionToken);
 

--- a/tests/Application/Authorization/AuthorizationServiceTest.php
+++ b/tests/Application/Authorization/AuthorizationServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Authorization/namespace.php');
 
-class AuthorizationServiceTests extends TestBase
+class AuthorizationServiceTest extends TestBase
 {
     /**
      * @var AuthorizationService

--- a/tests/Application/Authorization/AuthorizationServiceTest.php
+++ b/tests/Application/Authorization/AuthorizationServiceTest.php
@@ -34,21 +34,16 @@ class AuthorizationServiceTest extends TestBase
 
         $groupAdmin->expects($this->once())
                 ->method('IsGroupAdmin')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $normalDude->expects($this->once())
                 ->method('IsGroupAdmin')
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(2))
                 ->method('LoadById')
                 ->with($this->equalTo($userId))
-                ->will($this->returnValue($groupAdmin));
-
-        $this->userRepository->expects($this->at(1))
-                ->method('LoadById')
-                ->with($this->equalTo($userId))
-                ->will($this->returnValue($normalDude));
+                ->willReturn($groupAdmin, $normalDude);
 
         $asAdmin = $this->authorizationService->CanReserveForOthers($adminUser);
         $asGroupAdmin = $this->authorizationService->CanReserveForOthers($user);
@@ -73,36 +68,19 @@ class AuthorizationServiceTest extends TestBase
         $reserveForUser = $this->createMock('User');
 
         // group admin
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(4))
                 ->method('LoadById')
-                ->with($this->equalTo($userId))
-                ->will($this->returnValue($groupAdmin));
-
-        $this->userRepository->expects($this->at(1))
-                ->method('LoadById')
-                ->with($this->equalTo($reserveForId))
-                ->will($this->returnValue($reserveForUser));
+                ->willReturn($groupAdmin, $reserveForUser, $normalDude, $reserveForUser);
 
         $groupAdmin->expects($this->once())
                 ->method('IsAdminFor')
                 ->with($this->equalTo($reserveForUser))
-                ->will($this->returnValue(true));
-
-        // normal dude
-        $this->userRepository->expects($this->at(2))
-                ->method('LoadById')
-                ->with($this->equalTo($userId))
-                ->will($this->returnValue($normalDude));
-
-        $this->userRepository->expects($this->at(3))
-                ->method('LoadById')
-                ->with($this->equalTo($reserveForId))
-                ->will($this->returnValue($reserveForUser));
+                ->willReturn(true);
 
         $normalDude->expects($this->once())
                 ->method('IsAdminFor')
                 ->with($this->equalTo($reserveForUser))
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
         $asAdmin = $this->authorizationService->CanReserveFor($adminUser, $reserveForId);
         $asGroupAdmin = $this->authorizationService->CanReserveFor($user, $reserveForId);
@@ -128,36 +106,20 @@ class AuthorizationServiceTest extends TestBase
         $reserveForUser = $this->createMock('User');
 
         // group admin
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(4))
                 ->method('LoadById')
-                ->with($this->equalTo($userId))
-                ->will($this->returnValue($groupAdmin));
-
-        $this->userRepository->expects($this->at(1))
-                ->method('LoadById')
-                ->with($this->equalTo($reserveForId))
-                ->will($this->returnValue($reserveForUser));
+                ->willReturn($groupAdmin, $reserveForUser, $normalDude, $reserveForUser);
 
         $groupAdmin->expects($this->once())
                 ->method('IsAdminFor')
                 ->with($this->equalTo($reserveForUser))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         // normal dude
-        $this->userRepository->expects($this->at(2))
-                ->method('LoadById')
-                ->with($this->equalTo($userId))
-                ->will($this->returnValue($normalDude));
-
-        $this->userRepository->expects($this->at(3))
-                ->method('LoadById')
-                ->with($this->equalTo($reserveForId))
-                ->will($this->returnValue($reserveForUser));
-
         $normalDude->expects($this->once())
                 ->method('IsAdminFor')
                 ->with($this->equalTo($reserveForUser))
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
         $asAdmin = $this->authorizationService->CanApproveFor($adminUser, $reserveForId);
         $asGroupAdmin = $this->authorizationService->CanApproveFor($user, $reserveForId);
@@ -244,15 +206,15 @@ class AuthorizationServiceTest extends TestBase
         $groupAdmin = $this->createMock('User');
         $resource = $this->createMock('IResource');
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($userId))
-                ->will($this->returnValue($groupAdmin));
+                ->willReturn($groupAdmin);
 
         $groupAdmin->expects($this->once())
                 ->method('IsResourceAdminFor')
                 ->with($this->equalTo($resource))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $canEdit = $this->authorizationService->CanEditForResource($userSession, $resource);
 
@@ -268,15 +230,15 @@ class AuthorizationServiceTest extends TestBase
         $groupAdmin = $this->createMock('User');
         $resource = $this->createMock('IResource');
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($userId))
-                ->will($this->returnValue($groupAdmin));
+                ->willReturn($groupAdmin);
 
         $groupAdmin->expects($this->once())
                 ->method('IsResourceAdminFor')
                 ->with($this->equalTo($resource))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $canApprove = $this->authorizationService->CanApproveForResource($userSession, $resource);
 

--- a/tests/Application/Authorization/PrivacyFilterTest.php
+++ b/tests/Application/Authorization/PrivacyFilterTest.php
@@ -79,7 +79,7 @@ class PrivacyFilterTest extends TestBase
         $this->reservationAuthorization->expects($this->once())
                                        ->method('CanViewDetails')
                                        ->with($this->equalTo($reservation), $this->equalTo($user))
-                                       ->will($this->returnValue(true));
+                                       ->willReturn(true);
 
         $canView = $this->privacyFilter->CanViewUser($user, $reservation);
         $canView2 = $this->privacyFilter->CanViewUser($user, $reservation);
@@ -144,7 +144,7 @@ class PrivacyFilterTest extends TestBase
         $this->reservationAuthorization->expects($this->once())
                                        ->method('CanViewDetails')
                                        ->with($this->equalTo($reservation), $this->equalTo($user))
-                                       ->will($this->returnValue(true));
+                                       ->willReturn(true);
 
         $canView = $this->privacyFilter->CanViewDetails($user, $reservation);
         $canView2 = $this->privacyFilter->CanViewDetails($user, $reservation);
@@ -165,7 +165,7 @@ class PrivacyFilterTest extends TestBase
         $this->reservationAuthorization->expects($this->once())
                                        ->method('CanViewDetails')
                                        ->with($this->equalTo($res), $this->equalTo($user))
-                                       ->will($this->returnValue(false));
+                                       ->willReturn(false);
 
         $canView = $this->privacyFilter->CanViewDetails($user, $res);
 
@@ -184,7 +184,7 @@ class PrivacyFilterTest extends TestBase
         $this->reservationAuthorization->expects($this->once())
                                        ->method('CanViewDetails')
                                        ->with($this->equalTo($res), $this->equalTo($user))
-                                       ->will($this->returnValue(false));
+                                       ->willReturn(false);
 
         $canView = $this->privacyFilter->CanViewDetails($user, $res);
 

--- a/tests/Application/Authorization/PrivacyFilterTest.php
+++ b/tests/Application/Authorization/PrivacyFilterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class PrivacyFilterTests extends TestBase
+class PrivacyFilterTest extends TestBase
 {
     /**
      * @var PrivacyFilter

--- a/tests/Application/Reporting/CannedReportTest.php
+++ b/tests/Application/Reporting/CannedReportTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class CannedReportTests extends TestBase
+class CannedReportTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reporting/Report_RangeTest.php
+++ b/tests/Application/Reporting/Report_RangeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class Report_RangeTests extends TestBase
+class Report_RangeTest extends TestBase
 {
     /**
      * @var Date

--- a/tests/Application/Reporting/ReportingServiceTest.php
+++ b/tests/Application/Reporting/ReportingServiceTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Application/Reporting/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class ReportingServiceTests extends TestBase
+class ReportingServiceTest extends TestBase
 {
     /**
      * @var ReportingService

--- a/tests/Application/Reservation/AccessoryAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/AccessoryAvailabilityRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class AccessoryAvailabilityRuleTests extends TestBase
+class AccessoryAvailabilityRuleTest extends TestBase
 {
     /**
      * @var IReservationViewRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Reservation/AccessoryResourceRuleTest.php
+++ b/tests/Application/Reservation/AccessoryResourceRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class AccessoryResourceRuleTests extends TestBase
+class AccessoryResourceRuleTest extends TestBase
 {
     /**
      * @var FakeAccessoryRepository

--- a/tests/Application/Reservation/AdminEmailNotificationTest.php
+++ b/tests/Application/Reservation/AdminEmailNotificationTest.php
@@ -47,21 +47,21 @@ class AdminEmailNotificationTest extends TestBase
         $userRepo->expects($this->once())
                  ->method('LoadById')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
+                 ->willReturn($owner);
 
         $userRepo->expects($this->once())
                  ->method('GetResourceAdmins')
                  ->with($this->equalTo($resourceId))
-                 ->will($this->returnValue($resourceAdmins));
+                 ->willReturn($resourceAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetApplicationAdmins')
-                 ->will($this->returnValue($appAdmins));
+                 ->willReturn($appAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetGroupAdmins')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($groupAdmins));
+                 ->willReturn($groupAdmins);
 
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_CREATE_RESOURCE_ADMINS);
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_CREATE_APPLICATION_ADMINS);
@@ -107,21 +107,21 @@ class AdminEmailNotificationTest extends TestBase
         $userRepo->expects($this->once())
                  ->method('LoadById')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
+                 ->willReturn($owner);
 
         $userRepo->expects($this->once())
                  ->method('GetResourceAdmins')
                  ->with($this->equalTo($resourceId))
-                 ->will($this->returnValue($resourceAdmins));
+                 ->willReturn($resourceAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetApplicationAdmins')
-                 ->will($this->returnValue($appAdmins));
+                 ->willReturn($appAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetGroupAdmins')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($groupAdmins));
+                 ->willReturn($groupAdmins);
 
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_UPDATE_RESOURCE_ADMINS);
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_UPDATE_APPLICATION_ADMINS);
@@ -168,21 +168,21 @@ class AdminEmailNotificationTest extends TestBase
         $userRepo->expects($this->once())
                  ->method('LoadById')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
+                 ->willReturn($owner);
 
         $userRepo->expects($this->once())
                  ->method('GetResourceAdmins')
                  ->with($this->equalTo($resourceId))
-                 ->will($this->returnValue($resourceAdmins));
+                 ->willReturn($resourceAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetApplicationAdmins')
-                 ->will($this->returnValue($appAdmins));
+                 ->willReturn($appAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetGroupAdmins')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($groupAdmins));
+                 ->willReturn($groupAdmins);
 
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_APPROVAL_RESOURCE_ADMINS);
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_APPROVAL_APPLICATION_ADMINS);
@@ -254,21 +254,21 @@ class AdminEmailNotificationTest extends TestBase
         $userRepo->expects($this->once())
                  ->method('LoadById')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
+                 ->willReturn($owner);
 
         $userRepo->expects($this->once())
                  ->method('GetResourceAdmins')
                  ->with($this->equalTo($resourceId))
-                 ->will($this->returnValue($resourceAdmins));
+                 ->willReturn($resourceAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetApplicationAdmins')
-                 ->will($this->returnValue($appAdmins));
+                 ->willReturn($appAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetGroupAdmins')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($groupAdmins));
+                 ->willReturn($groupAdmins);
 
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_APPROVAL_RESOURCE_ADMINS);
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_APPROVAL_APPLICATION_ADMINS);
@@ -314,21 +314,21 @@ class AdminEmailNotificationTest extends TestBase
         $userRepo->expects($this->once())
                  ->method('LoadById')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
+                 ->willReturn($owner);
 
         $userRepo->expects($this->once())
                  ->method('GetResourceAdmins')
                  ->with($this->equalTo($resourceId))
-                 ->will($this->returnValue($resourceAdmins));
+                 ->willReturn($resourceAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetApplicationAdmins')
-                 ->will($this->returnValue($appAdmins));
+                 ->willReturn($appAdmins);
 
         $userRepo->expects($this->once())
                  ->method('GetGroupAdmins')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($groupAdmins));
+                 ->willReturn($groupAdmins);
 
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_DELETE_RESOURCE_ADMINS);
         $this->EnableNotifyFor(ConfigKeys::NOTIFY_DELETE_APPLICATION_ADMINS);

--- a/tests/Application/Reservation/AdminEmailNotificationTest.php
+++ b/tests/Application/Reservation/AdminEmailNotificationTest.php
@@ -6,7 +6,7 @@ require_once(ROOT_DIR . 'lib/Email/Messages/ReservationUpdatedEmailAdmin.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 
-class AdminEmailNotificationTests extends TestBase
+class AdminEmailNotificationTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/AdminExcludedRuleTest.php
+++ b/tests/Application/Reservation/AdminExcludedRuleTest.php
@@ -65,17 +65,11 @@ class AdminExcludedRuleTest extends TestBase
         $this->userRepository->expects($this->once())
                     ->method('LoadById')
                     ->with($this->equalTo($this->fakeUser->UserId))
-                    ->will($this->returnValue($this->user));
+                    ->willReturn($this->user);
 
-        $this->user->expects($this->at(0))
+        $this->user->expects($this->exactly(2))
                     ->method('IsResourceAdminFor')
-                    ->with($this->equalTo($this->resource1))
-                    ->will($this->returnValue(true));
-
-        $this->user->expects($this->at(1))
-                    ->method('IsResourceAdminFor')
-                    ->with($this->equalTo($this->resource2))
-                    ->will($this->returnValue(true));
+                    ->willReturn(true);
 
         $result = $this->rule->Validate($this->reservationSeries, null);
 
@@ -90,22 +84,18 @@ class AdminExcludedRuleTest extends TestBase
         $this->userRepository->expects($this->once())
                     ->method('LoadById')
                     ->with($this->equalTo($this->fakeUser->UserId))
-                    ->will($this->returnValue($this->user));
+                    ->willReturn($this->user);
 
-        $this->user->expects($this->at(0))
+        $this->user->expects($this->exactly(2))
                     ->method('IsResourceAdminFor')
-                    ->with($this->equalTo($this->resource1))
-                    ->will($this->returnValue(true));
-
-        $this->user->expects($this->at(1))
-                    ->method('IsResourceAdminFor')
-                    ->with($this->equalTo($this->resource2))
-                    ->will($this->returnValue(false));
+                    ->willReturnCallback(function ($resource) {
+                        return $this->equalTo($this->resource1)->evaluate($resource, '', true);
+                    });
 
         $this->baseRule->expects($this->once())
                     ->method('Validate')
                     ->with($this->equalTo($this->reservationSeries))
-                    ->will($this->returnValue($expectedResult));
+                    ->willReturn($expectedResult);
 
         $result = $this->rule->Validate($this->reservationSeries, null);
 
@@ -120,20 +110,17 @@ class AdminExcludedRuleTest extends TestBase
         $adminUser =  $this->createMock('User');
         $reservationUser =  $this->createMock('User');
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(2))
                             ->method('LoadById')
-                            ->with($this->equalTo($this->fakeUser->UserId))
-                            ->will($this->returnValue($adminUser));
-
-        $this->userRepository->expects($this->at(1))
-                            ->method('LoadById')
-                            ->with($this->equalTo($this->reservationSeries->UserId()))
-                            ->will($this->returnValue($reservationUser));
+                            ->willReturnMap([
+                                [$this->fakeUser->UserId, $adminUser],
+                                [$this->reservationSeries->UserId(), $reservationUser]
+                            ]);
 
         $adminUser->expects($this->once())
                     ->method('IsAdminFor')
                     ->with($this->equalTo($reservationUser))
-                    ->will($this->returnValue(true));
+                    ->willReturn(true);
 
         $result = $this->rule->Validate($this->reservationSeries, null);
 

--- a/tests/Application/Reservation/AdminExcludedRuleTest.php
+++ b/tests/Application/Reservation/AdminExcludedRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class AdminExcludedRuleTests extends TestBase
+class AdminExcludedRuleTest extends TestBase
 {
     /**
      * @var AdminExcludedRule

--- a/tests/Application/Reservation/AttachmentExtensionTest.php
+++ b/tests/Application/Reservation/AttachmentExtensionTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class AttachmentExtensionTests extends TestBase
+class AttachmentExtensionTest extends TestBase
 {
     /**
      * @var ReservationAttachmentRule

--- a/tests/Application/Reservation/BlackoutsServiceTest.php
+++ b/tests/Application/Reservation/BlackoutsServiceTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/ManageBlackoutsService.php');
 
-class BlackoutsServiceTests extends TestBase
+class BlackoutsServiceTest extends TestBase
 {
     /**
      * @var ManageBlackoutsService

--- a/tests/Application/Reservation/CreditsRuleTest.php
+++ b/tests/Application/Reservation/CreditsRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class CreditsRuleTests extends TestBase
+class CreditsRuleTest extends TestBase
 {
     /**
      * @var FakeUserRepository

--- a/tests/Application/Reservation/CustomAttributeValidationRuleTest.php
+++ b/tests/Application/Reservation/CustomAttributeValidationRuleTest.php
@@ -52,17 +52,14 @@ class CustomAttributeValidationRuleTest extends TestBase
         $this->bookedBy->_IsResourceAdmin = false;
         $this->bookedBy->_SetIsAdminForUser(false);
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(2))
                              ->method('LoadById')
-                             ->with($this->equalTo($this->reservation->UserId()))
-                             ->will($this->returnValue($this->user));
+                             ->willReturnMap([
+                                [$this->reservation->UserId(), $this->user],
+                                [$this->reservation->BookedBy()->UserId, $this->bookedBy]
+                             ]);
 
-        $this->userRepository->expects($this->at(1))
-                             ->method('LoadById')
-                             ->with($this->equalTo($this->reservation->BookedBy()->UserId))
-                             ->will($this->returnValue($this->bookedBy));
-
-        $this->rule = $rule = new CustomAttributeValidationRule($this->attributeService, $this->userRepository);
+        $this->rule = new CustomAttributeValidationRule($this->attributeService, $this->userRepository);
     }
 
     public function teardown(): void
@@ -81,7 +78,7 @@ class CustomAttributeValidationRuleTest extends TestBase
         $this->attributeService->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo(CustomAttributeCategory::RESERVATION), $this->equalTo($this->reservation->AttributeValues()), $this->equalTo([]), $this->isFalse(), $this->isFalse())
-                ->will($this->returnValue($validationResult));
+                ->willReturn($validationResult);
 
         $userAttribute = new FakeCustomAttribute();
         $userAttribute->WithSecondaryEntities(CustomAttributeCategory::USER, 123);
@@ -101,7 +98,7 @@ class CustomAttributeValidationRuleTest extends TestBase
         $this->attributeService->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo(CustomAttributeCategory::RESERVATION), $this->equalTo($this->reservation->AttributeValues()), $this->equalTo([]), $this->isFalse(), $this->isFalse())
-                ->will($this->returnValue($validationResult));
+                ->willReturn($validationResult);
 
         $result = $this->rule->Validate($this->reservation, null);
 
@@ -116,7 +113,7 @@ class CustomAttributeValidationRuleTest extends TestBase
         $this->attributeService->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo(CustomAttributeCategory::RESERVATION), $this->equalTo($this->reservation->AttributeValues()), $this->equalTo([]), $this->isFalse(), $this->isTrue())
-                ->will($this->returnValue($validationResult));
+                ->willReturn($validationResult);
 
         $result = $this->rule->Validate($this->reservation, null);
 
@@ -137,7 +134,7 @@ class CustomAttributeValidationRuleTest extends TestBase
         $attributeService->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo(CustomAttributeCategory::RESERVATION), $this->equalTo($this->reservation->AttributeValues()))
-                ->will($this->returnValue($validationResult));
+                ->willReturn($validationResult);
 
         $rule = new CustomAttributeValidationRule($attributeService, $this->userRepository);
 
@@ -162,7 +159,7 @@ class CustomAttributeValidationRuleTest extends TestBase
         $attributeService->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo(CustomAttributeCategory::RESERVATION), $this->equalTo($this->reservation->AttributeValues()))
-                ->will($this->returnValue($validationResult));
+                ->willReturn($validationResult);
 
         $rule = new CustomAttributeValidationRule($attributeService, $this->userRepository);
 
@@ -189,7 +186,7 @@ class CustomAttributeValidationRuleTest extends TestBase
         $attributeService->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo(CustomAttributeCategory::RESERVATION), $this->equalTo($this->reservation->AttributeValues()))
-                ->will($this->returnValue($validationResult));
+                ->willReturn($validationResult);
 
         $rule = new CustomAttributeValidationRule($attributeService, $this->userRepository);
 

--- a/tests/Application/Reservation/CustomAttributeValidationRuleTest.php
+++ b/tests/Application/Reservation/CustomAttributeValidationRuleTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class CustomAttributeValidationRuleTests extends TestBase
+class CustomAttributeValidationRuleTest extends TestBase
 {
     /**
      * @var IAttributeService|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Reservation/ExistingResourceAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/ExistingResourceAvailabilityRuleTest.php
@@ -5,7 +5,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ExistingResourceAvailabilityRuleTests extends TestBase
+class ExistingResourceAvailabilityRuleTest extends TestBase
 {
     private $timezone = 'UTC';
     /**

--- a/tests/Application/Reservation/ExistingResourceAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/ExistingResourceAvailabilityRuleTest.php
@@ -57,7 +57,7 @@ class ExistingResourceAvailabilityRuleTest extends TestBase
         $this->strategy->expects($this->exactly(2))
                        ->method('GetItemsBetween')
                        ->with($this->anything(), $this->anything())
-                       ->will($this->returnValue($reservations));
+                       ->willReturn($reservations);
 
         $rule = new ExistingResourceAvailabilityRule(new ReservationConflictIdentifier($this->strategy), $this->timezone);
         $ruleResult = $rule->Validate($series, null);
@@ -84,7 +84,7 @@ class ExistingResourceAvailabilityRuleTest extends TestBase
         $this->strategy->expects($this->once())
                        ->method('GetItemsBetween')
                        ->with($this->anything(), $this->anything())
-                       ->will($this->returnValue($reservations));
+                       ->willReturn($reservations);
 
         $rule = new ExistingResourceAvailabilityRule(new ReservationConflictIdentifier($this->strategy), $this->timezone);
         $ruleResult = $rule->Validate($series, null);
@@ -112,7 +112,7 @@ class ExistingResourceAvailabilityRuleTest extends TestBase
         $this->strategy->expects($this->once())
                        ->method('GetItemsBetween')
                        ->with($this->anything(), $this->anything())
-                       ->will($this->returnValue($reservations));
+                       ->willReturn($reservations);
 
         $rule = new ExistingResourceAvailabilityRule(new ReservationConflictIdentifier($this->strategy), $this->timezone);
         $ruleResult = $rule->Validate($series, null);
@@ -142,7 +142,7 @@ class ExistingResourceAvailabilityRuleTest extends TestBase
         $this->strategy->expects($this->once())
                        ->method('GetItemsBetween')
                        ->with($this->anything(), $this->anything())
-                       ->will($this->returnValue($reservations));
+                       ->willReturn($reservations);
 
         $rule = new ExistingResourceAvailabilityRule(new ReservationConflictIdentifier($this->strategy), $this->timezone);
         $ruleResult = $rule->Validate($series, null);
@@ -210,7 +210,7 @@ class ExistingResourceAvailabilityRuleTest extends TestBase
         $strategy->expects($this->once())
                  ->method('GetItemsBetween')
                  ->with($this->equalTo($startDate->AddMinutes(-60)), $this->equalTo($endDate->AddMinutes(60)))
-                 ->will($this->returnValue([$scheduleReservation1, $scheduleReservation2, $scheduleReservation3, $scheduleReservation4, $scheduleReservation5]));
+                 ->willReturn([$scheduleReservation1, $scheduleReservation2, $scheduleReservation3, $scheduleReservation4, $scheduleReservation5]);
 
         $rule = new ExistingResourceAvailabilityRule(new ReservationConflictIdentifier($strategy), "UTC");
         $result = $rule->Validate($reservation, null);
@@ -253,7 +253,7 @@ class ExistingResourceAvailabilityRuleTest extends TestBase
         $strategy->expects($this->once())
                  ->method('GetItemsBetween')
                  ->with($this->equalTo($startDate->AddMinutes(-60)), $this->equalTo($endDate->AddMinutes(60)))
-                 ->will($this->returnValue([$conflict1, $conflict2, $nonConflict1, $nonConflict2, $nonConflict3]));
+                 ->willReturn([$conflict1, $conflict2, $nonConflict1, $nonConflict2, $nonConflict3]);
 
 
         $rule = new ExistingResourceAvailabilityRule(new ReservationConflictIdentifier($strategy), "UTC");
@@ -287,7 +287,7 @@ class ExistingResourceAvailabilityRuleTest extends TestBase
         $this->strategy->expects($this->once())
                        ->method('GetItemsBetween')
                        ->with($this->anything(), $this->anything())
-                       ->will($this->returnValue($reservations));
+                       ->willReturn($reservations);
 
         $rule = new ExistingResourceAvailabilityRule(new ReservationConflictIdentifier($this->strategy), $this->timezone);
         $ruleResult = $rule->Validate($series, null);
@@ -351,15 +351,9 @@ class ExistingResourceAvailabilityRuleTest extends TestBase
                 new TestReservationItemView(++$currentId, $instance->StartDate(), $instance->EndDate(), $resourceId, "r$currentId"),
         ];
 
-        $this->strategy->expects($this->at(0))
+        $this->strategy->expects($this->exactly(2))
                        ->method('GetItemsBetween')
-                       ->with($this->anything(), $this->anything())
-                       ->will($this->returnValue($reservationsInstance1));
-
-        $this->strategy->expects($this->at(1))
-                       ->method('GetItemsBetween')
-                       ->with($this->anything(), $this->anything())
-                       ->will($this->returnValue($reservationsInstance2));
+                       ->willReturn($reservationsInstance1, $reservationsInstance2);
 
         $rule = new ExistingResourceAvailabilityRule(new ReservationConflictIdentifier($this->strategy), $this->timezone);
         $ruleResult = $rule->Validate($series, null);

--- a/tests/Application/Reservation/GuestEmailNotificationTest.php
+++ b/tests/Application/Reservation/GuestEmailNotificationTest.php
@@ -34,10 +34,10 @@ class GuestEmailNotificationTest extends TestBase
         $userRepo = $this->createMock('IUserRepository');
         $attributeRepo = $this->createMock('IAttributeRepository');
 
-        $userRepo->expects($this->at(0))
+        $userRepo->expects($this->once())
                  ->method('LoadById')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
+                 ->willReturn($owner);
 
         $notification = new GuestAddedEmailNotification($userRepo, $attributeRepo);
         $notification->Notify($series);
@@ -71,10 +71,10 @@ class GuestEmailNotificationTest extends TestBase
         $userRepo = $this->createMock('IUserRepository');
         $attributeRepo = $this->createMock('IAttributeRepository');
 
-        $userRepo->expects($this->at(0))
+        $userRepo->expects($this->once())
                  ->method('LoadById')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
+                 ->willReturn($owner);
 
         $notification = new GuestDeletedEmailNotification($userRepo, $attributeRepo);
         $notification->Notify($series);
@@ -107,10 +107,10 @@ class GuestEmailNotificationTest extends TestBase
         $userRepo = $this->createMock('IUserRepository');
         $attributeRepo = $this->createMock('IAttributeRepository');
 
-        $userRepo->expects($this->at(0))
+        $userRepo->expects($this->once())
                  ->method('LoadById')
                  ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
+                 ->willReturn($owner);
 
         $notification = new GuestUpdatedEmailNotification($userRepo, $attributeRepo);
         $notification->Notify($series);

--- a/tests/Application/Reservation/GuestEmailNotificationTest.php
+++ b/tests/Application/Reservation/GuestEmailNotificationTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 
-class GuestEmailNotificationTests extends TestBase
+class GuestEmailNotificationTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/InvitationEmailNotificationTest.php
+++ b/tests/Application/Reservation/InvitationEmailNotificationTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 
-class InvitationEmailNotificationTests extends TestBase
+class InvitationEmailNotificationTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/InvitationEmailNotificationTest.php
+++ b/tests/Application/Reservation/InvitationEmailNotificationTest.php
@@ -34,20 +34,13 @@ class InvitationEmailNotificationTest extends TestBase
         $userRepo = $this->createMock('IUserRepository');
         $attributeRepo = $this->createMock('IAttributeRepository');
 
-        $userRepo->expects($this->at(0))
+        $userRepo->expects($this->exactly(3))
             ->method('LoadById')
-            ->with($this->equalTo($ownerId))
-            ->will($this->returnValue($owner));
-
-        $userRepo->expects($this->at(1))
-            ->method('LoadById')
-            ->with($this->equalTo($inviteeId1))
-            ->will($this->returnValue($invitee1));
-
-        $userRepo->expects($this->at(2))
-            ->method('LoadById')
-            ->with($this->equalTo($inviteeId2))
-            ->will($this->returnValue($invitee2));
+            ->willReturnMap([
+                [$ownerId, $owner],
+                [$inviteeId1, $invitee1],
+                [$inviteeId2, $invitee2]
+            ]);
 
         $notification = new InviteeAddedEmailNotification($userRepo, $attributeRepo);
         $notification->Notify($series);

--- a/tests/Application/Reservation/OwnerEmailNotificationTest.php
+++ b/tests/Application/Reservation/OwnerEmailNotificationTest.php
@@ -6,7 +6,7 @@ require_once(ROOT_DIR . 'lib/Email/Messages/ReservationCreatedEmail.php');
 require_once(ROOT_DIR . 'lib/Email/Messages/ReservationUpdatedEmail.php');
 require_once(ROOT_DIR . 'lib/Email/Messages/ReservationDeletedEmail.php');
 
-class OwnerEmailNotificationTests extends TestBase
+class OwnerEmailNotificationTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/OwnerEmailNotificationTest.php
+++ b/tests/Application/Reservation/OwnerEmailNotificationTest.php
@@ -104,7 +104,7 @@ class OwnerEmailNotificationTest extends TestBase
     //		$user->expects($this->once())
     //			->method('WantsEventEmail')
     //			->with($this->equalTo($event))
-    //			->will($this->returnValue(true));
+    //			->willReturn(true);
     //	}
 
     public function LoadsUser($userRepo, $ownerId)
@@ -115,7 +115,7 @@ class OwnerEmailNotificationTest extends TestBase
         $userRepo->expects($this->once())
             ->method('LoadById')
             ->with($this->equalTo($ownerId))
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         return $user;
     }

--- a/tests/Application/Reservation/ParticipantEmailNotificationTest.php
+++ b/tests/Application/Reservation/ParticipantEmailNotificationTest.php
@@ -34,20 +34,13 @@ class ParticipantEmailNotificationTest extends TestBase
         $userRepo = $this->createMock('IUserRepository');
         $attributeRepo = $this->createMock('IAttributeRepository');
 
-        $userRepo->expects($this->at(0))
+        $userRepo->expects($this->exactly(3))
                  ->method('LoadById')
-                 ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
-
-        $userRepo->expects($this->at(1))
-                 ->method('LoadById')
-                 ->with($this->equalTo($participantId1))
-                 ->will($this->returnValue($participant1));
-
-        $userRepo->expects($this->at(2))
-                 ->method('LoadById')
-                 ->with($this->equalTo($participantId2))
-                 ->will($this->returnValue($participant2));
+                 ->willReturnMap([
+                    [$ownerId, $owner],
+                    [$participantId1, $participant1],
+                    [$participantId2, $participant2]
+                 ]);
 
         $notification = new ParticipantAddedEmailNotification($userRepo, $attributeRepo);
         $notification->Notify($series);
@@ -78,20 +71,13 @@ class ParticipantEmailNotificationTest extends TestBase
         $userRepo = $this->createMock('IUserRepository');
         $attributeRepo = $this->createMock('IAttributeRepository');
 
-        $userRepo->expects($this->at(0))
+        $userRepo->expects($this->exactly(3))
                  ->method('LoadById')
-                 ->with($this->equalTo($ownerId))
-                 ->will($this->returnValue($owner));
-
-        $userRepo->expects($this->at(1))
-                 ->method('LoadById')
-                 ->with($this->equalTo($participantId1))
-                 ->will($this->returnValue($participant1));
-
-        $userRepo->expects($this->at(2))
-                 ->method('LoadById')
-                 ->with($this->equalTo($participantId2))
-                 ->will($this->returnValue($participant2));
+                 ->willReturnMap([
+                    [$ownerId, $owner],
+                    [$participantId1, $participant1],
+                    [$participantId2, $participant2]
+                 ]);
 
         $notification = new ParticipantDeletedEmailNotification($userRepo, $attributeRepo);
         $notification->Notify($series);

--- a/tests/Application/Reservation/ParticipantEmailNotificationTest.php
+++ b/tests/Application/Reservation/ParticipantEmailNotificationTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 
-class ParticipantEmailNotificationTests extends TestBase
+class ParticipantEmailNotificationTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ParticipationNotificationTest.php
+++ b/tests/Application/Reservation/ParticipationNotificationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ParticipationNotificationTests extends TestBase
+class ParticipationNotificationTest extends TestBase
 {
     /**
      * @var FakeUserRepository

--- a/tests/Application/Reservation/PermissionValidationRuleTest.php
+++ b/tests/Application/Reservation/PermissionValidationRuleTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class PermissionValidationRuleTests extends TestBase
+class PermissionValidationRuleTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/PermissionValidationRuleTest.php
+++ b/tests/Application/Reservation/PermissionValidationRuleTest.php
@@ -46,7 +46,7 @@ class PermissionValidationRuleTest extends TestBase
 
         $factory->expects($this->once())
             ->method('GetPermissionService')
-            ->will($this->returnValue($service));
+            ->willReturn($service);
 
         $rule = new PermissionValidationRule($factory);
         $result = $rule->Validate($reservation, null);

--- a/tests/Application/Reservation/QuotaRuleTest.php
+++ b/tests/Application/Reservation/QuotaRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class QuotaRuleTests extends TestBase
+class QuotaRuleTest extends TestBase
 {
     /**
      * @var IReservationViewRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Reservation/QuotaRuleTest.php
+++ b/tests/Application/Reservation/QuotaRuleTest.php
@@ -80,17 +80,17 @@ class QuotaRuleTest extends TestBase
 
         $this->quotaRepository->expects($this->once())
                               ->method('LoadAll')
-                              ->will($this->returnValue($quotas));
+                              ->willReturn($quotas);
 
         $this->userRepository->expects($this->once())
                              ->method('LoadById')
                              ->with($this->equalTo($userId))
-                             ->will($this->returnValue($user));
+                             ->willReturn($user);
 
         $this->scheduleRepository->expects($this->once())
                                  ->method('LoadById')
                                  ->with($this->equalTo($scheduleId))
-                                 ->will($this->returnValue($schedule));
+                                 ->willReturn($schedule);
 
         $this->ChecksAgainstQuota($quota1, $series, $this->reservationViewRepository, $schedule, $user);
         $this->ChecksAgainstQuota($quota2, $series, $this->reservationViewRepository, $schedule, $user);
@@ -141,17 +141,17 @@ class QuotaRuleTest extends TestBase
 
         $this->quotaRepository->expects($this->once())
                               ->method('LoadAll')
-                              ->will($this->returnValue($quotas));
+                              ->willReturn($quotas);
 
         $this->userRepository->expects($this->once())
                              ->method('LoadById')
                              ->with($this->equalTo($userId))
-                             ->will($this->returnValue($user));
+                             ->willReturn($user);
 
         $this->scheduleRepository->expects($this->once())
                                  ->method('LoadById')
                                  ->with($this->equalTo($scheduleId))
-                                 ->will($this->returnValue($schedule));
+                                 ->willReturn($schedule);
 
         $this->ChecksAgainstQuota($quota1, $series, $this->reservationViewRepository, $schedule, $user, true);
 
@@ -175,7 +175,7 @@ class QuotaRuleTest extends TestBase
         $quota->expects($this->once())
               ->method('ExceedsQuota')
               ->with($this->equalTo($series), $this->equalTo($user), $this->equalTo($schedule), $this->equalTo($repo))
-              ->will($this->returnValue($exceeds));
+              ->willReturn($exceeds);
     }
 
     private function mockQuota()
@@ -183,7 +183,7 @@ class QuotaRuleTest extends TestBase
         $mock = $this->createMock('IQuota');
         $mock->expects($this->any())
              ->method('ToString')
-             ->will($this->returnValue(''));
+             ->willReturn('');
 
         return $mock;
     }

--- a/tests/Application/Reservation/ReminderValidationRuleTest.php
+++ b/tests/Application/Reservation/ReminderValidationRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ReminderValidationRuleTests extends TestBase
+class ReminderValidationRuleTest extends TestBase
 {
     public function testWhenEnabledAndValid()
     {

--- a/tests/Application/Reservation/RequiresApprovalRuleTest.php
+++ b/tests/Application/Reservation/RequiresApprovalRuleTest.php
@@ -37,7 +37,7 @@ class RequiresApprovalRuleTest extends TestBase
         $this->authorizationService->expects($this->once())
                             ->method('CanApproveForResource')
                             ->with($this->equalTo($this->fakeUser), $this->equalTo($resource))
-                            ->will($this->returnValue(false));
+                            ->willReturn(false);
 
         $this->rule->Validate($series, null);
 
@@ -68,7 +68,7 @@ class RequiresApprovalRuleTest extends TestBase
         $this->authorizationService->expects($this->once())
                                     ->method('CanApproveForResource')
                                     ->with($this->equalTo($this->fakeUser), $this->equalTo($resource))
-                                    ->will($this->returnValue(true));
+                                    ->willReturn(true);
 
         $this->rule->Validate($series, null);
 

--- a/tests/Application/Reservation/RequiresApprovalRuleTest.php
+++ b/tests/Application/Reservation/RequiresApprovalRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class RequiresApprovalRuleTests extends TestBase
+class RequiresApprovalRuleTest extends TestBase
 {
     /**
      * @var IUserRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Reservation/ReservationAuthorizationTest.php
+++ b/tests/Application/Reservation/ReservationAuthorizationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ReservationAuthorizationTests extends TestBase
+class ReservationAuthorizationTest extends TestBase
 {
     /**
      * @var FakeAuthorizationService

--- a/tests/Application/Reservation/ReservationCanBeCheckedInRuleTest.php
+++ b/tests/Application/Reservation/ReservationCanBeCheckedInRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ReservationCanBeCheckedInRuleTests extends TestBase
+class ReservationCanBeCheckedInRuleTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ReservationCanBeCheckedInRuleTest.php
+++ b/tests/Application/Reservation/ReservationCanBeCheckedInRuleTest.php
@@ -2,9 +2,16 @@
 
 class ReservationCanBeCheckedInRuleTest extends TestBase
 {
+    /**
+     *
+     * @var UserSession
+     */
+    private $userSession;
+
     public function setUp(): void
     {
         parent::setup();
+        $this->userSession = new UserSession(123);
     }
 
     public function testCanBeCheckedInIfWithinWindowWithAutoRelease()
@@ -24,7 +31,7 @@ class ReservationCanBeCheckedInRuleTest extends TestBase
         $series->WithCurrentInstance($reservation);
         $series->AddResource($resource2);
 
-        $rule = new ReservationCanBeCheckedInRule();
+        $rule = new ReservationCanBeCheckedInRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertTrue($result->IsValid());
     }
@@ -42,7 +49,7 @@ class ReservationCanBeCheckedInRuleTest extends TestBase
         $series->WithPrimaryResource($resource1);
         $series->WithCurrentInstance($reservation);
 
-        $rule = new ReservationCanBeCheckedInRule();
+        $rule = new ReservationCanBeCheckedInRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertTrue($result->IsValid());
     }
@@ -60,7 +67,7 @@ class ReservationCanBeCheckedInRuleTest extends TestBase
         $series->WithPrimaryResource($resource1);
         $series->WithCurrentInstance($reservation);
 
-        $rule = new ReservationCanBeCheckedInRule();
+        $rule = new ReservationCanBeCheckedInRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertFalse($result->IsValid());
     }
@@ -74,7 +81,7 @@ class ReservationCanBeCheckedInRuleTest extends TestBase
         $series->WithPrimaryResource($resource1);
         $series->WithCurrentInstance(new TestReservation());
 
-        $rule = new ReservationCanBeCheckedInRule();
+        $rule = new ReservationCanBeCheckedInRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertFalse($result->IsValid());
     }
@@ -96,7 +103,7 @@ class ReservationCanBeCheckedInRuleTest extends TestBase
         $series->WithCurrentInstance($reservation);
         $series->AddResource($resource2);
 
-        $rule = new ReservationCanBeCheckedInRule();
+        $rule = new ReservationCanBeCheckedInRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertFalse($result->IsValid());
     }
@@ -112,7 +119,7 @@ class ReservationCanBeCheckedInRuleTest extends TestBase
         $series->WithPrimaryResource($resource1);
         $series->WithCurrentInstance($reservation);
 
-        $rule = new ReservationCanBeCheckedInRule();
+        $rule = new ReservationCanBeCheckedInRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertFalse($result->IsValid());
     }

--- a/tests/Application/Reservation/ReservationCanBeCheckedOutRuleTest.php
+++ b/tests/Application/Reservation/ReservationCanBeCheckedOutRuleTest.php
@@ -2,9 +2,16 @@
 
 class ReservationCanBeCheckedOutRuleTest extends TestBase
 {
+    /**
+     *
+     * @var UserSession
+     */
+    private $userSession;
+
     public function setUp(): void
     {
         parent::setup();
+        $this->userSession = new UserSession(123);
     }
 
     public function testCanBeCheckedOutIfCheckedInAndPastStartDate()
@@ -24,7 +31,7 @@ class ReservationCanBeCheckedOutRuleTest extends TestBase
         $series->AddResource($resource2);
         $series->Checkin($this->fakeUser);
 
-        $rule = new ReservationCanBeCheckedOutRule();
+        $rule = new ReservationCanBeCheckedOutRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertTrue($result->IsValid());
     }
@@ -42,7 +49,7 @@ class ReservationCanBeCheckedOutRuleTest extends TestBase
         $series->WithPrimaryResource($resource1);
         $series->WithCurrentInstance($reservation);
 
-        $rule = new ReservationCanBeCheckedOutRule();
+        $rule = new ReservationCanBeCheckedOutRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertFalse($result->IsValid());
     }
@@ -59,7 +66,7 @@ class ReservationCanBeCheckedOutRuleTest extends TestBase
         $series->WithCurrentInstance($reservation);
         $series->Checkin($this->fakeUser);
 
-        $rule = new ReservationCanBeCheckedOutRule();
+        $rule = new ReservationCanBeCheckedOutRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertFalse($result->IsValid());
     }
@@ -76,7 +83,7 @@ class ReservationCanBeCheckedOutRuleTest extends TestBase
         $series->WithCurrentInstance($reservation);
         $series->Checkin($this->fakeUser);
 
-        $rule = new ReservationCanBeCheckedOutRule();
+        $rule = new ReservationCanBeCheckedOutRule($this->userSession);
         $result = $rule->Validate($series, null);
         $this->assertFalse($result->IsValid());
     }

--- a/tests/Application/Reservation/ReservationCanBeCheckedOutRuleTest.php
+++ b/tests/Application/Reservation/ReservationCanBeCheckedOutRuleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ReservationCanBeCheckedOutRuleTests extends TestBase
+class ReservationCanBeCheckedOutRuleTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ReservationComponentTest.php
+++ b/tests/Application/Reservation/ReservationComponentTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/ReservationInitializerBase.php');
 
-class ReservationComponentTests extends TestBase
+class ReservationComponentTest extends TestBase
 {
     /**
      * @var int

--- a/tests/Application/Reservation/ReservationComponentTest.php
+++ b/tests/Application/Reservation/ReservationComponentTest.php
@@ -93,21 +93,21 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->once())
                           ->method('GetOwnerId')
-                          ->will($this->returnValue($this->userId));
+                          ->willReturn($this->userId);
 
         $this->initializer->expects($this->atLeastOnce())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->userRepository->expects($this->once())
                              ->method('GetById')
                              ->with($this->equalTo($this->userId))
-                             ->will($this->returnValue($userDto));
+                             ->willReturn($userDto);
 
         $this->reservationAuthorization->expects($this->once())
                                        ->method('CanChangeUsers')
                                        ->with($this->fakeUser)
-                                       ->will($this->returnValue(true));
+                                       ->willReturn(true);
 
         $this->fakeConfig->SetSectionKey(ConfigSection::PRIVACY, ConfigKeys::PRIVACY_HIDE_USER_DETAILS, 'true');
         $this->initializer->expects($this->once())
@@ -134,15 +134,15 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->atLeastOnce())
                           ->method('GetScheduleId')
-                          ->will($this->returnValue($requestedScheduleId));
+                          ->willReturn($requestedScheduleId);
 
         $this->initializer->expects($this->atLeastOnce())
                           ->method('GetResourceId')
-                          ->will($this->returnValue($requestedResourceId));
+                          ->willReturn($requestedResourceId);
 
         $this->initializer->expects($this->atLeastOnce())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
 
         $bookedResource = new TestResourceDto(
@@ -204,13 +204,13 @@ class ReservationComponentTest extends TestBase
         $this->resourceService->expects($this->once())
                               ->method('GetResourceGroups')
                               ->with($this->equalTo($requestedScheduleId), $this->equalTo($this->fakeUser))
-                              ->will($this->returnValue($groups));
+                              ->willReturn($groups);
 
         // accessories
         $accessoryList = [new Accessory(1, 'a1', 30), new Accessory(2, 'a2', 20)];
         $this->resourceService->expects($this->once())
                               ->method('GetAccessories')
-                              ->will($this->returnValue($accessoryList));
+                              ->willReturn($accessoryList);
 
         $this->initializer->expects($this->once())
                           ->method('BindResourceGroups')
@@ -243,15 +243,15 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->once())
                           ->method('GetScheduleId')
-                          ->will($this->returnValue($requestedScheduleId));
+                          ->willReturn($requestedScheduleId);
 
         $this->initializer->expects($this->once())
                           ->method('GetResourceId')
-                          ->will($this->returnValue($requestedResourceId));
+                          ->willReturn($requestedResourceId);
 
         $this->initializer->expects($this->once())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $resourceList = [];
         $groups = new FakeResourceGroupTree();
@@ -260,7 +260,7 @@ class ReservationComponentTest extends TestBase
         $this->resourceService->expects($this->once())
                               ->method('GetResourceGroups')
                               ->with($this->equalTo($requestedScheduleId), $this->equalTo($this->fakeUser))
-                              ->will($this->returnValue($groups));
+                              ->willReturn($groups);
 
         $this->initializer->expects($this->once())
                           ->method('RedirectToError')
@@ -291,31 +291,31 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->initializer->expects($this->any())
                           ->method('GetTimezone')
-                          ->will($this->returnValue($timezone));
+                          ->willReturn($timezone);
 
         $this->initializer->expects($this->any())
                           ->method('GetReservationDate')
-                          ->will($this->returnValue($dateInUserTimezone));
+                          ->willReturn($dateInUserTimezone);
 
         $this->initializer->expects($this->any())
                           ->method('GetStartDate')
-                          ->will($this->returnValue($startDate));
+                          ->willReturn($startDate);
 
         $this->initializer->expects($this->any())
                           ->method('GetEndDate')
-                          ->will($this->returnValue($endDate));
+                          ->willReturn($endDate);
 
         $this->initializer->expects($this->any())
                           ->method('GetScheduleId')
-                          ->will($this->returnValue($scheduleId));
+                          ->willReturn($scheduleId);
 
         $this->initializer->expects($this->any())
                           ->method('PrimaryResource')
-                          ->will($this->returnValue($resourceDto));
+                          ->willReturn($resourceDto);
 
         $startPeriods = [new SchedulePeriod(Date::Now(), Date::Now())];
         $endPeriods = [new SchedulePeriod(Date::Now()->AddDays(1), Date::Now()->AddDays(1))];
@@ -324,15 +324,16 @@ class ReservationComponentTest extends TestBase
         $this->scheduleRepository->_Layout = $layout;
         $this->scheduleRepository->_Schedule = $schedule;
 
-        $layout->expects($this->at(0))
+        $layout->expects($this->exactly(2))
                ->method('GetLayout')
-               ->with($this->equalTo($startDate), $this->equalTo(true))
-               ->will($this->returnValue($startPeriods));
-
-        $layout->expects($this->at(1))
-               ->method('GetLayout')
-               ->with($this->equalTo($endDate), $this->equalTo(true))
-               ->will($this->returnValue($endPeriods));
+               ->willReturnCallback(function(Date $date, $hideBlockedPeriods) use ($startDate, $endDate, $startPeriods, $endPeriods)
+               {
+                    if ($date->Equals($startDate) && $hideBlockedPeriods)
+                        return $startPeriods;
+                    if ($date->Equals($endDate) && $hideBlockedPeriods)
+                        return $endPeriods;
+                    throw new Exception("Unexpected arguments");
+               });
 
         $this->initializer->expects($this->once())
                           ->method('SetDates')
@@ -372,31 +373,31 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->initializer->expects($this->any())
                           ->method('GetTimezone')
-                          ->will($this->returnValue($timezone));
+                          ->willReturn($timezone);
 
         $this->initializer->expects($this->any())
                           ->method('GetReservationDate')
-                          ->will($this->returnValue($dateInUserTimezone));
+                          ->willReturn($dateInUserTimezone);
 
         $this->initializer->expects($this->any())
                           ->method('GetStartDate')
-                          ->will($this->returnValue($startDate));
+                          ->willReturn($startDate);
 
         $this->initializer->expects($this->any())
                           ->method('GetEndDate')
-                          ->will($this->returnValue($endDate));
+                          ->willReturn($endDate);
 
         $this->initializer->expects($this->any())
                           ->method('GetScheduleId')
-                          ->will($this->returnValue($scheduleId));
+                          ->willReturn($scheduleId);
 
         $this->initializer->expects($this->any())
                           ->method('PrimaryResource')
-                          ->will($this->returnValue($resourceDto));
+                          ->willReturn($resourceDto);
 
         $startPeriods = [new SchedulePeriod(Date::Now(), Date::Now())];
         $endPeriods = [new SchedulePeriod(Date::Now()->AddDays(1), Date::Now()->AddDays(1))];
@@ -405,15 +406,16 @@ class ReservationComponentTest extends TestBase
         $this->scheduleRepository->_Layout = $layout;
         $this->scheduleRepository->_Schedule = new FakeSchedule();
 
-        $layout->expects($this->at(0))
+        $layout->expects($this->exactly(2))
                ->method('GetLayout')
-               ->with($this->equalTo($startDate))
-               ->will($this->returnValue($startPeriods));
-
-        $layout->expects($this->at(1))
-               ->method('GetLayout')
-               ->with($this->equalTo($endDate))
-               ->will($this->returnValue($endPeriods));
+               ->willReturnCallback(function(Date $date) use ($startDate, $endDate, $startPeriods, $endPeriods)
+               {
+                    if($date->Equals($startDate))
+                        return $startPeriods;
+                    if($date->Equals($endDate))
+                        return $endPeriods;
+                    throw new Exception("Unexpeced argument");
+               });
 
         $this->initializer->expects($this->once())
                           ->method('SetDates')
@@ -430,7 +432,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->once())
                           ->method('IsNew')
-                          ->will($this->returnValue(true));
+                          ->willReturn(true);
 
         $binder = new ReservationDateBinder($this->scheduleRepository);
         $binder->Bind($this->initializer);
@@ -447,27 +449,27 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->initializer->expects($this->any())
                           ->method('GetTimezone')
-                          ->will($this->returnValue($timezone));
+                          ->willReturn($timezone);
 
         $this->initializer->expects($this->any())
                           ->method('GetReservationDate')
-                          ->will($this->returnValue($dateInUserTimezone));
+                          ->willReturn($dateInUserTimezone);
 
         $this->initializer->expects($this->any())
                           ->method('GetStartDate')
-                          ->will($this->returnValue($requestedDate));
+                          ->willReturn($requestedDate);
 
         $this->initializer->expects($this->any())
                           ->method('GetEndDate')
-                          ->will($this->returnValue($requestedDate));
+                          ->willReturn($requestedDate);
 
         $this->initializer->expects($this->any())
                           ->method('GetScheduleId')
-                          ->will($this->returnValue($scheduleId));
+                          ->willReturn($scheduleId);
 
         $periods = [
                 new SchedulePeriod(
@@ -489,7 +491,7 @@ class ReservationComponentTest extends TestBase
         $layout->expects($this->any())
                ->method('GetLayout')
                ->with($this->equalTo($requestedDate))
-               ->will($this->returnValue($periods));
+               ->willReturn($periods);
 
         $this->initializer->expects($this->once())
                           ->method('SetDates')
@@ -645,7 +647,7 @@ class ReservationComponentTest extends TestBase
         $this->reservationAuthorization->expects($this->once())
                                        ->method('CanEdit')
                                        ->with($this->equalTo($this->reservationView), $this->equalTo($this->fakeUser))
-                                       ->will($this->returnValue($isEditable));
+                                       ->willReturn($isEditable);
 
         $this->page->expects($this->once())
                    ->method('SetIsEditable')
@@ -655,7 +657,7 @@ class ReservationComponentTest extends TestBase
         $this->reservationAuthorization->expects($this->once())
                                        ->method('CanApprove')
                                        ->with($this->equalTo($this->reservationView), $this->equalTo($this->fakeUser))
-                                       ->will($this->returnValue($isApprovable));
+                                       ->willReturn($isApprovable);
 
         $this->page->expects($this->once())
                    ->method('SetIsApprovable')
@@ -680,23 +682,23 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->atLeastOnce())
                           ->method('GetTimezone')
-                          ->will($this->returnValue($timezone));
+                          ->willReturn($timezone);
 
         $this->initializer->expects($this->atLeastOnce())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $canViewDetails = true;
         $canViewUser = true;
         $this->privacyFilter->expects($this->once())
                             ->method('CanViewDetails')
                             ->with($this->equalTo($this->fakeUser), $this->equalTo($this->reservationView))
-                            ->will($this->returnValue($canViewDetails));
+                            ->willReturn($canViewDetails);
 
         $this->privacyFilter->expects($this->once())
                             ->method('CanViewUser')
                             ->with($this->equalTo($this->fakeUser), $this->equalTo($this->reservationView))
-                            ->will($this->returnValue($canViewUser));
+                            ->willReturn($canViewUser);
 
         $this->initializer->expects($this->once())
                           ->method('ShowUserDetails')
@@ -725,11 +727,11 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationAuthorization->expects($this->once())
             ->method('CanEdit')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -758,7 +760,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -785,7 +787,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -812,7 +814,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -841,11 +843,11 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationAuthorization->expects($this->once())
             ->method('CanEdit')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -872,7 +874,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -899,7 +901,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -927,7 +929,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -954,7 +956,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -981,11 +983,11 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationAuthorization->expects($this->once())
             ->method('CanEdit')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,
@@ -1012,7 +1014,7 @@ class ReservationComponentTest extends TestBase
 
         $this->initializer->expects($this->any())
                           ->method('CurrentUser')
-                          ->will($this->returnValue($this->fakeUser));
+                          ->willReturn($this->fakeUser);
 
         $this->reservationDetailsBinder = new ReservationDetailsBinder(
             $this->reservationAuthorization,

--- a/tests/Application/Reservation/ReservationConflictResolutionTest.php
+++ b/tests/Application/Reservation/ReservationConflictResolutionTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/ManageBlackoutsService.php');
 
-class ReservationConflictResolutionTests extends TestBase
+class ReservationConflictResolutionTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ReservationConflictResolutionTest.php
+++ b/tests/Application/Reservation/ReservationConflictResolutionTest.php
@@ -25,7 +25,7 @@ class ReservationConflictResolutionTest extends TestBase
         $repo->expects($this->once())
              ->method('LoadById')
              ->with($this->equalTo($id))
-             ->will($this->returnValue($reservation));
+             ->willReturn($reservation);
 
         $repo->expects($this->once())
              ->method('Delete')

--- a/tests/Application/Reservation/ReservationDateTimeRuleTest.php
+++ b/tests/Application/Reservation/ReservationDateTimeRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ReservationDateTimeRuleTests extends TestBase
+class ReservationDateTimeRuleTest extends TestBase
 {
     public function testEnsuresThatStartMustBeBeforeEnd()
     {

--- a/tests/Application/Reservation/ReservationNotificationFactoryTest.php
+++ b/tests/Application/Reservation/ReservationNotificationFactoryTest.php
@@ -31,7 +31,7 @@ class ReservationNotificationFactoryTest extends TestBase
         $this->plugin->expects($this->once())
                 ->method('CreatePostAddService')
                 ->with($this->fakeUser)
-                ->will($this->returnValue($this->service));
+                ->willReturn($this->service);
 
         $reservationValidationFactory = new ReservationNotificationFactory();
         $actual = $reservationValidationFactory->Create(ReservationAction::Create, $this->fakeUser);
@@ -44,7 +44,7 @@ class ReservationNotificationFactoryTest extends TestBase
         $this->plugin->expects($this->once())
                 ->method('CreatePostUpdateService')
                 ->with($this->fakeUser)
-                ->will($this->returnValue($this->service));
+                ->willReturn($this->service);
 
         $reservationValidationFactory = new ReservationNotificationFactory();
         $actual = $reservationValidationFactory->Create(ReservationAction::Update, $this->fakeUser);
@@ -57,7 +57,7 @@ class ReservationNotificationFactoryTest extends TestBase
         $this->plugin->expects($this->once())
                 ->method('CreatePostDeleteService')
                 ->with($this->fakeUser)
-                ->will($this->returnValue($this->service));
+                ->willReturn($this->service);
 
         $reservationValidationFactory = new ReservationNotificationFactory();
         $actual = $reservationValidationFactory->Create(ReservationAction::Delete, $this->fakeUser);
@@ -71,7 +71,7 @@ class ReservationNotificationFactoryTest extends TestBase
         $this->plugin->expects($this->once())
                 ->method('CreatePostApproveService')
                 ->with($this->fakeUser)
-                ->will($this->returnValue($this->service));
+                ->willReturn($this->service);
 
         $reservationValidationFactory = new ReservationNotificationFactory();
         $actual = $reservationValidationFactory->Create(ReservationAction::Approve, $this->fakeUser);

--- a/tests/Application/Reservation/ReservationNotificationFactoryTest.php
+++ b/tests/Application/Reservation/ReservationNotificationFactoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 
-class ReservationNotificationFactoryTests extends TestBase
+class ReservationNotificationFactoryTest extends TestBase
 {
     /**
      * @var IPostReservationFactory|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Reservation/ReservationStartTimeRuleTest.php
+++ b/tests/Application/Reservation/ReservationStartTimeRuleTest.php
@@ -108,13 +108,13 @@ class ReservationStartTimeRuleTest extends TestBase
         $this->scheduleRepository->expects($this->once())
             ->method('GetLayout')
             ->with($this->equalTo($scheduleId), $this->equalTo(new ScheduleLayoutFactory('UTC')))
-            ->will($this->returnValue($this->layout));
+            ->willReturn($this->layout);
 
         $period = new SchedulePeriod($periodStart, $periodEnd);
         $this->layout->expects($this->once())
                 ->method('GetPeriod')
                 ->with($this->equalTo($end))
-                ->will($this->returnValue($period));
+                ->willReturn($period);
 
 
         $rule = new ReservationStartTimeRule($this->scheduleRepository);
@@ -144,13 +144,13 @@ class ReservationStartTimeRuleTest extends TestBase
         $this->scheduleRepository->expects($this->once())
             ->method('GetLayout')
             ->with($this->equalTo($scheduleId), $this->equalTo(new ScheduleLayoutFactory('UTC')))
-            ->will($this->returnValue($this->layout));
+            ->willReturn($this->layout);
 
         $period = new SchedulePeriod($periodStart, $periodEnd);
         $this->layout->expects($this->once())
                 ->method('GetPeriod')
                 ->with($this->equalTo($end))
-                ->will($this->returnValue($period));
+                ->willReturn($period);
 
 
         $rule = new ReservationStartTimeRule($this->scheduleRepository);

--- a/tests/Application/Reservation/ReservationStartTimeRuleTest.php
+++ b/tests/Application/Reservation/ReservationStartTimeRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ReservationStartTimeRuleTests extends TestBase
+class ReservationStartTimeRuleTest extends TestBase
 {
     /**
      * @var IScheduleRepository

--- a/tests/Application/Reservation/ReservationValidationFactoryTest.php
+++ b/tests/Application/Reservation/ReservationValidationFactoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class ReservationValidationFactoryTests extends TestBase
+class ReservationValidationFactoryTest extends TestBase
 {
     public function testLoadsAddRulesFromPlugins()
     {

--- a/tests/Application/Reservation/ReservationValidationFactoryTest.php
+++ b/tests/Application/Reservation/ReservationValidationFactoryTest.php
@@ -16,7 +16,7 @@ class ReservationValidationFactoryTest extends TestBase
         $preResPlugin->expects($this->once())
                 ->method('CreatePreAddService')
                 ->with($this->fakeUser)
-                ->will($this->returnValue($validationService));
+                ->willReturn($validationService);
 
         $reservationValidationFactory = new ReservationValidationFactory();
         $actual = $reservationValidationFactory->Create(ReservationAction::Create, $this->fakeUser);
@@ -36,7 +36,7 @@ class ReservationValidationFactoryTest extends TestBase
         $preResPlugin->expects($this->once())
                 ->method('CreatePreUpdateService')
                 ->with($this->fakeUser)
-                ->will($this->returnValue($validationService));
+                ->willReturn($validationService);
 
         $reservationValidationFactory = new ReservationValidationFactory();
         $actual = $reservationValidationFactory->Create(ReservationAction::Update, $this->fakeUser);
@@ -56,7 +56,7 @@ class ReservationValidationFactoryTest extends TestBase
         $preResPlugin->expects($this->once())
                 ->method('CreatePreDeleteService')
                 ->with($this->fakeUser)
-                ->will($this->returnValue($validationService));
+                ->willReturn($validationService);
 
         $reservationValidationFactory = new ReservationValidationFactory();
         $actual = $reservationValidationFactory->Create(ReservationAction::Delete, $this->fakeUser);

--- a/tests/Application/Reservation/ReservationValidationRuleProcessorTest.php
+++ b/tests/Application/Reservation/ReservationValidationRuleProcessorTest.php
@@ -26,17 +26,17 @@ class ReservationValidationRuleProcessorTest extends TestBase
         $rule1->expects($this->once())
             ->method('Validate')
             ->with($this->equalTo($reservation))
-            ->will($this->returnValue($validResult));
+            ->willReturn($validResult);
 
         $rule2->expects($this->once())
             ->method('Validate')
             ->with($this->equalTo($reservation))
-            ->will($this->returnValue($validResult));
+            ->willReturn($validResult);
 
         $rule3->expects($this->once())
             ->method('Validate')
             ->with($this->equalTo($reservation))
-            ->will($this->returnValue($validResult));
+            ->willReturn($validResult);
 
         $rules = [$rule1, $rule2, $rule3];
 
@@ -61,7 +61,7 @@ class ReservationValidationRuleProcessorTest extends TestBase
         $rule1->expects($this->once())
             ->method('Validate')
             ->with($this->equalTo($reservation))
-            ->will($this->returnValue(new ReservationRuleResult()));
+            ->willReturn(new ReservationRuleResult());
 
         $error = 'something went wrong';
         $retryMessage = 'retry message';
@@ -70,7 +70,7 @@ class ReservationValidationRuleProcessorTest extends TestBase
         $rule2->expects($this->once())
             ->method('Validate')
             ->with($this->equalTo($reservation))
-            ->will($this->returnValue(new ReservationRuleResult(false, $error, true, $retryMessage, $retryParams)));
+            ->willReturn(new ReservationRuleResult(false, $error, true, $retryMessage, $retryParams));
 
         $vs = new ReservationValidationRuleProcessor($rules);
 

--- a/tests/Application/Reservation/ReservationValidationRuleProcessorTest.php
+++ b/tests/Application/Reservation/ReservationValidationRuleProcessorTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class ReservationValidationRuleProcessorTests extends TestBase
+class ReservationValidationRuleProcessorTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ResourceAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/ResourceAvailabilityRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ResourceAvailabilityRuleTests extends TestBase
+class ResourceAvailabilityRuleTest extends TestBase
 {
     /**
      * @var FakeScheduleRepository

--- a/tests/Application/Reservation/ResourceCountRuleTest.php
+++ b/tests/Application/Reservation/ResourceCountRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ResourceCountRuleTests extends TestBase
+class ResourceCountRuleTest extends TestBase
 {
     /**
      * @var FakeScheduleRepository

--- a/tests/Application/Reservation/ResourceCrossDayRuleTest.php
+++ b/tests/Application/Reservation/ResourceCrossDayRuleTest.php
@@ -43,7 +43,7 @@ class ResourceCrossDayRuleTest extends TestBase
         $this->scheduleRepository->expects($this->once())
         ->method('LoadById')
         ->with($this->equalTo($reservation->ScheduleId()))
-        ->will($this->returnValue($this->schedule));
+        ->willReturn($this->schedule);
 
         $rule = new ResourceCrossDayRule($this->scheduleRepository);
         $result = $rule->Validate($reservation, null);
@@ -92,7 +92,7 @@ class ResourceCrossDayRuleTest extends TestBase
         $this->scheduleRepository->expects($this->once())
         ->method('LoadById')
         ->with($this->equalTo($reservation->ScheduleId()))
-        ->will($this->returnValue($this->schedule));
+        ->willReturn($this->schedule);
 
         $rule = new ResourceCrossDayRule($this->scheduleRepository);
         $result = $rule->Validate($reservation, null);

--- a/tests/Application/Reservation/ResourceCrossDayRuleTest.php
+++ b/tests/Application/Reservation/ResourceCrossDayRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ResourceCrossDayRuleTests extends TestBase
+class ResourceCrossDayRuleTest extends TestBase
 {
     /**
      * @var IScheduleRepository

--- a/tests/Application/Reservation/ResourceMaximumDurationRuleTest.php
+++ b/tests/Application/Reservation/ResourceMaximumDurationRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ResourceMaximumDurationRuleTests extends TestBase
+class ResourceMaximumDurationRuleTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ResourceMaximumNoticeRuleTest.php
+++ b/tests/Application/Reservation/ResourceMaximumNoticeRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ResourceMaximumNoticeRuleTests extends TestBase
+class ResourceMaximumNoticeRuleTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ResourceMinimumDurationRuleTest.php
+++ b/tests/Application/Reservation/ResourceMinimumDurationRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ResourceMinimumDurationRuleTests extends TestBase
+class ResourceMinimumDurationRuleTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ResourceMinimumNoticeRuleTest.php
+++ b/tests/Application/Reservation/ResourceMinimumNoticeRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ResourceMinimumNoticeRuleTests extends TestBase
+class ResourceMinimumNoticeRuleTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ResourceParticipationRuleTest.php
+++ b/tests/Application/Reservation/ResourceParticipationRuleTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class ResourceParticipationRuleTests extends TestBase
+class ResourceParticipationRuleTest extends TestBase
 {
     /**
      * @var ResourceParticipationRule

--- a/tests/Application/Reservation/RetryOptionsTest.php
+++ b/tests/Application/Reservation/RetryOptionsTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class RetryOptionsTests extends TestBase
+class RetryOptionsTest extends TestBase
 {
     /**
      * @var FakeReservationConflictIdentifier

--- a/tests/Application/Reservation/ScheduleAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/ScheduleAvailabilityRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class ScheduleAvailabilityRuleTests extends TestBase
+class ScheduleAvailabilityRuleTest extends TestBase
 {
     /**
      * @var FakeScheduleRepository

--- a/tests/Application/Reservation/SchedulePeriodRuleTest.php
+++ b/tests/Application/Reservation/SchedulePeriodRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class SchedulePeriodRuleTests extends TestBase
+class SchedulePeriodRuleTest extends TestBase
 {
     /**
      * @var IScheduleRepository

--- a/tests/Application/Reservation/ScheduleTotalConcurrentReservationsRuleTest.php
+++ b/tests/Application/Reservation/ScheduleTotalConcurrentReservationsRuleTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
-class ScheduleTotalConcurrentReservationsRuleTests extends TestBase
+class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 {
     /**
      * @var FakeScheduleRepository

--- a/tests/Application/Schedule/CalendarMonthTest.php
+++ b/tests/Application/Schedule/CalendarMonthTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class CalendarMonthTests extends TestBase
+class CalendarMonthTest extends TestBase
 {
     public function testAddsReservationsToCalendar()
     {

--- a/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
+++ b/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class CalendarSubscriptionServiceTests extends TestBase
+class CalendarSubscriptionServiceTest extends TestBase
 {
     /**
      * @var CalendarSubscriptionService

--- a/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
+++ b/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
@@ -43,7 +43,7 @@ class CalendarSubscriptionServiceTest extends TestBase
         $this->userRepo->expects($this->once())
                 ->method('LoadByPublicId')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($expected));
+                ->willReturn($expected);
 
         $actual = $this->service->GetUser($publicId);
 
@@ -58,7 +58,7 @@ class CalendarSubscriptionServiceTest extends TestBase
         $this->resourceRepo->expects($this->once())
                 ->method('LoadByPublicId')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($expected));
+                ->willReturn($expected);
 
         $actual = $this->service->GetResource($publicId);
 
@@ -73,7 +73,7 @@ class CalendarSubscriptionServiceTest extends TestBase
         $this->scheduleRepo->expects($this->once())
                 ->method('LoadByPublicId')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($expected));
+                ->willReturn($expected);
 
         $actual = $this->service->GetSchedule($publicId);
 

--- a/tests/Application/Schedule/CalendarWeekTest.php
+++ b/tests/Application/Schedule/CalendarWeekTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class CalendarWeekTests extends TestBase
+class CalendarWeekTest extends TestBase
 {
     public function testAddsReservationsToCalendar()
     {

--- a/tests/Application/Schedule/DailyLayoutTest.php
+++ b/tests/Application/Schedule/DailyLayoutTest.php
@@ -33,7 +33,7 @@ class DailyLayoutTest extends TestBase
         $listing->expects($this->once())
             ->method('OnDateForResource')
             ->with($this->equalTo($date), $this->equalTo($resourceId))
-            ->will($this->returnValue($reservations));
+            ->willReturn($reservations);
 
         $layout = new DailyLayout($listing, $scheduleLayout);
         $layoutSlots = $layout->GetLayout($date, $resourceId);
@@ -57,7 +57,7 @@ class DailyLayoutTest extends TestBase
         $scheduleLayout->expects($this->once())
             ->method('GetLayout')
             ->with($this->equalTo($displayDate))
-            ->will($this->returnValue($periods));
+            ->willReturn($periods);
 
         $layout = new DailyLayout(new ReservationListing("America/Chicago"), $scheduleLayout);
         $labels = $layout->GetLabels($displayDate);
@@ -91,11 +91,11 @@ class DailyLayoutTest extends TestBase
         $scheduleLayout->expects($this->once())
             ->method('GetLayout')
             ->with($this->equalTo($displayDate))
-            ->will($this->returnValue($periods));
+            ->willReturn($periods);
 
         $scheduleLayout->expects($this->once())
             ->method('FitsToHours')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $layout = new DailyLayout(new ReservationListing("America/Chicago"), $scheduleLayout);
         $labels = $layout->GetPeriods($displayDate, true);
@@ -152,7 +152,7 @@ class DailyLayoutTest extends TestBase
         $listing->expects($this->once())
             ->method('OnDateForResource')
             ->with($this->equalTo($date), $this->equalTo($resourceId))
-            ->will($this->returnValue($reservations));
+            ->willReturn($reservations);
 
         $layout = new DailyLayout($listing, $scheduleLayout);
         $summary = $layout->GetSummary($date, $resourceId);

--- a/tests/Application/Schedule/DailyLayoutTest.php
+++ b/tests/Application/Schedule/DailyLayoutTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class DailyLayoutTests extends TestBase
+class DailyLayoutTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Schedule/LayoutValidatorTest.php
+++ b/tests/Application/Schedule/LayoutValidatorTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Common/Validators/namespace.php');
 
-class LayoutValidatorTests extends TestBase
+class LayoutValidatorTest extends TestBase
 {
     public function testInvalidUnlessThereIsASlotCoveringEveryMinuteForTheWholeDay()
     {

--- a/tests/Application/Schedule/ReservationListingTest.php
+++ b/tests/Application/Schedule/ReservationListingTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class ReservationListingTests extends TestBase
+class ReservationListingTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Schedule/ResourcePermissionStoreTest.php
+++ b/tests/Application/Schedule/ResourcePermissionStoreTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class ResourcePermissionStoreTests extends TestBase
+class ResourcePermissionStoreTest extends TestBase
 {
     public function testRepositoryIsAccessedForUserPermissionInformation()
     {

--- a/tests/Application/Schedule/ResourcePermissionStoreTest.php
+++ b/tests/Application/Schedule/ResourcePermissionStoreTest.php
@@ -27,14 +27,14 @@ class ResourcePermissionStoreTest extends TestBase
 
         $user->expects($this->once())
             ->method('GetAllResources')
-            ->will($this->returnValue([$r1, $r2, $r3, $r4]));
+            ->willReturn([$r1, $r2, $r3, $r4]);
 
         $userRepository = $this->createMock('IScheduleUserRepository');
 
         $userRepository->expects($this->once())
             ->method('GetUser')
             ->with($this->equalTo($userId))
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $rps = new ResourcePermissionStore($userRepository);
 
@@ -65,7 +65,7 @@ class ResourcePermissionStoreTest extends TestBase
         $userRepository = $this->createMock('IScheduleUserRepository');
         $userRepository->expects($this->any())
             ->method('GetUser')
-            ->will($this->returnValue($user));
+            ->willReturn($user);
 
         $rps = new ResourcePermissionStore($userRepository);
 

--- a/tests/Application/Schedule/ResourceServiceTest.php
+++ b/tests/Application/Schedule/ResourceServiceTest.php
@@ -68,70 +68,28 @@ class ResourceServiceTest extends TestBase
                 ->expects($this->once())
                 ->method('GetScheduleResources')
                 ->with($this->equalTo($scheduleId))
-                ->will($this->returnValue($resources));
+                ->willReturn($resources);
 
+        $matcher = $this->exactly(4);
         $this->permissionService
-                ->expects($this->at(0))
+                ->expects($matcher)
                 ->method('CanAccessResource')
-                ->with(
-                    $this->equalTo($resource1),
-                    $this->equalTo($user)
-                )
-                ->will($this->returnValue(true));
+                ->willReturnCallback(function ($res, $u) use ($matcher, $resource1, $resource2, $resource3, $resource4, $user) {
+                    $this->assertEquals($u, $user);
+                    match ($matcher->numberOfInvocations())
+                    {
+                        1 => $this->assertEquals($res, $resource1),
+                        2 => $this->assertEquals($res, $resource2),
+                        3 => $this->assertEquals($res, $resource3),
+                        4 => $this->assertEquals($res, $resource4)
+                    };
+                    return $matcher->numberOfInvocations() == 4 ? false : true;
+                });
 
         $this->permissionService
-                ->expects($this->at(1))
+                ->expects($this->exactly(3))
                 ->method('CanBookResource')
-                ->with(
-                    $this->equalTo($resource1),
-                    $this->equalTo($user)
-                )
-                ->will($this->returnValue(true));
-
-        $this->permissionService
-                ->expects($this->at(2))
-                ->method('CanAccessResource')
-                ->with(
-                    $this->equalTo($resource2),
-                    $this->equalTo($user)
-                )
-                ->will($this->returnValue(true));
-
-        $this->permissionService
-                ->expects($this->at(3))
-                ->method('CanBookResource')
-                ->with(
-                    $this->equalTo($resource2),
-                    $this->equalTo($user)
-                )
-                ->will($this->returnValue(true));
-
-        $this->permissionService
-                ->expects($this->at(4))
-                ->method('CanAccessResource')
-                ->with(
-                    $this->equalTo($resource3),
-                    $this->equalTo($user)
-                )
-                ->will($this->returnValue(true));
-
-        $this->permissionService
-                ->expects($this->at(5))
-                ->method('CanBookResource')
-                ->with(
-                    $this->equalTo($resource3),
-                    $this->equalTo($user)
-                )
-                ->will($this->returnValue(true));
-
-        $this->permissionService
-                ->expects($this->at(6))
-                ->method('CanAccessResource')
-                ->with(
-                    $this->equalTo($resource4),
-                    $this->equalTo($user)
-                )
-                ->will($this->returnValue(false));
+                ->willReturn(true);
 
         $resourceDto1 = new ResourceDto(
             1,
@@ -226,39 +184,37 @@ class ResourceServiceTest extends TestBase
         $this->resourceRepository
                 ->expects($this->once())
                 ->method('GetResourceList')
-                ->will($this->returnValue($resources));
+                ->willReturn($resources);
 
+        $matcher = $this->exactly(2);
         $this->permissionService
-                ->expects($this->at(0))
+                ->expects($matcher)
                 ->method('CanAccessResource')
-                ->with(
-                    $this->equalTo($resource1),
-                    $this->equalTo($session)
-                )
-                ->will($this->returnValue(false));
+                ->willReturnCallback(function($res, $ses) use ($resource1, $resource2, $session, $matcher)
+                {
+                    $this->assertEquals($ses, $session);
+                    match ($matcher->numberOfInvocations())
+                    {
+                        1 => $this->assertEquals($res, $resource1),
+                        2 => $this->assertEquals($res, $resource2),
+                    };
+                    return $matcher->numberOfInvocations() == 2;
+                });
 
         $this->permissionService
-                ->expects($this->at(1))
-                ->method('CanAccessResource')
-                ->with(
-                    $this->equalTo($resource2),
-                    $this->equalTo($session)
-                )
-                ->will($this->returnValue(true));
-
-        $this->permissionService
-                ->expects($this->at(2))
+                ->expects($this->once())
                 ->method('CanBookResource')
                 ->with(
                     $this->equalTo($resource2),
                     $this->equalTo($session)
                 )
-                ->will($this->returnValue(true));
+                ->willReturn(true);
+
 
         $this->userRepository->expects($this->any())
                              ->method('LoadById')
                              ->with($this->equalTo($session->UserId))
-                             ->will($this->returnValue($user));
+                             ->willReturn($user);
 
         $resourceDto1 = new ResourceDto(
             1,
@@ -320,21 +276,21 @@ class ResourceServiceTest extends TestBase
                 ->expects($this->any())
                 ->method('GetScheduleResources')
                 ->with($this->equalTo($scheduleId))
-                ->will($this->returnValue($resources));
+                ->willReturn($resources);
 
         $this->permissionService
-                ->expects($this->at(0))
+                ->expects($this->any())
                 ->method('CanAccessResource')
                 ->with(
                     $this->equalTo($resource1),
                     $this->equalTo($session)
                 )
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->userRepository->expects($this->any())
                              ->method('LoadById')
                              ->with($this->equalTo($session->UserId))
-                             ->will($this->returnValue($user));
+                             ->willReturn($user);
 
         $resourceDto1 = new ResourceDto(
             1,
@@ -376,13 +332,13 @@ class ResourceServiceTest extends TestBase
                 ->expects($this->once())
                 ->method('GetScheduleResources')
                 ->with($this->equalTo($scheduleId))
-                ->will($this->returnValue([$resource1]));
+                ->willReturn([$resource1]);
 
         $this->permissionService
-                ->expects($this->at(0))
+                ->expects($this->once())
                 ->method('CanAccessResource')
                 ->with($this->equalTo($resource1))
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
         $includeInaccessibleResources = false;
         $actual = $this->resourceService->GetScheduleResources($scheduleId, $includeInaccessibleResources, $user);
@@ -397,7 +353,7 @@ class ResourceServiceTest extends TestBase
         $this->accessoryRepository
                 ->expects($this->once())
                 ->method('LoadAll')
-                ->will($this->returnValue($accessories));
+                ->willReturn($accessories);
 
         $actualAccessories = $this->resourceService->GetAccessories();
 
@@ -419,20 +375,20 @@ class ResourceServiceTest extends TestBase
                 ->expects($this->once())
                 ->method('GetScheduleResources')
                 ->with($this->equalTo($scheduleId))
-                ->will($this->returnValue($resources));
+                ->willReturn($resources);
 
         $this->permissionService
                 ->expects($this->any())
                 ->method('CanAccessResource')
                 ->with($this->anything(), $this->anything())
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $filter = $this->createMock('IScheduleResourceFilter');
 
         $filter->expects($this->once())
                ->method('FilterResources')
                ->with($this->equalTo($resources), $this->equalTo($this->resourceRepository))
-               ->will($this->returnValue([$resourceId]));
+               ->willReturn([$resourceId]);
 
         $resources = $this->resourceService->GetScheduleResources($scheduleId, true, $this->fakeUser, $filter);
 
@@ -447,7 +403,7 @@ class ResourceServiceTest extends TestBase
         $this->attributeService->expects($this->once())
                                ->method('GetByCategory')
                                ->with($this->equalTo(CustomAttributeCategory::RESOURCE))
-                               ->will($this->returnValue($customAttributes));
+                               ->willReturn($customAttributes);
 
         $attributes = $this->resourceService->GetResourceAttributes();
 
@@ -462,7 +418,7 @@ class ResourceServiceTest extends TestBase
         $this->attributeService->expects($this->once())
                                ->method('GetByCategory')
                                ->with($this->equalTo(CustomAttributeCategory::RESOURCE_TYPE))
-                               ->will($this->returnValue($customAttributes));
+                               ->willReturn($customAttributes);
 
         $attributes = $this->resourceService->GetResourceTypeAttributes();
 
@@ -479,7 +435,7 @@ class ResourceServiceTest extends TestBase
         $this->resourceRepository->expects($this->once())
                                  ->method('GetResourceGroups')
                                  ->with($this->equalTo($scheduleId), $this->anything())
-                                 ->will($this->returnValue($expectedGroups));
+                                 ->willReturn($expectedGroups);
 
         $groups = $this->resourceService->GetResourceGroups($scheduleId, $this->fakeUser);
 

--- a/tests/Application/Schedule/ResourceServiceTest.php
+++ b/tests/Application/Schedule/ResourceServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Schedule/ResourceService.php');
 
-class ResourceServiceTests extends TestBase
+class ResourceServiceTest extends TestBase
 {
     /**
      * @var IPermissionService|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Schedule/ScheduleLayoutSerializableTest.php
+++ b/tests/Application/Schedule/ScheduleLayoutSerializableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ScheduleLayoutSerializableTests extends TestBase
+class ScheduleLayoutSerializableTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Application/Schedule/ScheduleLayoutTest.php
+++ b/tests/Application/Schedule/ScheduleLayoutTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class ScheduleLayoutTests extends TestBase
+class ScheduleLayoutTest extends TestBase
 {
     private $date;
 

--- a/tests/Application/Schedule/ScheduleReservationListTest.php
+++ b/tests/Application/Schedule/ScheduleReservationListTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class ScheduleReservationListTests extends TestBase
+class ScheduleReservationListTest extends TestBase
 {
     private $utc;
     private $userTz;

--- a/tests/Application/Schedule/ScheduleReservationListTest.php
+++ b/tests/Application/Schedule/ScheduleReservationListTest.php
@@ -73,12 +73,12 @@ class ScheduleReservationListTest extends TestBase
         $layout = $this->createMock('IScheduleLayout');
         $layout->expects($this->once())
                 ->method('Timezone')
-                ->will($this->returnValue($userTz));
+                ->willReturn($userTz);
 
         $layout->expects($this->once())
                 ->method('GetLayout')
                 ->with($this->equalTo($date), $this->equalTo($hideBlocked))
-                ->will($this->returnValue($layoutPeriods));
+                ->willReturn($layoutPeriods);
 
         $scheduleList = new ScheduleReservationList([$r1], $layout, $date, $hideBlocked);
         $slots = $scheduleList->BuildSlots();

--- a/tests/Application/Schedule/ScheduleResourceFilterTest.php
+++ b/tests/Application/Schedule/ScheduleResourceFilterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class ScheduleResourceFilterTests extends TestBase
+class ScheduleResourceFilterTest extends TestBase
 {
     /**
      * @var IResourceRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Application/Schedule/ScheduleResourceFilterTest.php
+++ b/tests/Application/Schedule/ScheduleResourceFilterTest.php
@@ -123,7 +123,7 @@ class ScheduleResourceFilterTest extends TestBase
         $this->attributeService->expects($this->once())
         ->method('GetAttributes')
         ->with($this->equalTo(CustomAttributeCategory::RESOURCE), $this->isNull())
-        ->will($this->returnValue($attributeList));
+        ->willReturn($attributeList);
 
         $filter = new ScheduleResourceFilter();
         $filter->ResourceAttributes = [
@@ -163,7 +163,7 @@ class ScheduleResourceFilterTest extends TestBase
         $this->attributeService->expects($this->once())
         ->method('GetAttributes')
         ->with($this->equalTo(CustomAttributeCategory::RESOURCE_TYPE), $this->isNull())
-        ->will($this->returnValue($attributeList));
+        ->willReturn($attributeList);
 
         $filter = new ScheduleResourceFilter();
         $filter->ResourceTypeAttributes = [

--- a/tests/Application/Schedule/SlotLabelFactoryTest.php
+++ b/tests/Application/Schedule/SlotLabelFactoryTest.php
@@ -19,6 +19,8 @@ class SlotLabelFactoryTest extends TestBase
         $this->reservation->LastName = 'last';
         $this->reservation->StartDate = Date::Now();
         $this->reservation->EndDate = Date::Now();
+        $this->reservation->UserId = 1;
+        $this->reservation->UserLevelId = ReservationUserLevel::OWNER;
     }
 
     public function testGetsNone()

--- a/tests/Application/Schedule/SlotLabelFactoryTest.php
+++ b/tests/Application/Schedule/SlotLabelFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class SlotLabelFactoryTests extends TestBase
+class SlotLabelFactoryTest extends TestBase
 {
     /**
      * @var ReservationItemView

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Application/User/ManageUsersService.php');
 
-class ManageUsersServiceTests extends TestBase
+class ManageUsersServiceTest extends TestBase
 {
     /**
      * @var ManageUsersService

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -89,7 +89,7 @@ class ManageUsersServiceTest extends TestBase
                                $this->equalTo($extraAttributes),
                                $this->equalTo($customAttributes)
                            )
-                           ->will($this->returnValue($user));
+                           ->willReturn($user);
 
         $actualUser = $this->service->AddUser(
             $username,
@@ -138,12 +138,12 @@ class ManageUsersServiceTest extends TestBase
 
         $this->userViewRepo->expects($this->once())
                            ->method('GetApplicationAdmins')
-                           ->will($this->returnValue($appAdmins));
+                           ->willReturn($appAdmins);
 
         $this->userViewRepo->expects($this->once())
                            ->method('GetGroupAdmins')
                            ->with($this->equalTo($userId))
-                           ->will($this->returnValue($groupAdmins));
+                           ->willReturn($groupAdmins);
 
         $this->service->DeleteUser($userId);
 
@@ -203,20 +203,13 @@ class ManageUsersServiceTest extends TestBase
         $group4 = new FakeGroup(4);
         $group4->WithUser($userId);
 
-        $this->groupRepo->expects($this->at(0))
+        $this->groupRepo->expects($this->exactly(3))
                         ->method('LoadById')
-                        ->with($this->equalTo(2))
-                        ->will($this->returnValue($group2));
-
-        $this->groupRepo->expects($this->at(2))
-                        ->method('LoadById')
-                        ->with($this->equalTo(3))
-                        ->will($this->returnValue($group3));
-
-        $this->groupRepo->expects($this->at(4))
-                        ->method('LoadById')
-                        ->with($this->equalTo(4))
-                        ->will($this->returnValue($group4));
+                        ->willReturnMap([
+                            [2, $group2],
+                            [3, $group3],
+                            [4, $group4]
+                        ]);
 
         $this->service->ChangeGroups($user, $groupids);
 

--- a/tests/Domain/Announcement/AnnouncementRepositoryTest.php
+++ b/tests/Domain/Announcement/AnnouncementRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/AnnouncementRepository.php');
 
-class AnnouncementRepositoryTests extends TestBase
+class AnnouncementRepositoryTest extends TestBase
 {
     /**
      * @var AnnouncementRepository

--- a/tests/Domain/Attribute/AttributeRepositoryTest.php
+++ b/tests/Domain/Attribute/AttributeRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/AttributeRepository.php');
 
-class AttributeRepositoryTests extends TestBase
+class AttributeRepositoryTest extends TestBase
 {
     /**
      * @var AttributeRepository

--- a/tests/Domain/Attribute/CustomAttributeTest.php
+++ b/tests/Domain/Attribute/CustomAttributeTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class CustomAttributeTests extends TestBase
+class CustomAttributeTest extends TestBase
 {
     public function testChecksForRequiredValues()
     {

--- a/tests/Domain/Payment/PayPalPaymentResultTest.php
+++ b/tests/Domain/Payment/PayPalPaymentResultTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Values/PayPalPaymentResult.php');
 
-class PayPalPaymentResultTests extends TestBase
+class PayPalPaymentResultTest extends TestBase
 {
     public function testParsesJsonString()
     {

--- a/tests/Domain/Payment/PaymentRepositoryTest.php
+++ b/tests/Domain/Payment/PaymentRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/PaymentRepository.php');
 
-class PaymentRepositoryTests extends TestBase
+class PaymentRepositoryTest extends TestBase
 {
     /**
      * @var PaymentRepository

--- a/tests/Domain/Reporting/ReportCommandBuilderTest.php
+++ b/tests/Domain/Reporting/ReportCommandBuilderTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class ReportCommandBuilderTests extends TestBase
+class ReportCommandBuilderTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Domain/Reporting/ReportingRepositoryTest.php
+++ b/tests/Domain/Reporting/ReportingRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class ReportingRepositoryTests extends TestBase
+class ReportingRepositoryTest extends TestBase
 {
     /**
      * @var ReportingRepository

--- a/tests/Domain/Reservation/BlackoutRepositoryTest.php
+++ b/tests/Domain/Reservation/BlackoutRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/BlackoutRepository.php');
 
-class BlackoutRepositoryTests extends TestBase
+class BlackoutRepositoryTest extends TestBase
 {
     /**
      * @var BlackoutRepository

--- a/tests/Domain/Reservation/ExistingReservationDeleteTest.php
+++ b/tests/Domain/Reservation/ExistingReservationDeleteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ExistingReservationDeleteTests extends TestBase
+class ExistingReservationDeleteTest extends TestBase
 {
     /**
      * @var FakeUserSession

--- a/tests/Domain/Reservation/ExistingReservationTest.php
+++ b/tests/Domain/Reservation/ExistingReservationTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class ExistingReservationTests extends TestBase
+class ExistingReservationTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Domain/Reservation/QuotaRepositoryTest.php
+++ b/tests/Domain/Reservation/QuotaRepositoryTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class QuotaRepositoryTests extends TestBase
+class QuotaRepositoryTest extends TestBase
 {
     /**
      * @var QuotaRepository

--- a/tests/Domain/Reservation/QuotaTest.php
+++ b/tests/Domain/Reservation/QuotaTest.php
@@ -940,7 +940,7 @@ class QuotaTest extends TestBase
 
         $this->reservationViewRepository->expects($this->any())
                                         ->method('GetReservations')
-                                        ->will($this->returnValue([$res1]));
+                                        ->willReturn([$res1]);
 
         $exceeds = $quota->ExceedsQuota($series, $this->user, $this->schedule, $this->reservationViewRepository);
 
@@ -955,7 +955,7 @@ class QuotaTest extends TestBase
 
         $this->reservationViewRepository->expects($this->any())
                                         ->method('GetReservations')
-                                        ->will($this->returnValue([]));
+                                        ->willReturn([]);
 
         $exceeds = $quota->ExceedsQuota($series, $this->user, $this->schedule, $this->reservationViewRepository);
 
@@ -971,7 +971,7 @@ class QuotaTest extends TestBase
 
         $this->reservationViewRepository->expects($this->any())
                                         ->method('GetReservations')
-                                        ->will($this->returnValue([$overnightReservation]));
+                                        ->willReturn([$overnightReservation]);
 
         $exceeds = $quota->ExceedsQuota($series, $this->user, $this->schedule, $this->reservationViewRepository);
 
@@ -1018,7 +1018,7 @@ class QuotaTest extends TestBase
                                             $this->equalTo($series->UserId()),
                                             $this->equalTo(ReservationUserLevel::OWNER)
                                         )
-                                        ->will($this->returnValue($reservations));
+                                        ->willReturn($reservations);
     }
 
     private function SearchReturns($reservations)
@@ -1026,6 +1026,6 @@ class QuotaTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                                         ->method('GetReservations')
                                         ->with($this->anything(), $this->anything(), $this->anything(), $this->anything())
-                                        ->will($this->returnValue($reservations));
+                                        ->willReturn($reservations);
     }
 }

--- a/tests/Domain/Reservation/QuotaTest.php
+++ b/tests/Domain/Reservation/QuotaTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class QuotaTests extends TestBase
+class QuotaTest extends TestBase
 {
     /**
      * @var string

--- a/tests/Domain/Reservation/QuotaWhenModifyingTest.php
+++ b/tests/Domain/Reservation/QuotaWhenModifyingTest.php
@@ -187,6 +187,6 @@ class QuotaWhenModifyingTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
             ->method('GetReservations')
             ->with($this->anything(), $this->anything(), $this->anything(), $this->anything())
-            ->will($this->returnValue($reservations));
+            ->willReturn($reservations);
     }
 }

--- a/tests/Domain/Reservation/QuotaWhenModifyingTest.php
+++ b/tests/Domain/Reservation/QuotaWhenModifyingTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class QuotaWhenModifyingTests extends TestBase
+class QuotaWhenModifyingTest extends TestBase
 {
     /**
      * @var string

--- a/tests/Domain/Reservation/ReminderRepositoryTest.php
+++ b/tests/Domain/Reservation/ReminderRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/ReminderRepository.php');
 
-class ReminderRepositoryTests extends TestBase
+class ReminderRepositoryTest extends TestBase
 {
     /**
      * @var ReminderRepository

--- a/tests/Domain/Reservation/RepeatOptionsTest.php
+++ b/tests/Domain/Reservation/RepeatOptionsTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class RepeatOptionsTests extends TestBase
+class RepeatOptionsTest extends TestBase
 {
     //http://www.timeanddate.com/calendar/
 

--- a/tests/Domain/Reservation/ReservationRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationRepositoryTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class ReservationRepositoryTests extends TestBase
+class ReservationRepositoryTest extends TestBase
 {
     /**
      * @var ReservationRepository

--- a/tests/Domain/Reservation/ReservationRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationRepositoryTest.php
@@ -184,7 +184,7 @@ class ReservationRepositoryTest extends TestBase
         $repeats->expects($this->once())
             ->method('GetDates')
             ->with($this->anything())
-            ->will($this->returnValue($dates));
+            ->willReturn($dates);
 
         $userSession = new FakeUserSession();
 

--- a/tests/Domain/Reservation/ReservationServiceTest.php
+++ b/tests/Domain/Reservation/ReservationServiceTest.php
@@ -42,19 +42,19 @@ class ReservationServiceTest extends TestBase
             ->expects($this->once())
             ->method('GetReservations')
             ->with($this->equalTo($startDate), $this->equalTo($endDate), $this->isNull(), $this->isNull(), $this->equalTo($scheduleId), $this->isNull())
-            ->will($this->returnValue([$res1, $res2, $res3]));
+            ->willReturn([$res1, $res2, $res3]);
 
         $repository
             ->expects($this->once())
             ->method('GetBlackoutsWithin')
             ->with($this->equalTo(new DateRange($startDate, $endDate)), $this->equalTo($scheduleId))
-            ->will($this->returnValue([$blackout1, $blackout2, $blackout3]));
+            ->willReturn([$blackout1, $blackout2, $blackout3]);
 
         $listingFactory
             ->expects($this->once())
             ->method('CreateReservationListing')
             ->with($this->equalTo($timezone))
-            ->will($this->returnValue($reservationListing));
+            ->willReturn($reservationListing);
 
         $service = new ReservationService($repository, $listingFactory);
 

--- a/tests/Domain/Reservation/ReservationServiceTest.php
+++ b/tests/Domain/Reservation/ReservationServiceTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class ReservationServiceTests extends TestBase
+class ReservationServiceTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Domain/Reservation/ReservationTest.php
+++ b/tests/Domain/Reservation/ReservationTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class ReservationTests extends TestBase
+class ReservationTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Domain/Reservation/ReservationTest.php
+++ b/tests/Domain/Reservation/ReservationTest.php
@@ -39,7 +39,7 @@ class ReservationTest extends TestBase
         $repeatOptions->expects($this->once())
             ->method('GetDates')
             ->with($this->equalTo($dateRange->ToTimezone($userSession->Timezone)))
-            ->will($this->returnValue($repeatDates));
+            ->willReturn($repeatDates);
 
         $resource = new FakeBookableResource($resourceId);
         $series = ReservationSeries::Create(

--- a/tests/Domain/Reservation/ReservationViewRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationViewRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ReservationViewRepositoryTests extends TestBase
+class ReservationViewRepositoryTest extends TestBase
 {
     /**
      * @var ReservationViewRepository

--- a/tests/Domain/Reservation/ReservationWaitlistRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationWaitlistRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class ReservationWaitlistRepositoryTests extends TestBase
+class ReservationWaitlistRepositoryTest extends TestBase
 {
     /**
      * @var ReservationWaitlistRepository

--- a/tests/Domain/Resource/AccessoryRepositoryTest.php
+++ b/tests/Domain/Resource/AccessoryRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/AccessoryRepository.php');
 
-class AccessoryRepositoryTests extends TestBase
+class AccessoryRepositoryTest extends TestBase
 {
     /**
      * @var AccessoryRepository

--- a/tests/Domain/Resource/PermissionServiceTest.php
+++ b/tests/Domain/Resource/PermissionServiceTest.php
@@ -19,7 +19,7 @@ class PermissionServiceTest extends TestBase
         $store->expects($this->once())
             ->method('GetAllResources')
             ->with($this->equalTo($userId))
-            ->will($this->returnValue($resourceIdList));
+            ->willReturn($resourceIdList);
 
         $canAccess = $ps->CanAccessResource($resource, $user);
 
@@ -41,7 +41,7 @@ class PermissionServiceTest extends TestBase
         $store->expects($this->once())
             ->method('GetAllResources')
             ->with($this->equalTo($userId))
-            ->will($this->returnValue($resourceIdList));
+            ->willReturn($resourceIdList);
 
         $canAccess1 = $ps->CanAccessResource($resource, $user);
         $canAccess2 = $ps->CanAccessResource($resource, $user);

--- a/tests/Domain/Resource/PermissionServiceTest.php
+++ b/tests/Domain/Resource/PermissionServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class PermissionServiceTests extends TestBase
+class PermissionServiceTest extends TestBase
 {
     public function testAsksStoreForAllowedResourcesAndReturnsTrueIfItExists()
     {

--- a/tests/Domain/Resource/ResourceGroupTest.php
+++ b/tests/Domain/Resource/ResourceGroupTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ResourceGroupTests extends TestBase
+class ResourceGroupTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Domain/Resource/ResourceRepositoryTest.php
+++ b/tests/Domain/Resource/ResourceRepositoryTest.php
@@ -29,7 +29,7 @@ class ResourceRepositoryTest extends TestBase
         $scheduleId = 10;
 
         $ra = new FakeResourceAccess();
-        $rows = $ra->GetRows();
+        $rows = $ra->Rows();
         $this->db->SetRow(0, $rows);
 
         foreach ($rows as $row) {
@@ -238,7 +238,7 @@ class ResourceRepositoryTest extends TestBase
         $publicId = uniqid();
 
         $fr = new FakeResourceAccess();
-        $rows = $fr->GetRows();
+        $rows = $fr->Rows();
         $this->db->SetRow(0, $rows);
 
         $car = new CustomAttributeValueRow();
@@ -263,7 +263,7 @@ class ResourceRepositoryTest extends TestBase
         $id = 1;
 
         $fr = new FakeResourceAccess();
-        $rows = $fr->GetRows();
+        $rows = $fr->Rows();
         $this->db->SetRow(0, $rows);
 
         $car = new CustomAttributeValueRow();

--- a/tests/Domain/Resource/ResourceRepositoryTest.php
+++ b/tests/Domain/Resource/ResourceRepositoryTest.php
@@ -5,7 +5,7 @@ require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 require_once(ROOT_DIR . 'tests/fakes/namespace.php');
 
-class ResourceRepositoryTests extends TestBase
+class ResourceRepositoryTest extends TestBase
 {
     /**
      * @var ResourceRepository

--- a/tests/Domain/Resource/ResourcesTest.php
+++ b/tests/Domain/Resource/ResourcesTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 require_once(ROOT_DIR . 'lib/Config/namespace.php');
 
-class ResourcesTests extends TestBase
+class ResourcesTest extends TestBase
 {
     private $Resources;
 

--- a/tests/Domain/Schedule/ScheduleRepositoryTest.php
+++ b/tests/Domain/Schedule/ScheduleRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class ScheduleRepositoryTests extends TestBase
+class ScheduleRepositoryTest extends TestBase
 {
     /**
      * @var ScheduleRepository

--- a/tests/Domain/Schedule/ScheduleRepositoryTest.php
+++ b/tests/Domain/Schedule/ScheduleRepositoryTest.php
@@ -95,7 +95,7 @@ class ScheduleRepositoryTest extends TestBase
 
         $layoutFactory->expects($this->once())
                       ->method('CreateLayout')
-                      ->will($this->returnValue($expectedLayout));
+                      ->willReturn($expectedLayout);
 
         $layout = $this->scheduleRepository->GetLayout($scheduleId, $layoutFactory);
 
@@ -162,7 +162,7 @@ class ScheduleRepositoryTest extends TestBase
 
         $layoutFactory->expects($this->once())
                       ->method('CreateLayout')
-                      ->will($this->returnValue($expectedLayout));
+                      ->willReturn($expectedLayout);
 
         $layout = $this->scheduleRepository->GetLayout($scheduleId, $layoutFactory);
 
@@ -198,7 +198,7 @@ class ScheduleRepositoryTest extends TestBase
 
         $layoutFactory->expects($this->once())
                       ->method('CreateLayout')
-                      ->will($this->returnValue($expectedLayout));
+                      ->willReturn($expectedLayout);
 
         $layoutRows = [
                 ColumnNames::BLOCK_START => '02:00:00',
@@ -375,20 +375,20 @@ class ScheduleRepositoryTest extends TestBase
 
         $layout->expects($this->once())
                ->method('UsesDailyLayouts')
-               ->will($this->returnValue(false));
+               ->willReturn(false);
 
         $layout->expects($this->any())
                ->method('GetType')
-               ->will($this->returnValue(ScheduleLayout::Standard));
+               ->willReturn(ScheduleLayout::Standard);
 
         $layout->expects($this->once())
                ->method('Timezone')
-               ->will($this->returnValue($timezone));
+               ->willReturn($timezone);
 
         $layout->expects($this->once())
                ->method('GetSlots')
                ->with($this->isNull())
-               ->will($this->returnValue($slots));
+               ->willReturn($slots);
 
         $this->db->_ExpectedInsertId = $layoutId;
 
@@ -434,22 +434,19 @@ class ScheduleRepositoryTest extends TestBase
 
         $layout->expects($this->once())
                ->method('UsesDailyLayouts')
-               ->will($this->returnValue(true));
+               ->willReturn(true);
 
         $layout->expects($this->any())
                ->method('GetType')
-               ->will($this->returnValue(ScheduleLayout::Standard));
+               ->willReturn(ScheduleLayout::Standard);
 
         $layout->expects($this->once())
                ->method('Timezone')
-               ->will($this->returnValue($timezone));
+               ->willReturn($timezone);
 
-        foreach (DayOfWeek::Days() as $day) {
-            $layout->expects($this->at($day + 3))
-                   ->method('GetSlots')
-                   ->with($this->equalTo($day))
-                   ->will($this->returnValue($slots));
-        }
+        $layout->expects($this->exactly(count(DayOfWeek::Days())))
+                ->method('GetSlots')
+                ->willReturn($slots);
 
         $this->db->_ExpectedInsertId = $layoutId;
 

--- a/tests/Domain/Schedule/ScheduleUserRepositoryTest.php
+++ b/tests/Domain/Schedule/ScheduleUserRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ScheduleUserRepositoryTests extends TestBase
+class ScheduleUserRepositoryTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Domain/User/GroupRepositoryTest.php
+++ b/tests/Domain/User/GroupRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 
-class GroupRepositoryTests extends TestBase
+class GroupRepositoryTest extends TestBase
 {
     /**
      * @var GroupRepository

--- a/tests/Domain/User/UserRepositoryTest.php
+++ b/tests/Domain/User/UserRepositoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class UserRepositoryTests extends TestBase
+class UserRepositoryTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Domain/User/UserSessionRepositoryTest.php
+++ b/tests/Domain/User/UserSessionRepositoryTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Access/UserSessionRepository.php');
 
-class UserSessionRepositoryTests extends TestBase
+class UserSessionRepositoryTest extends TestBase
 {
     /**
      * @var UserSessionRepository

--- a/tests/Domain/User/UserTest.php
+++ b/tests/Domain/User/UserTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class UserTests extends TestBase
+class UserTest extends TestBase
 {
     public function testUserIsGroupAdminIfAtLeastOneGroupIsAnAdminGroup()
     {

--- a/tests/Infrastructure/Common/DateTest.php
+++ b/tests/Infrastructure/Common/DateTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
-class DateTests extends TestBase
+class DateTest extends TestBase
 {
     private $tz;
     private $datestring;

--- a/tests/Infrastructure/Common/PluginManagerTest__BROKEN.php
+++ b/tests/Infrastructure/Common/PluginManagerTest__BROKEN.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
-class PluginManagerTests extends TestBase
+class PluginManagerTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/Infrastructure/Common/SmartyControlTest.php
+++ b/tests/Infrastructure/Common/SmartyControlTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Common/SmartyControls/namespace.php');
 
-class SmartyControlTests extends TestBase
+class SmartyControlTest extends TestBase
 {
     private $_server;
     private $_attributes = 'style="font-size:12px;" class="something"';

--- a/tests/Infrastructure/Common/ValidatorTest.php
+++ b/tests/Infrastructure/Common/ValidatorTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
-class ValidatorTests extends TestBase
+class ValidatorTest extends TestBase
 {
     public function testValidatorsAreEvaluatedWhenRegistered()
     {

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Config/namespace.php');
 
-class ConfigTests extends TestBase
+class ConfigTest extends TestBase
 {
     public function setup(): void
     {

--- a/tests/Infrastructure/Database/DatabaseCommandTest.php
+++ b/tests/Infrastructure/Database/DatabaseCommandTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'lib/Database/Commands/namespace.php');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
-class DatabaseCommandTests extends TestBase
+class DatabaseCommandTest extends TestBase
 {
     public function testAuthorizationCommand()
     {

--- a/tests/Infrastructure/Database/DatabaseTest.php
+++ b/tests/Infrastructure/Database/DatabaseTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/Database/namespace.php');
 
-class DatabaseTests extends TestBase
+class DatabaseTest extends TestBase
 {
     public $db = null;
 

--- a/tests/Plugins/Authentication/ActiveDirectory/ActiveDirectoryTest_BROKEN.php
+++ b/tests/Plugins/Authentication/ActiveDirectory/ActiveDirectoryTest_BROKEN.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'plugins/Authentication/ActiveDirectory/namespace.php');
 
-class ActiveDirectoryTests extends TestBase
+class ActiveDirectoryTest extends TestBase
 {
     /**
      * @var FakeAuth

--- a/tests/Plugins/Authentication/Ldap/LdapTest_BROKEN.php
+++ b/tests/Plugins/Authentication/Ldap/LdapTest_BROKEN.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'plugins/Authentication/Ldap/namespace.php');
 
-class LdapTests extends TestBase
+class LdapTest extends TestBase
 {
     /**
      * @var FakeAuth
@@ -329,7 +329,7 @@ class LdapTests extends TestBase
     }
 }
 
-class LdapIntegrationTests extends TestBase
+class LdapIntegrationTest extends TestBase
 {
     public function testAuthRealLdap()
     {

--- a/tests/Presenters/ActivationPresenterTest.php
+++ b/tests/Presenters/ActivationPresenterTest.php
@@ -45,7 +45,7 @@ class ActivationPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetActivationCode')
-                ->will($this->returnValue($activationCode));
+                ->willReturn($activationCode);
 
         $this->page->expects($this->once())
                 ->method('Redirect')
@@ -67,7 +67,7 @@ class ActivationPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetActivationCode')
-                ->will($this->returnValue($activationCode));
+                ->willReturn($activationCode);
 
         $this->page->expects($this->once())
                 ->method('ShowError');

--- a/tests/Presenters/ActivationPresenterTest.php
+++ b/tests/Presenters/ActivationPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/ActivationPresenter.php');
 
-class ActivationPresenterTests extends TestBase
+class ActivationPresenterTest extends TestBase
 {
     /**
      * @var ActivationPresenter

--- a/tests/Presenters/Admin/ImportICalPresenterTest.php
+++ b/tests/Presenters/Admin/ImportICalPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Admin/Import/ICalImportPresenter.php');
 
-class ImportICalPresenterTests extends TestBase
+class ImportICalPresenterTest extends TestBase
 {
     public function testCreatesEverything()
     {

--- a/tests/Presenters/Admin/ManageAccessoriesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageAccessoriesPresenterTest.php
@@ -51,11 +51,11 @@ class ManageAccessoriesPresenterTest extends TestBase
 
         $this->resourceRepository->expects($this->once())
             ->method('GetAccessoryList')
-            ->will($this->returnValue($accessories));
+            ->willReturn($accessories);
 
         $this->resourceRepository->expects($this->once())
             ->method('GetResourceList')
-            ->will($this->returnValue($resources));
+            ->willReturn($resources);
 
         $this->page->expects($this->once())
             ->method('BindAccessories')
@@ -77,11 +77,11 @@ class ManageAccessoriesPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetAccessoryName')
-                ->will($this->returnValue($name));
+                ->willReturn($name);
 
         $this->page->expects($this->once())
                 ->method('GetQuantityAvailable')
-                ->will($this->returnValue($quantity));
+                ->willReturn($quantity);
 
         $this->accessoryRepository->expects($this->once())
             ->method('Add')
@@ -101,20 +101,20 @@ class ManageAccessoriesPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetAccessoryId')
-                ->will($this->returnValue($id));
+                ->willReturn($id);
 
         $this->page->expects($this->once())
                 ->method('GetAccessoryName')
-                ->will($this->returnValue($name));
+                ->willReturn($name);
 
         $this->page->expects($this->once())
                 ->method('GetQuantityAvailable')
-                ->will($this->returnValue($quantity));
+                ->willReturn($quantity);
 
         $this->accessoryRepository->expects($this->once())
             ->method('LoadById')
             ->with($this->equalTo($id))
-            ->will($this->returnValue($currentAccessory));
+            ->willReturn($currentAccessory);
 
         $this->accessoryRepository->expects($this->once())
             ->method('Update')
@@ -129,7 +129,7 @@ class ManageAccessoriesPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetAccessoryId')
-                ->will($this->returnValue($id));
+                ->willReturn($id);
 
         $this->accessoryRepository->expects($this->once())
             ->method('Delete')

--- a/tests/Presenters/Admin/ManageAccessoriesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageAccessoriesPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Pages/Admin/ManageAccessoriesPage.php');
 
-class ManageAccessoriesPresenterTests extends TestBase
+class ManageAccessoriesPresenterTest extends TestBase
 {
     /**
      * @var IManageAccessoriesPage|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/Admin/ManageAttributesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageAttributesPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 require_once(ROOT_DIR . 'Pages/Admin/ManageAttributesPage.php');
 
-class ManageAttributesPresenterTests extends TestBase
+class ManageAttributesPresenterTest extends TestBase
 {
     /**
      * @var FakeAttributePage

--- a/tests/Presenters/Admin/ManageAttributesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageAttributesPresenterTest.php
@@ -40,7 +40,7 @@ class ManageAttributesPresenterTest extends TestBase
         $this->attributeRepository->expects($this->once())
                 ->method('GetByCategory')
                 ->with($this->equalTo($categoryId))
-                ->will($this->returnValue($attributes));
+                ->willReturn($attributes);
 
         $this->presenter->HandleDataRequest('');
 
@@ -79,7 +79,7 @@ class ManageAttributesPresenterTest extends TestBase
         $this->attributeRepository->expects($this->once())
                 ->method('Add')
                 ->with($this->equalTo($expectedAttribute))
-                ->will($this->returnValue(1));
+                ->willReturn(1);
 
         $this->presenter->AddAttribute();
     }
@@ -115,7 +115,7 @@ class ManageAttributesPresenterTest extends TestBase
         $this->attributeRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($attributeId))
-                ->will($this->returnValue($expectedAttribute));
+                ->willReturn($expectedAttribute);
 
         $this->attributeRepository->expects($this->once())
                 ->method('Update')

--- a/tests/Presenters/Admin/ManageBlackoutsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageBlackoutsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Admin/ManageBlackoutsPresenter.php');
 
-class ManageBlackoutsPresenterTests extends TestBase
+class ManageBlackoutsPresenterTest extends TestBase
 {
     /**
      * @var ManageBlackoutsPresenter

--- a/tests/Presenters/Admin/ManageBlackoutsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageBlackoutsPresenterTest.php
@@ -56,26 +56,26 @@ class ManageBlackoutsPresenterTest extends TestBase
 
         $this->page->expects($this->atLeastOnce())
                 ->method('GetStartDate')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->page->expects($this->atLeastOnce())
                 ->method('GetEndDate')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->page->expects($this->once())
             ->method('GetScheduleId')
-            ->will($this->returnValue($searchedScheduleId));
+            ->willReturn($searchedScheduleId);
 
         $this->page->expects($this->once())
             ->method('GetResourceId')
-            ->will($this->returnValue($searchedResourceId));
+            ->willReturn($searchedResourceId);
 
         $filter = $this->GetExpectedFilter($defaultStart, $defaultEnd, $searchedScheduleId, $searchedResourceId);
         $data = new PageableData();
         $this->blackoutsService->expects($this->once())
                 ->method('LoadFiltered')
                 ->with($this->anything(), $this->anything(), $this->anything(), $this->anything(), $this->equalTo($filter), $this->equalTo($this->fakeUser))
-                ->will($this->returnValue($data));
+                ->willReturn($data);
 
         $this->page->expects($this->once())
                 ->method('SetStartDate')
@@ -123,11 +123,11 @@ class ManageBlackoutsPresenterTest extends TestBase
         $resourceId = 123;
         $this->page->expects($this->once())
             ->method('GetBlackoutResourceId')
-            ->will($this->returnValue($resourceId));
+            ->willReturn($resourceId);
 
         $this->page->expects($this->once())
             ->method('GetApplyBlackoutToAllResources')
-            ->will($this->returnValue(false));
+            ->willReturn(false);
 
         $result = $this->createMock('IBlackoutValidationResult');
         $this->blackoutsService->expects($this->once())
@@ -139,7 +139,7 @@ class ManageBlackoutsPresenterTest extends TestBase
                 $this->equalTo($conflictResolution),
                 $this->equalTo($repeatOptions)
             )
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $this->presenter->AddBlackout();
     }
@@ -172,17 +172,17 @@ class ManageBlackoutsPresenterTest extends TestBase
         $scheduleId = 123;
         $this->page->expects($this->once())
             ->method('GetBlackoutScheduleId')
-            ->will($this->returnValue($scheduleId));
+            ->willReturn($scheduleId);
 
         $this->page->expects($this->once())
             ->method('GetApplyBlackoutToAllResources')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $resources = [new FakeBookableResource(1), new FakeBookableResource(2), new FakeBookableResource(3)];
         $this->resourceRepository->expects($this->once())
             ->method('GetScheduleResources')
             ->with($this->equalTo($scheduleId))
-            ->will($this->returnValue($resources));
+            ->willReturn($resources);
 
         $result = $this->createMock('IBlackoutValidationResult');
         $this->blackoutsService->expects($this->once())
@@ -194,7 +194,7 @@ class ManageBlackoutsPresenterTest extends TestBase
                 $this->equalTo($conflictResolution),
                 $this->equalTo($repeatOptions)
             )
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $this->presenter->AddBlackout();
     }
@@ -206,11 +206,11 @@ class ManageBlackoutsPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                     ->method('GetBlackoutId')
-                    ->will($this->returnValue($id));
+                    ->willReturn($id);
 
         $this->page->expects($this->once())
                             ->method('GetSeriesUpdateScope')
-                            ->will($this->returnValue(SeriesUpdateScope::ThisInstance));
+                            ->willReturn(SeriesUpdateScope::ThisInstance);
 
         $this->blackoutsService->expects($this->once())
                     ->method('Delete')
@@ -234,7 +234,7 @@ class ManageBlackoutsPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                    ->method('GetBlackoutId')
-                   ->will($this->returnValue($id));
+                   ->willReturn($id);
 
         $this->page->expects($this->once())
                     ->method('SetBlackoutResources')
@@ -290,7 +290,7 @@ class ManageBlackoutsPresenterTest extends TestBase
         $this->blackoutsService->expects($this->once())
                                ->method('LoadBlackout')
                                ->with($this->equalTo($id), $this->equalTo($this->fakeUser->UserId))
-                               ->will($this->returnValue($series));
+                               ->willReturn($series);
 
         $this->presenter->LoadBlackout();
     }
@@ -324,15 +324,15 @@ class ManageBlackoutsPresenterTest extends TestBase
         $resourceIds = [123, 456];
         $this->page->expects($this->once())
             ->method('GetBlackoutResourceIds')
-            ->will($this->returnValue($resourceIds));
+            ->willReturn($resourceIds);
 
         $this->page->expects($this->once())
             ->method('GetUpdateBlackoutId')
-            ->will($this->returnValue($blackoutInstanceId));
+            ->willReturn($blackoutInstanceId);
 
         $this->page->expects($this->once())
             ->method('GetSeriesUpdateScope')
-            ->will($this->returnValue($scope));
+            ->willReturn($scope);
 
         $result = $this->createMock('IBlackoutValidationResult');
 
@@ -347,7 +347,7 @@ class ManageBlackoutsPresenterTest extends TestBase
                 $this->equalTo($repeatOptions),
                 $this->equalTo($scope)
             )
-            ->will($this->returnValue($result));
+            ->willReturn($result);
 
         $this->presenter->UpdateBlackout();
     }
@@ -368,53 +368,53 @@ class ManageBlackoutsPresenterTest extends TestBase
     {
         $this->page->expects($this->once())
             ->method('GetBlackoutStartDate')
-            ->will($this->returnValue($startDate));
+            ->willReturn($startDate);
 
         $this->page->expects($this->once())
             ->method('GetBlackoutStartTime')
-            ->will($this->returnValue($startTime));
+            ->willReturn($startTime);
 
         $this->page->expects($this->once())
             ->method('GetBlackoutEndDate')
-            ->will($this->returnValue($endDate));
+            ->willReturn($endDate);
 
         $this->page->expects($this->once())
             ->method('GetBlackoutEndTime')
-            ->will($this->returnValue($endTime));
+            ->willReturn($endTime);
 
         $this->page->expects($this->once())
             ->method('GetBlackoutTitle')
-            ->will($this->returnValue($title));
+            ->willReturn($title);
 
         $this->page->expects($this->once())
             ->method('GetBlackoutConflictAction')
-            ->will($this->returnValue($conflictAction));
+            ->willReturn($conflictAction);
     }
 
     private function ExpectPageToReturnRepeatInfo($repeatType = RepeatType::None, $repeatInterval = null, $endDateString = null, $repeatDays = null, $repeatMonthlyType = null)
     {
         $this->page->expects($this->any())
                     ->method('GetRepeatType')
-                    ->will($this->returnValue($repeatType));
+                    ->willReturn($repeatType);
 
         $this->page->expects($this->any())
                     ->method('GetRepeatInterval')
-                    ->will($this->returnValue($repeatInterval));
+                    ->willReturn($repeatInterval);
 
         $this->page->expects($this->any())
                     ->method('GetRepeatTerminationDate')
-                    ->will($this->returnValue($endDateString));
+                    ->willReturn($endDateString);
 
         $this->page->expects($this->any())
                     ->method('GetRepeatWeekdays')
-                    ->will($this->returnValue($repeatDays));
+                    ->willReturn($repeatDays);
 
         $this->page->expects($this->any())
                     ->method('GetRepeatMonthlyType')
-                    ->will($this->returnValue($repeatMonthlyType));
+                    ->willReturn($repeatMonthlyType);
 
         $this->page->expects($this->once())
                     ->method('GetRepeatCustomDates')
-                    ->will($this->returnValue([]));
+                    ->willReturn([]);
     }
 }

--- a/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
+++ b/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
@@ -51,7 +51,7 @@ class ManageConfigurationPresenterTest extends TestBase
         $this->configSettings->expects($this->once())
                 ->method('CanOverwriteFile')
                 ->with($this->equalTo($this->configFilePath))
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
         $this->presenter->PageLoad();
 
@@ -63,14 +63,14 @@ class ManageConfigurationPresenterTest extends TestBase
         $this->configSettings->expects($this->once())
                 ->method('CanOverwriteFile')
                 ->with($this->equalTo($this->configFilePath))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $configValues = $this->getDefaultConfigValues();
 
         $this->configSettings->expects($this->once())
                 ->method('GetSettings')
                 ->with($this->equalTo($this->configFilePath))
-                ->will($this->returnValue($configValues));
+                ->willReturn($configValues);
 
         $this->presenter->PageLoad();
 
@@ -115,7 +115,7 @@ class ManageConfigurationPresenterTest extends TestBase
         $this->configSettings->expects($this->once())
                 ->method('GetSettings')
                 ->with($this->equalTo($this->configFilePath))
-                ->will($this->returnValue($existingValues));
+                ->willReturn($existingValues);
 
         $this->configSettings->expects($this->once())
                 ->method('WriteSettings')

--- a/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
+++ b/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Admin/ManageConfigurationPresenter.php');
 
-class ManageConfigurationPresenterTests extends TestBase
+class ManageConfigurationPresenterTest extends TestBase
 {
     /**
      * @var ManageConfigurationPresenter

--- a/tests/Presenters/Admin/ManageEmailTemplatesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageEmailTemplatesPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Admin/ManageEmailTemplatesPresenter.php');
 
-class ManageEmailTemplatesPresenterTests extends TestBase
+class ManageEmailTemplatesPresenterTest extends TestBase
 {
     /**
      * @var FakeManageEmailTemplatesPage

--- a/tests/Presenters/Admin/ManagePaymentsPresenterTest.php
+++ b/tests/Presenters/Admin/ManagePaymentsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Admin/ManagePaymentsPresenter.php');
 
-class ManagePaymentsPresenterTests extends TestBase
+class ManagePaymentsPresenterTest extends TestBase
 {
     /**
      * @var FakeManagePaymentsPage

--- a/tests/Presenters/Admin/ManagePaymentsPresenterTest.php
+++ b/tests/Presenters/Admin/ManagePaymentsPresenterTest.php
@@ -33,8 +33,8 @@ class ManagePaymentsPresenterTest extends TestBase
 
         $this->presenter->PageLoad();
 
-        $this->assertEquals($creditCost->Cost(), $this->page->_CreditCost);
-        $this->assertEquals($creditCost->Currency(), $this->page->_CreditCurrency);
+        $this->assertEquals($creditCost->Cost(), $this->page->_CreditCost->Cost());
+        $this->assertEquals($creditCost->Currency(), $this->page->_CreditCost->Currency());
     }
 
     public function testPageLoadSetsGatewayValues()
@@ -64,7 +64,7 @@ class ManagePaymentsPresenterTest extends TestBase
 
         $this->presenter->UpdateCreditCost();
 
-        $this->assertEquals(new CreditCost($this->page->_CreditCost, $this->page->_CreditCurrency), $this->paymentRepository->_LastCost);
+        $this->assertEquals(new CreditCost(1, $this->page->_CreditCost, $this->page->_CreditCurrency), $this->paymentRepository->_LastCost);
     }
 
     public function testUpdatesPaymentGateways()
@@ -170,7 +170,6 @@ class ManagePaymentsPresenterTest extends TestBase
 
 class FakeManagePaymentsPage extends ManagePaymentsPage
 {
-    public $_CreditCount;
     public $_CreditCost;
     public $_CreditCurrency;
     public $_PayPalEnabled;
@@ -204,11 +203,9 @@ class FakeManagePaymentsPage extends ManagePaymentsPage
         return $this->_CreditCurrency;
     }
 
-    public function SetCreditCost($count, $cost, $currency)
+    public function SetCreditCosts($cost)
     {
-        $this->_CreditCount = $count;
         $this->_CreditCost = $cost;
-        $this->_CreditCurrency = $currency;
     }
 
     public function GetPayPalIsEnabled()

--- a/tests/Presenters/Admin/ManageQuotasPresenterTest.php
+++ b/tests/Presenters/Admin/ManageQuotasPresenterTest.php
@@ -70,7 +70,7 @@ class ManageQuotasPresenterTest extends TestBase
 
         $this->resourceRepository->expects($this->once())
                                  ->method('GetResourceList')
-                                 ->will($this->returnValue($bookableResources));
+                                 ->willReturn($bookableResources);
 
         $this->page->expects($this->once())
                    ->method('BindResources')
@@ -78,7 +78,7 @@ class ManageQuotasPresenterTest extends TestBase
 
         $this->groupRepository->expects($this->once())
                               ->method('GetList')
-                              ->will($this->returnValue($groupResult));
+                              ->willReturn($groupResult);
 
         $this->page->expects($this->once())
                    ->method('BindGroups')
@@ -86,7 +86,7 @@ class ManageQuotasPresenterTest extends TestBase
 
         $this->scheduleRepository->expects($this->once())
                                  ->method('GetAll')
-                                 ->will($this->returnValue($schedules));
+                                 ->willReturn($schedules);
 
         $this->page->expects($this->once())
                    ->method('BindSchedules')
@@ -94,7 +94,7 @@ class ManageQuotasPresenterTest extends TestBase
 
         $this->quotaRepository->expects($this->once())
                               ->method('GetAll')
-                              ->will($this->returnValue($quotaList));
+                              ->willReturn($quotaList);
 
         $this->presenter->PageLoad();
     }
@@ -114,51 +114,51 @@ class ManageQuotasPresenterTest extends TestBase
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetDuration')
-                   ->will($this->returnValue($duration));
+                   ->willReturn($duration);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetLimit')
-                   ->will($this->returnValue($limit));
+                   ->willReturn($limit);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetUnit')
-                   ->will($this->returnValue($unit));
+                   ->willReturn($unit);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetResourceId')
-                   ->will($this->returnValue($resourceId));
+                   ->willReturn($resourceId);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetGroupId')
-                   ->will($this->returnValue($groupId));
+                   ->willReturn($groupId);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetScheduleId')
-                   ->will($this->returnValue($scheduleId));
+                   ->willReturn($scheduleId);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetEnforcedAllDay')
-                   ->will($this->returnValue(false));
+                   ->willReturn(false);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetEnforcedStartTime')
-                   ->will($this->returnValue($enforcedStartTime));
+                   ->willReturn($enforcedStartTime);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetEnforcedEndTime')
-                   ->will($this->returnValue($enforcedEndTime));
+                   ->willReturn($enforcedEndTime);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetEnforcedEveryDay')
-                   ->will($this->returnValue(false));
+                   ->willReturn(false);
 
         $this->page->expects($this->atLeastOnce())
                    ->method('GetEnforcedDays')
-                   ->will($this->returnValue($enforcedDays));
+                   ->willReturn($enforcedDays);
 
         $this->page->expects($this->atLeastOnce())
                         ->method('GetScope')
-                        ->will($this->returnValue($scope));
+                        ->willReturn($scope);
 
         $expectedQuota = Quota::Create($duration, $limit, $unit, $resourceId, $groupId, $scheduleId, $enforcedStartTime, $enforcedEndTime, $enforcedDays, $scope);
 

--- a/tests/Presenters/Admin/ManageQuotasPresenterTest.php
+++ b/tests/Presenters/Admin/ManageQuotasPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Pages/Admin/ManageQuotasPage.php');
 
-class ManageQuotasPresenterTests extends TestBase
+class ManageQuotasPresenterTest extends TestBase
 {
     /**
      * @var IManageQuotasPage|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/Admin/ManageReservationsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageReservationsPresenterTest.php
@@ -69,7 +69,7 @@ class ManageReservationsPresenterTest extends TestBase
         $this->userRepository->expects($this->any())
             ->method('LoadById')
             ->with($this->anything())
-            ->will($this->returnValue(new FakeUser()));
+            ->willReturn(new FakeUser());
     }
 
     public function testUsesTwoWeekSpanWhenNoDateFilterProvided()
@@ -92,55 +92,55 @@ class ManageReservationsPresenterTest extends TestBase
 
         $this->resourceRepository->expects($this->once())
             ->method('GetStatusReasons')
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $this->page->expects($this->any())
             ->method('FilterButtonPressed')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetStartDate')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetEndDate')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetScheduleId')
-            ->will($this->returnValue($searchedScheduleId));
+            ->willReturn($searchedScheduleId);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetResourceId')
-            ->will($this->returnValue($searchedResourceId));
+            ->willReturn($searchedResourceId);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetReservationStatusId')
-            ->will($this->returnValue($searchedStatusId));
+            ->willReturn($searchedStatusId);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetUserId')
-            ->will($this->returnValue($searchedUserId));
+            ->willReturn($searchedUserId);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetUserName')
-            ->will($this->returnValue($searchedUserName));
+            ->willReturn($searchedUserName);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetReferenceNumber')
-            ->will($this->returnValue($searchedReferenceNumber));
+            ->willReturn($searchedReferenceNumber);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetResourceStatusFilterId')
-            ->will($this->returnValue($searchedResourceStatusId));
+            ->willReturn($searchedResourceStatusId);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetResourceStatusReasonFilterId')
-            ->will($this->returnValue($searchedResourceStatusReasonId));
+            ->willReturn($searchedResourceStatusReasonId);
 
         $this->page->expects($this->atLeastOnce())
             ->method('GetAttributeFilters')
-            ->will($this->returnValue([new AttributeFormElement($customAttributes[0]->Id(), 'value')]));
+            ->willReturn([new AttributeFormElement($customAttributes[0]->Id(), 'value')]);
 
         $filter = $this->GetExpectedFilter(
             $defaultStart,
@@ -166,12 +166,12 @@ class ManageReservationsPresenterTest extends TestBase
                 $this->equalTo($filter),
                 $this->equalTo($this->fakeUser)
             )
-            ->will($this->returnValue($data));
+            ->willReturn($data);
 
         $this->attributeService->expects($this->once())
             ->method('GetByCategory')
             ->with($this->equalTo(CustomAttributeCategory::RESERVATION))
-            ->will($this->returnValue($customAttributes));
+            ->willReturn($customAttributes);
 
         $this->page->expects($this->once())
             ->method('SetAttributeFilters')
@@ -236,32 +236,32 @@ class ManageReservationsPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('CanUpdateResourceStatuses')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->page->expects($this->once())
             ->method('GetResourceStatus')
-            ->will($this->returnValue($resourceStatusId));
+            ->willReturn($resourceStatusId);
 
         $this->page->expects($this->once())
             ->method('GetUpdateScope')
-            ->will($this->returnValue(''));
+            ->willReturn('');
 
         $this->page->expects($this->once())
             ->method('GetResourceStatusReason')
-            ->will($this->returnValue($resourceStatusReasonId));
+            ->willReturn($resourceStatusReasonId);
 
         $this->page->expects($this->once())
             ->method('GetUpdateResourceId')
-            ->will($this->returnValue($resourceId));
+            ->willReturn($resourceId);
 
         $this->page->expects($this->once())
             ->method('GetResourceStatusReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->resourceRepository->expects($this->once())
             ->method('LoadById')
             ->with($resourceId)
-            ->will($this->returnValue($resource));
+            ->willReturn($resource);
 
         $this->resourceRepository->expects($this->once())
             ->method('Update')
@@ -290,23 +290,23 @@ class ManageReservationsPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('CanUpdateResourceStatuses')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->page->expects($this->once())
             ->method('GetResourceStatus')
-            ->will($this->returnValue($resourceStatusId));
+            ->willReturn($resourceStatusId);
 
         $this->page->expects($this->once())
             ->method('GetUpdateScope')
-            ->will($this->returnValue('all'));
+            ->willReturn('all');
 
         $this->page->expects($this->once())
             ->method('GetResourceStatusReason')
-            ->will($this->returnValue($resourceStatusReasonId));
+            ->willReturn($resourceStatusReasonId);
 
         $this->page->expects($this->once())
             ->method('GetResourceStatusReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->reservationsService->expects($this->once())
             ->method('LoadFiltered')
@@ -318,23 +318,17 @@ class ManageReservationsPresenterTest extends TestBase
                 $this->equalTo(new ReservationFilter(null, null, $referenceNumber, null, null, null, null, null)),
                 $this->equalTo($this->fakeUser)
             )
-            ->will($this->returnValue($pageableReservations));
+            ->willReturn($pageableReservations);
 
-        $this->resourceRepository->expects($this->at(0))
+        $this->resourceRepository->expects($this->exactly(2))
             ->method('LoadById')
-            ->with(1)
-            ->will($this->returnValue($resource1));
+            ->willReturnMap(
+            [
+                [1, $resource1],
+                [2, $resource2]
+            ]);
 
-        $this->resourceRepository->expects($this->at(2))
-            ->method('LoadById')
-            ->with(2)
-            ->will($this->returnValue($resource2));
-
-        $this->resourceRepository->expects($this->at(1))
-            ->method('Update')
-            ->with($this->anything());
-
-        $this->resourceRepository->expects($this->at(3))
+        $this->resourceRepository->expects($this->exactly(2))
             ->method('Update')
             ->with($this->anything());
 
@@ -352,12 +346,12 @@ class ManageReservationsPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->reservationsService->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($referenceNumber), $this->equalTo($this->fakeUser))
-            ->will($this->returnValue($reservationView));
+            ->willReturn($reservationView);
 
         $this->page->expects($this->once())
             ->method('SetReservationJson')
@@ -374,20 +368,20 @@ class ManageReservationsPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->page->expects($this->once())
             ->method('GetName')
-            ->will($this->returnValue($attrId));
+            ->willReturn($attrId);
 
         $this->page->expects($this->once())
             ->method('GetValue')
-            ->will($this->returnValue($attrValue));
+            ->willReturn($attrValue);
 
         $this->reservationsService->expects($this->once())
             ->method('UpdateAttribute')
             ->with($this->equalTo($referenceNumber), $this->equalTo($attrId), $this->equalTo($attrValue), $this->equalTo($this->fakeUser))
-            ->will($this->returnValue([]));
+            ->willReturn([]);
 
         $this->presenter->UpdateAttribute();
     }
@@ -420,28 +414,32 @@ class ManageReservationsPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetImportFile')
-            ->will($this->returnValue($importFile));
+            ->willReturn($importFile);
 
         $this->attributeService->expects($this->once())
             ->method('GetByCategory')
             ->with($this->equalTo(CustomAttributeCategory::RESERVATION))
-            ->will($this->returnValue($attributes));
+            ->willReturn($attributes);
 
         $this->resourceRepository->expects($this->once())
             ->method('GetResourceList')
-            ->will($this->returnValue($resources));
+            ->willReturn($resources);
 
         $this->userRepository->expects($this->once())
             ->method('GetAll')
-            ->will($this->returnValue($users));
+            ->willReturn($users);
 
-        $this->reservationsService->expects($this->at(0))
+        $matcher = $this->exactly(2);
+        $this->reservationsService->expects($matcher)
             ->method('UnsafeAdd')
-            ->with($this->equalTo($res1));
-
-        $this->reservationsService->expects($this->at(1))
-            ->method('UnsafeAdd')
-            ->with($this->equalTo($res2));
+            ->willReturnCallback(function ($res) use ($matcher, $res1, $res2)
+            {
+                match ($matcher->numberOfInvocations())
+                {
+                    1 => $this->assertEquals($res, $res1),
+                    2 => $this->assertEquals($res, $res2)
+                };
+            });
 
         $this->page->expects($this->once())
             ->method('SetImportResult')
@@ -456,15 +454,20 @@ class ManageReservationsPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetDeletedReservationIds')
-            ->will($this->returnValue($ids));
+            ->willReturn($ids);
 
-        $this->reservationsService->expects($this->at(0))
+        $matcher = $this->exactly(2);
+        $this->reservationsService->expects($matcher)
             ->method('UnsafeDelete')
-            ->with($this->equalTo(1), $this->equalTo($this->fakeUser));
-
-        $this->reservationsService->expects($this->at(1))
-            ->method('UnsafeDelete')
-            ->with($this->equalTo(2), $this->equalTo($this->fakeUser));
+            ->willReturnCallback(function(int $id, UserSession $session) use ($matcher)
+            {
+                $this->assertEquals($this->fakeUser, $session);
+                match ($matcher->numberOfInvocations())
+                {
+                    1 => $this->assertEquals(1, $id),
+                    2 => $this->assertEquals(2, $id)
+                };
+            });
 
         $this->presenter->DeleteMultiple();
     }

--- a/tests/Presenters/Admin/ManageReservationsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageReservationsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Admin/ManageReservationsPresenter.php');
 
-class ManageReservationsPresenterTests extends TestBase
+class ManageReservationsPresenterTest extends TestBase
 {
     /**
      * @var ManageReservationsPresenter

--- a/tests/Presenters/Admin/ManageResourceGroupsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageResourceGroupsPresenterTest.php
@@ -38,12 +38,12 @@ class ManageResourceGroupsPresenterTest extends TestBase
         $this->resourceRepository
                 ->expects($this->once())
         ->method('GetResourceGroups')
-        ->will($this->returnValue($groupTree));
+        ->willReturn($groupTree);
 
         $this->resourceRepository
                 ->expects($this->once())
         ->method('GetResourceList')
-        ->will($this->returnValue($resources));
+        ->willReturn($resources);
 
         $this->page
                 ->expects($this->atLeastOnce())
@@ -66,12 +66,12 @@ class ManageResourceGroupsPresenterTest extends TestBase
         $this->page
                 ->expects($this->atLeastOnce())
         ->method('GetResourceId')
-        ->will($this->returnValue($resourceId));
+        ->willReturn($resourceId);
 
         $this->page
                 ->expects($this->atLeastOnce())
         ->method('GetGroupId')
-        ->will($this->returnValue($groupId));
+        ->willReturn($groupId);
 
         $this->resourceRepository
                 ->expects($this->once())
@@ -89,12 +89,12 @@ class ManageResourceGroupsPresenterTest extends TestBase
         $this->page
                 ->expects($this->atLeastOnce())
         ->method('GetResourceId')
-        ->will($this->returnValue($resourceId));
+        ->willReturn($resourceId);
 
         $this->page
                 ->expects($this->atLeastOnce())
         ->method('GetGroupId')
-        ->will($this->returnValue($groupId));
+        ->willReturn($groupId);
 
         $this->resourceRepository
                 ->expects($this->once())
@@ -117,28 +117,28 @@ class ManageResourceGroupsPresenterTest extends TestBase
         $this->page
                 ->expects($this->atLeastOnce())
         ->method('GetNodeId')
-        ->will($this->returnValue($nodeId));
+        ->willReturn($nodeId);
 
         $this->page
                 ->expects($this->atLeastOnce())
         ->method('GetTargetNodeId')
-        ->will($this->returnValue($targetId));
+        ->willReturn($targetId);
 
         $this->page
                 ->expects($this->atLeastOnce())
         ->method('GetNodeType')
-        ->will($this->returnValue($nodeType));
+        ->willReturn($nodeType);
 
         $this->page
                 ->expects($this->atLeastOnce())
         ->method('GetPreviousNodeId')
-        ->will($this->returnValue($previousNodeId));
+        ->willReturn($previousNodeId);
 
         $this->resourceRepository
                 ->expects($this->once())
         ->method('LoadResourceGroup')
         ->with($this->equalTo($nodeId))
-        ->will($this->returnValue($group));
+        ->willReturn($group);
 
         $this->resourceRepository
                 ->expects($this->once())

--- a/tests/Presenters/Admin/ManageResourceGroupsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageResourceGroupsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Admin/ManageResourceGroupsPresenter.php');
 
-class ManageResourceGroupsPresenterTests extends TestBase
+class ManageResourceGroupsPresenterTest extends TestBase
 {
     /**
      * @var ManageResourceGroupsPresenter

--- a/tests/Presenters/Admin/ManageResourceTypesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageResourceTypesPresenterTest.php
@@ -44,13 +44,13 @@ class ManageResourceTypesPresenterTest extends TestBase
         $this->resourceRepository
                 ->expects($this->once())
         ->method('GetResourceTypes')
-        ->will($this->returnValue($types));
+        ->willReturn($types);
 
         $this->attributeService
                 ->expects($this->once())
         ->method('GetByCategory')
         ->with($this->equalTo(CustomAttributeCategory::RESOURCE_TYPE))
-        ->will($this->returnValue($attributes));
+        ->willReturn($attributes);
 
         $this->page
                 ->expects($this->once())
@@ -71,11 +71,11 @@ class ManageResourceTypesPresenterTest extends TestBase
         $description = 'description';
         $this->page->expects($this->once())
         ->method('GetResourceTypeName')
-        ->will($this->returnValue($name));
+        ->willReturn($name);
 
         $this->page->expects($this->once())
         ->method('GetDescription')
-        ->will($this->returnValue($description));
+        ->willReturn($description);
 
         $type = ResourceType::CreateNew($name, $description);
 
@@ -98,23 +98,23 @@ class ManageResourceTypesPresenterTest extends TestBase
         $this->page
                 ->expects($this->once())
         ->method('GetId')
-        ->will($this->returnValue($id));
+        ->willReturn($id);
 
         $this->page
                 ->expects($this->once())
         ->method('GetResourceTypeName')
-        ->will($this->returnValue($id));
+        ->willReturn($id);
 
         $this->page
                 ->expects($this->once())
         ->method('GetDescription')
-        ->will($this->returnValue($id));
+        ->willReturn($id);
 
         $this->resourceRepository
                 ->expects($this->once())
         ->method('LoadResourceType')
         ->with($this->equalTo($id))
-        ->will($this->returnValue($resourceType));
+        ->willReturn($resourceType);
 
         $this->resourceRepository
                 ->expects($this->once())
@@ -131,7 +131,7 @@ class ManageResourceTypesPresenterTest extends TestBase
         $this->page
                 ->expects($this->once())
         ->method('GetId')
-        ->will($this->returnValue($id));
+        ->willReturn($id);
 
         $this->resourceRepository
                         ->expects($this->once())

--- a/tests/Presenters/Admin/ManageResourceTypesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageResourceTypesPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Admin/ManageResourceTypesPresenter.php');
 
-class ManageResourceTypesPresenterTests extends TestBase
+class ManageResourceTypesPresenterTest extends TestBase
 {
     /**
      * @var ManageResourceTypesPresenter

--- a/tests/Presenters/Admin/ManageSchedulesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageSchedulesPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Presenters/Admin/ManageSchedulesPresenter.php');
 require_once(ROOT_DIR . 'Pages/Admin/ManageSchedulesPage.php');
 
-class ManageSchedulesPresenterTests extends TestBase
+class ManageSchedulesPresenterTest extends TestBase
 {
     /**
      * @var IUpdateSchedulePage|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/Admin/ManageSchedulesPresenterTest.php
+++ b/tests/Presenters/Admin/ManageSchedulesPresenterTest.php
@@ -58,23 +58,23 @@ class ManageSchedulesPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetScheduleId')
-                ->will($this->returnValue($scheduleId));
+                ->willReturn($scheduleId);
 
         $this->page->expects($this->once())
                 ->method('GetLayoutTimezone')
-                ->will($this->returnValue($timezone));
+                ->willReturn($timezone);
 
         $this->page->expects($this->once())
                 ->method('GetUsingSingleLayout')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->page->expects($this->once())
                 ->method('GetReservableSlots')
-                ->will($this->returnValue($reservableSlots));
+                ->willReturn($reservableSlots);
 
         $this->page->expects($this->once())
                 ->method('GetBlockedSlots')
-                ->will($this->returnValue($blockedSlots));
+                ->willReturn($blockedSlots);
 
         $this->scheduleRepo->expects($this->once())
                 ->method('AddScheduleLayout')
@@ -100,23 +100,23 @@ class ManageSchedulesPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetScheduleId')
-                ->will($this->returnValue($scheduleId));
+                ->willReturn($scheduleId);
 
         $this->page->expects($this->once())
                 ->method('GetLayoutTimezone')
-                ->will($this->returnValue($timezone));
+                ->willReturn($timezone);
 
         $this->page->expects($this->once())
                 ->method('GetUsingSingleLayout')
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
         $this->page->expects($this->once())
                 ->method('GetDailyReservableSlots')
-                ->will($this->returnValue($reservableSlots));
+                ->willReturn($reservableSlots);
 
         $this->page->expects($this->once())
                 ->method('GetDailyBlockedSlots')
-                ->will($this->returnValue($blockedSlots));
+                ->willReturn($blockedSlots);
 
         $this->scheduleRepo->expects($this->once())
                 ->method('AddScheduleLayout')
@@ -137,19 +137,19 @@ class ManageSchedulesPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetSourceScheduleId')
-                ->will($this->returnValue($sourceScheduleId));
+                ->willReturn($sourceScheduleId);
 
         $this->page->expects($this->once())
                 ->method('GetScheduleName')
-                ->will($this->returnValue($name));
+                ->willReturn($name);
 
         $this->page->expects($this->once())
                 ->method('GetStartDay')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $this->page->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $this->scheduleRepo->expects($this->once())
                 ->method('Add')
@@ -175,16 +175,16 @@ class ManageSchedulesPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetScheduleId')
-                ->will($this->returnValue($scheduleId));
+                ->willReturn($scheduleId);
 
         $this->page->expects($this->once())
                 ->method('GetTargetScheduleId')
-                ->will($this->returnValue($targetId));
+                ->willReturn($targetId);
 
         $this->scheduleRepo->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($scheduleId))
-                ->will($this->returnValue($schedule));
+                ->willReturn($schedule);
 
         $this->scheduleRepo->expects($this->once())
                 ->method('Delete')
@@ -193,15 +193,19 @@ class ManageSchedulesPresenterTest extends TestBase
         $this->resourceRepo->expects($this->once())
                 ->method('GetScheduleResources')
                 ->with($this->equalTo($scheduleId))
-                ->will($this->returnValue($resources));
+                ->willReturn($resources);
 
-        $this->resourceRepo->expects($this->at(1))
+        $matcher = $this->exactly(2);
+        $this->resourceRepo->expects($matcher)
                 ->method('Update')
-                ->with($this->equalTo($resource1));
-
-        $this->resourceRepo->expects($this->at(2))
-                ->method('Update')
-                ->with($this->equalTo($resource2));
+                ->willReturnCallback(function ($resource) use ($matcher, $resource1, $resource2)
+                {
+                    match ($matcher->numberOfInvocations())
+                    {
+                        1 => $this->assertEquals($resource, $resource1),
+                        2 => $this->assertEquals($resource, $resource2)
+                    };
+                });
 
         $presenter = new ManageSchedulesPresenter($this->page, $this->service, $this->groupRepo);
 

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -113,7 +113,7 @@ class ManageUsersPresenterTest extends TestBase
         $this->groupViewRepository
                 ->expects($this->once())
                 ->method('GetList')
-                ->will($this->returnValue($groupList));
+                ->willReturn($groupList);
 
         $this->presenter->PageLoad();
 
@@ -178,12 +178,12 @@ class ManageUsersPresenterTest extends TestBase
 
         $this->encryption->expects($this->once())
                          ->method('Salt')
-                         ->will($this->returnValue($salt));
+                         ->willReturn($salt);
 
         $this->encryption->expects($this->once())
                          ->method('Encrypt')
                          ->with($this->equalTo($password), $this->equalTo($salt))
-                         ->will($this->returnValue($encrypted));
+                         ->willReturn($encrypted);
 
         $user = new User();
 
@@ -241,7 +241,7 @@ class ManageUsersPresenterTest extends TestBase
                                      $this->equalTo($extraAttributes),
                                      $this->equalTo([new AttributeValue($attributeId, $attributeValue)])
                                  )
-                                 ->will($this->returnValue($user));
+                                 ->willReturn($user);
 
         $this->presenter->UpdateUser();
     }
@@ -263,13 +263,17 @@ class ManageUsersPresenterTest extends TestBase
         $userIds = [809, 909];
         $this->page->_DeletedUserIds = $userIds;
 
-        $this->manageUsersService->expects($this->at(0))
+        $matcher = $this->exactly(2);
+        $this->manageUsersService->expects($matcher)
                                  ->method('DeleteUser')
-                                 ->with($this->equalTo(809));
-
-        $this->manageUsersService->expects($this->at(1))
-                                 ->method('DeleteUser')
-                                 ->with($this->equalTo(909));
+                                 ->willReturnCallback(function ($userId) use ($matcher)
+                                 {
+                                    match ($matcher->numberOfInvocations())
+                                    {
+                                        1 => $this->assertEquals(809, $userId),
+                                        2 => $this->assertEquals(909, $userId)
+                                    };
+                                 });
 
         $this->presenter->DeleteMultipleUsers();
     }
@@ -324,12 +328,12 @@ class ManageUsersPresenterTest extends TestBase
                                                                UserAttribute::Position => null]),
                                      $this->equalTo([new AttributeValue($attributeId, $attributeValue)])
                                  )
-                                 ->will($this->returnValue($user));
+                                 ->willReturn($user);
 
         $this->groupRepository->expects($this->once())
                               ->method('LoadById')
                               ->with($this->equalTo($groupId))
-                              ->will($this->returnValue($group));
+                              ->willReturn($group);
 
         $this->groupRepository->expects($this->once())
                               ->method('Update')

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Presenters/Admin/ManageUsersPresenter.php');
 require_once(ROOT_DIR . 'Pages/Admin/ManageUsersPage.php');
 
-class ManageUsersPresenterTests extends TestBase
+class ManageUsersPresenterTest extends TestBase
 {
     /**
      * @var FakeManageUsersPage

--- a/tests/Presenters/AvailableAccessoriesPresenterTest.php
+++ b/tests/Presenters/AvailableAccessoriesPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/Ajax/AvailableAccessoriesPage.php');
 require_once(ROOT_DIR . 'Presenters/AvailableAccessoriesPresenter.php');
 
-class AvailableAccessoriesPresenterTests extends TestBase
+class AvailableAccessoriesPresenterTest extends TestBase
 {
     /**
      * @var FakeAccessoryRepository

--- a/tests/Presenters/CalendarExportPresenterTest.php
+++ b/tests/Presenters/CalendarExportPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/Export/CalendarExportPage.php');
 require_once(ROOT_DIR . 'Presenters/CalendarExportPresenter.php');
 
-class CalendarExportPresenterTests extends TestBase
+class CalendarExportPresenterTest extends TestBase
 {
     /**
      * @var IReservationViewRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/CalendarExportPresenterTest.php
+++ b/tests/Presenters/CalendarExportPresenterTest.php
@@ -49,16 +49,16 @@ class CalendarExportPresenterTest extends TestBase
 
         $this->validator->expects($this->atLeastOnce())
                 ->method('IsValid')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->page->expects($this->once())
                 ->method('GetReferenceNumber')
-                ->will($this->returnValue($referenceNumber));
+                ->willReturn($referenceNumber);
 
         $this->repo->expects($this->once())
                 ->method('GetReservationForEditing')
                 ->with($this->equalTo($referenceNumber))
-                ->will($this->returnValue($reservationResult));
+                ->willReturn($reservationResult);
 
         $this->page->expects($this->once())
                 ->method('SetReservations')
@@ -74,16 +74,16 @@ class CalendarExportPresenterTest extends TestBase
 
         $this->validator->expects($this->atLeastOnce())
                 ->method('IsValid')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->page->expects($this->once())
                 ->method('GetReferenceNumber')
-                ->will($this->returnValue($referenceNumber));
+                ->willReturn($referenceNumber);
 
         $this->repo->expects($this->once())
                 ->method('GetReservationForEditing')
                 ->with($this->equalTo($referenceNumber))
-                ->will($this->returnValue($reservationResult));
+                ->willReturn($reservationResult);
 
         $this->page->expects($this->once())
                 ->method('SetReservations')

--- a/tests/Presenters/CalendarPresenterTest.php
+++ b/tests/Presenters/CalendarPresenterTest.php
@@ -109,35 +109,35 @@ class CalendarPresenterTest extends TestBase
         $this->scheduleRepository
             ->expects($this->atLeastOnce())
             ->method('GetAll')
-            ->will($this->returnValue($schedules));
+            ->willReturn($schedules);
 
         $this->resourceService
             ->expects($this->atLeastOnce())
             ->method('GetAllResources')
             ->with($this->equalTo($showInaccessible), $this->equalTo($this->fakeUser))
-            ->will($this->returnValue($resources));
+            ->willReturn($resources);
 
         $this->resourceService
             ->expects($this->atLeastOnce())
             ->method('GetResourceGroups')
             ->with($this->isNull(), $this->equalTo($this->fakeUser))
-            ->will($this->returnValue(new ResourceGroupTree()));
+            ->willReturn(new ResourceGroupTree());
 
         $this->page
             ->expects($this->atLeastOnce())
             ->method('GetScheduleId')
-            ->will($this->returnValue($defaultScheduleId));
+            ->willReturn($defaultScheduleId);
 
         $this->page
             ->expects($this->atLeastOnce())
             ->method('GetResourceId')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
 
         $this->page
             ->expects($this->atLeastOnce())
             ->method('GetCalendarType')
-            ->will($this->returnValue($calendarType));
+            ->willReturn($calendarType);
 
         $this->page
             ->expects($this->atLeastOnce())
@@ -145,7 +145,7 @@ class CalendarPresenterTest extends TestBase
             ->with($this->equalTo($schedules[1]->GetWeekdayStart()));
 
         $details = new CalendarSubscriptionDetails(true);
-        $this->subscriptionService->expects($this->once())->method('ForSchedule')->with($this->equalTo($defaultScheduleId))->will($this->returnValue($details));
+        $this->subscriptionService->expects($this->once())->method('ForSchedule')->with($this->equalTo($defaultScheduleId))->willReturn($details);
 
         $this->page->expects($this->atLeastOnce())->method('BindSubscription')->with($this->equalTo($details));
 
@@ -213,31 +213,31 @@ class CalendarPresenterTest extends TestBase
         $this->page
             ->expects($this->atLeastOnce())
             ->method('GetResourceId')
-            ->will($this->returnValue($resourceId));
+            ->willReturn($resourceId);
         $this->page
             ->expects($this->atLeastOnce())
             ->method('GetScheduleId')
-            ->will($this->returnValue($scheduleId));
+            ->willReturn($scheduleId);
         $this->resourceService
             ->expects($this->atLeastOnce())
             ->method('GetAllResources')
-            ->will($this->returnValue($resources));
+            ->willReturn($resources);
         $this->resourceService
             ->expects($this->atLeastOnce())
             ->method('GetResource')
-            ->will($this->returnValue(new FakeBookableResource(1)));
+            ->willReturn(new FakeBookableResource(1));
         $this->repository
             ->expects($this->atLeastOnce())
             ->method('GetReservations')
-            ->will($this->returnValue($reservations));
+            ->willReturn($reservations);
         $this->repository
             ->expects($this->atLeastOnce())
             ->method('GetBlackoutsWithin')
-            ->will($this->returnValue($blackouts));
+            ->willReturn($blackouts);
         $this->scheduleRepository
             ->expects($this->atLeastOnce())
             ->method('GetLayout')
-            ->will($this->returnValue($layout));
+            ->willReturn($layout);
 
         $this->presenter->ProcessDataRequest('events');
     }

--- a/tests/Presenters/CalendarPresenterTest.php
+++ b/tests/Presenters/CalendarPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/CalendarPage.php');
 require_once(ROOT_DIR . 'Presenters/Calendar/CalendarPresenter.php');
 
-class CalendarPresenterTests extends TestBase
+class CalendarPresenterTest extends TestBase
 {
     /**
      * @var ICommonCalendarPage|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/CalendarSubscriptionPresenterTest.php
+++ b/tests/Presenters/CalendarSubscriptionPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/Export/CalendarSubscriptionPage.php');
 require_once(ROOT_DIR . 'Presenters/CalendarSubscriptionPresenter.php');
 
-class CalendarSubscriptionPresenterTests extends TestBase
+class CalendarSubscriptionPresenterTest extends TestBase
 {
     /**
      * @var IReservationViewRepository|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/CalendarSubscriptionPresenterTest.php
+++ b/tests/Presenters/CalendarSubscriptionPresenterTest.php
@@ -47,7 +47,7 @@ class CalendarSubscriptionPresenterTest extends TestBase
 
         $this->validator->expects($this->atLeastOnce())
                 ->method('IsValid')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->presenter = new CalendarSubscriptionPresenter(
             $this->page,
@@ -74,12 +74,12 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->service->expects($this->once())
                 ->method('GetSchedule')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($schedule));
+                ->willReturn($schedule);
 
         $this->repo->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->equalTo($weekAgo), $this->equalTo($nextYear), $this->isNull(), ReservationUserLevel::OWNER, $scheduleId, $this->isNull())
-                ->will($this->returnValue($reservationResult));
+                ->willReturn($reservationResult);
 
         $this->presenter->PageLoad();
 
@@ -102,12 +102,12 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->service->expects($this->once())
                 ->method('GetResource')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($resource));
+                ->willReturn($resource);
 
         $this->repo->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->equalTo($weekAgo), $this->equalTo($nextYear), $this->isNull(), ReservationUserLevel::OWNER, $this->isNull(), $resourceId)
-                ->will($this->returnValue($reservationResult));
+                ->willReturn($reservationResult);
 
         $this->presenter->PageLoad();
 
@@ -130,12 +130,12 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->service->expects($this->once())
                 ->method('GetUser')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $this->repo->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->equalTo($weekAgo), $this->equalTo($nextYear), $this->equalTo($userId), ReservationUserLevel::ALL, $this->isNull(), $this->isNull())
-                ->will($this->returnValue($reservationResult));
+                ->willReturn($reservationResult);
 
         $this->presenter->PageLoad();
 
@@ -160,12 +160,12 @@ class CalendarSubscriptionPresenterTest extends TestBase
         $this->service->expects($this->once())
                 ->method('GetResourcesInGroup')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($resourceIds));
+                ->willReturn($resourceIds);
 
         $this->repo->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->equalTo($weekAgo), $this->equalTo($nextYear), $this->isNull(), ReservationUserLevel::OWNER, $this->isNull(), $this->isNull())
-                ->will($this->returnValue($reservationResult));
+                ->willReturn($reservationResult);
 
         $this->presenter->PageLoad();
 

--- a/tests/Presenters/CalendarSubscriptionValidatorTest.php
+++ b/tests/Presenters/CalendarSubscriptionValidatorTest.php
@@ -38,12 +38,12 @@ class CalendarSubscriptionValidatorTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetResourceId')
-                ->will($this->returnValue($publicId));
+                ->willReturn($publicId);
 
         $this->subscriptionService->expects($this->once())
                 ->method('GetResource')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($resource));
+                ->willReturn($resource);
 
         $this->StubSubscriptionKey();
 
@@ -61,12 +61,12 @@ class CalendarSubscriptionValidatorTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetScheduleId')
-                ->will($this->returnValue($publicId));
+                ->willReturn($publicId);
 
         $this->subscriptionService->expects($this->once())
                 ->method('GetSchedule')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($schedule));
+                ->willReturn($schedule);
 
         $this->StubSubscriptionKey();
 
@@ -84,12 +84,12 @@ class CalendarSubscriptionValidatorTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetUserId')
-                ->will($this->returnValue($publicId));
+                ->willReturn($publicId);
 
         $this->subscriptionService->expects($this->once())
                 ->method('GetUser')
                 ->with($this->equalTo($publicId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $this->StubSubscriptionKey();
 
@@ -102,7 +102,7 @@ class CalendarSubscriptionValidatorTest extends TestBase
     {
         $this->page->expects($this->once())
             ->method('GetSubscriptionKey')
-            ->will($this->returnValue('12'));
+            ->willReturn('12');
 
         $this->fakeConfig->SetSectionKey(ConfigSection::ICS, ConfigKeys::ICS_SUBSCRIPTION_KEY, '123');
 
@@ -124,7 +124,7 @@ class CalendarSubscriptionValidatorTest extends TestBase
     {
         $this->page->expects($this->once())
             ->method('GetSubscriptionKey')
-            ->will($this->returnValue('123'));
+            ->willReturn('123');
 
         $this->fakeConfig->SetSectionKey(ConfigSection::ICS, ConfigKeys::ICS_SUBSCRIPTION_KEY, '123');
     }

--- a/tests/Presenters/CalendarSubscriptionValidatorTest.php
+++ b/tests/Presenters/CalendarSubscriptionValidatorTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/Export/CalendarSubscriptionPage.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
-class CalendarSubscriptionValidatorTests extends TestBase
+class CalendarSubscriptionValidatorTest extends TestBase
 {
     /**
      * @var ICalendarSubscriptionPage|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/CheckoutPresenterTest.php
+++ b/tests/Presenters/CheckoutPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Credits/CheckoutPresenter.php');
 
-class CheckoutPresenterTests extends TestBase
+class CheckoutPresenterTest extends TestBase
 {
     /**
      * @var FakeCheckoutPage

--- a/tests/Presenters/CheckoutPresenterTest.php
+++ b/tests/Presenters/CheckoutPresenterTest.php
@@ -39,8 +39,9 @@ class CheckoutPresenterTest extends TestBase
     public function testPageLoadCreatesCartAndPresentsPaymentOptions()
     {
         $this->page->_CreditQuantity = 10;
-        $cost = new CreditCost(5);
-        $this->paymentRepository->_CreditCost = $cost;
+        $this->page->_CreditCount = 1;
+        $cost = new CreditCost(1, 5);
+        $this->paymentRepository->_CreditCost = [$cost];
         $this->paymentRepository->_PayPal = new PayPalGateway(true, 'client', 'secret', 'live');
         $this->paymentRepository->_Stripe = new StripeGateway(true, 'publish', 'secret');
 

--- a/tests/Presenters/Dashboard/AnnouncementPresenterTest.php
+++ b/tests/Presenters/Dashboard/AnnouncementPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Presenters/Dashboard/AnnouncementPresenter.php');
 require_once(ROOT_DIR . 'Controls/Dashboard/AnnouncementsControl.php');
 
-class AnnouncementPresenterTests extends TestBase
+class AnnouncementPresenterTest extends TestBase
 {
     private $permissionService;
     /**

--- a/tests/Presenters/Dashboard/ResourceAvailabilityControlPresenterTest.php
+++ b/tests/Presenters/Dashboard/ResourceAvailabilityControlPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Dashboard/ResourceAvailabilityControlPresenter.php');
 
-class ResourceAvailabilityControlPresenterTests extends TestBase
+class ResourceAvailabilityControlPresenterTest extends TestBase
 {
     /**
      * @var FakeReservationViewRepository

--- a/tests/Presenters/Dashboard/UpcomingReservationsPresenterTest.php
+++ b/tests/Presenters/Dashboard/UpcomingReservationsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Dashboard/UpcomingReservationsPresenter.php');
 
-class UpcomingReservationsPresenterTests extends TestBase
+class UpcomingReservationsPresenterTest extends TestBase
 {
     /**
      * @var UpcomingReservationsPresenter

--- a/tests/Presenters/Dashboard/UpcomingReservationsPresenterTest.php
+++ b/tests/Presenters/Dashboard/UpcomingReservationsPresenterTest.php
@@ -48,7 +48,7 @@ class UpcomingReservationsPresenterTest extends TestBase
         $this->repository->expects($this->once())
             ->method('GetReservations')
             ->with($this->equalTo($startDate), $this->equalTo($endDate), $this->equalTo($userId), $this->equalTo(ReservationUserLevel::ALL))
-            ->will($this->returnValue($reservations));
+            ->willReturn($reservations);
 
         $this->control->expects($this->once())
             ->method('SetTimezone')
@@ -95,7 +95,7 @@ class UpcomingReservationsPresenterTest extends TestBase
         $this->repository->expects($this->once())
             ->method('GetReservations')
             ->with($this->anything(), $this->anything(), $this->anything())
-            ->will($this->returnValue($reservations));
+            ->willReturn($reservations);
 
         $this->control->expects($this->once())
             ->method('BindToday')

--- a/tests/Presenters/EmbeddedCalendarPresenterTest.php
+++ b/tests/Presenters/EmbeddedCalendarPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/EmbeddedCalendarPresenter.php');
 
-class EmbeddedCalendarPresenterTests extends TestBase
+class EmbeddedCalendarPresenterTest extends TestBase
 {
     /**
      * @var FakeEmbeddedCalendarPage

--- a/tests/Presenters/Integrate/SlackPresenterTest.php
+++ b/tests/Presenters/Integrate/SlackPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Integrate/SlackPresenter.php');
 
-class SlackPresenterTests extends TestBase
+class SlackPresenterTest extends TestBase
 {
     /**
      * @var SlackPresenter

--- a/tests/Presenters/LoginPresenterTest.php
+++ b/tests/Presenters/LoginPresenterTest.php
@@ -201,7 +201,7 @@ class LoginPresenterTest extends TestBase
     }
 }
 
-abstract class FakeLoginPage extends FakePageBase implements ILoginPage
+class FakeLoginPage extends FakePageBase implements ILoginPage
 {
     public $_EmailAddress;
     public $_Password;
@@ -222,6 +222,12 @@ abstract class FakeLoginPage extends FakePageBase implements ILoginPage
     public $_ShowForgotPasswordPrompt = false;
     public $_ShowScheduleLink = false;
     public $_Announcements;
+
+    public function SetGoogleUrl($URL) { }
+
+    public function SetMicrosoftUrl($URL) { }
+
+    public function SetFacebookUrl($URL) { }
 
     public function PageLoad()
     {

--- a/tests/Presenters/LoginPresenterTest.php
+++ b/tests/Presenters/LoginPresenterTest.php
@@ -5,7 +5,7 @@ require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 require_once(ROOT_DIR . 'Pages/LoginPage.php');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 
-class LoginPresenterTests extends TestBase
+class LoginPresenterTest extends TestBase
 {
     /**
      * @var FakeWebAuthentication
@@ -201,7 +201,7 @@ class LoginPresenterTests extends TestBase
     }
 }
 
-class FakeLoginPage extends FakePageBase implements ILoginPage
+abstract class FakeLoginPage extends FakePageBase implements ILoginPage
 {
     public $_EmailAddress;
     public $_Password;

--- a/tests/Presenters/MonitorDisplayPresenterTest.php
+++ b/tests/Presenters/MonitorDisplayPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/MonitorDisplayPresenter.php');
 
-class MonitorDisplayPresenterTests extends TestBase
+class MonitorDisplayPresenterTest extends TestBase
 {
     /**
      * @var TestMonitorDisplayPage

--- a/tests/Presenters/ParticipationPresenterTest.php
+++ b/tests/Presenters/ParticipationPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/ParticipationPresenter.php');
 
-class ParticipationPresenterTests extends TestBase
+class ParticipationPresenterTest extends TestBase
 {
     /**
      * @var IParticipationPage|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/ParticipationPresenterTest.php
+++ b/tests/Presenters/ParticipationPresenterTest.php
@@ -85,24 +85,24 @@ class ParticipationPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetResponseType')
-            ->will($this->returnValue('json'));
+            ->willReturn('json');
 
         $this->page->expects($this->once())
             ->method('GetInvitationAction')
-            ->will($this->returnValue($invitationAction));
+            ->willReturn($invitationAction);
 
         $this->page->expects($this->once())
             ->method('GetInvitationReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->page->expects($this->once())
             ->method('GetUserId')
-            ->will($this->returnValue($currentUserId));
+            ->willReturn($currentUserId);
 
         $this->reservationRepo->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($referenceNumber))
-            ->will($this->returnValue($series));
+            ->willReturn($series);
 
         $this->page->expects($this->once())
             ->method('DisplayResult')
@@ -140,24 +140,24 @@ class ParticipationPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetResponseType')
-            ->will($this->returnValue('json'));
+            ->willReturn('json');
 
         $this->page->expects($this->once())
             ->method('GetInvitationAction')
-            ->will($this->returnValue($invitationAction));
+            ->willReturn($invitationAction);
 
         $this->page->expects($this->once())
             ->method('GetInvitationReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->page->expects($this->once())
             ->method('GetUserId')
-            ->will($this->returnValue($currentUserId));
+            ->willReturn($currentUserId);
 
         $this->reservationRepo->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($referenceNumber))
-            ->will($this->returnValue($series));
+            ->willReturn($series);
 
         $this->page->expects($this->once())
             ->method('DisplayResult')
@@ -197,24 +197,24 @@ class ParticipationPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetResponseType')
-            ->will($this->returnValue('json'));
+            ->willReturn('json');
 
         $this->page->expects($this->once())
             ->method('GetInvitationAction')
-            ->will($this->returnValue($invitationAction));
+            ->willReturn($invitationAction);
 
         $this->page->expects($this->once())
             ->method('GetInvitationReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->page->expects($this->once())
             ->method('GetUserId')
-            ->will($this->returnValue($currentUserId));
+            ->willReturn($currentUserId);
 
         $this->reservationRepo->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($referenceNumber))
-            ->will($this->returnValue($series));
+            ->willReturn($series);
 
         $this->page->expects($this->once())
             ->method('DisplayResult')
@@ -263,7 +263,7 @@ class ParticipationPresenterTest extends TestBase
         $this->reservationViewRepo->expects($this->once())
             ->method('GetReservations')
             ->with($this->equalTo($startDate), $this->equalTo($endDate), $this->equalTo($userId), $this->equalTo($inviteeLevel))
-            ->will($this->returnValue($reservations));
+            ->willReturn($reservations);
 
         $this->page->expects($this->once())
             ->method('BindReservations')
@@ -287,24 +287,24 @@ class ParticipationPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetResponseType')
-            ->will($this->returnValue('json'));
+            ->willReturn('json');
 
         $this->page->expects($this->once())
             ->method('GetInvitationAction')
-            ->will($this->returnValue(InvitationAction::Join));
+            ->willReturn(InvitationAction::Join);
 
         $this->page->expects($this->once())
             ->method('GetInvitationReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->page->expects($this->once())
             ->method('GetUserId')
-            ->will($this->returnValue($currentUserId));
+            ->willReturn($currentUserId);
 
         $this->reservationRepo->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($referenceNumber))
-            ->will($this->returnValue($series));
+            ->willReturn($series);
 
         $this->page->expects($this->once())
             ->method('DisplayResult')
@@ -321,29 +321,29 @@ class ParticipationPresenterTest extends TestBase
         $currentUserId = 1029;
         $referenceNumber = 'abc123';
         $series = $this->createMock('ExistingReservationSeries');
-        $series->expects($this->any())->method('GetAllowParticipation')->will($this->returnValue(true));
-        $series->expects($this->any())->method('AllResources')->will($this->returnValue([]));
+        $series->expects($this->any())->method('GetAllowParticipation')->willReturn(true);
+        $series->expects($this->any())->method('AllResources')->willReturn([]);
 
         $this->page->expects($this->once())
             ->method('GetResponseType')
-            ->will($this->returnValue('json'));
+            ->willReturn('json');
 
         $this->page->expects($this->once())
             ->method('GetInvitationAction')
-            ->will($this->returnValue($invitationAction));
+            ->willReturn($invitationAction);
 
         $this->page->expects($this->once())
             ->method('GetInvitationReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->page->expects($this->once())
             ->method('GetUserId')
-            ->will($this->returnValue($currentUserId));
+            ->willReturn($currentUserId);
 
         $this->reservationRepo->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($referenceNumber))
-            ->will($this->returnValue($series));
+            ->willReturn($series);
 
         $series->expects($this->once())
             ->method($seriesMethod)

--- a/tests/Presenters/PasswordPresenterTest.php
+++ b/tests/Presenters/PasswordPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/PasswordPage.php');
 require_once(ROOT_DIR . 'Presenters/PasswordPresenter.php');
 
-class PasswordPresenterTests extends TestBase
+class PasswordPresenterTest extends TestBase
 {
     public function testResetsPassword()
     {

--- a/tests/Presenters/PasswordPresenterTest.php
+++ b/tests/Presenters/PasswordPresenterTest.php
@@ -22,25 +22,25 @@ class PasswordPresenterTest extends TestBase
 
         $page->expects($this->once())
                 ->method('ResettingPassword')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $page->expects($this->once())
                 ->method('IsValid')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $page->expects($this->atLeastOnce())
                 ->method('GetPassword')
-                ->will($this->returnValue($newPassword));
+                ->willReturn($newPassword);
 
         $userRepo->expects($this->atLeastOnce())
                 ->method('LoadById')
                 ->with($this->equalTo($this->fakeUser->UserId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $encryption->expects($this->once())
                 ->method('EncryptPassword')
                 ->with($this->equalTo($newPassword))
-                ->will($this->returnValue($encryptedPassword));
+                ->willReturn($encryptedPassword);
 
         $user->expects($this->once())
                 ->method('ChangePassword')
@@ -52,7 +52,7 @@ class PasswordPresenterTest extends TestBase
 
         $page->expects($this->once())
                 ->method('ShowResetPasswordSuccess')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $presenter->PageLoad();
     }

--- a/tests/Presenters/PersonalCalendarPresenterTest.php
+++ b/tests/Presenters/PersonalCalendarPresenterTest.php
@@ -94,23 +94,23 @@ class PersonalCalendarPresenterTest extends TestBase
         $this->page
                 ->expects($this->atLeastOnce())
                 ->method('GetScheduleId')
-                ->will($this->returnValue($defaultScheduleId));
+                ->willReturn($defaultScheduleId);
 
         $this->page
                 ->expects($this->atLeastOnce())
                 ->method('GetResourceId')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->page->expects($this->once())
                    ->method('GetCalendarType')
-                   ->will($this->returnValue($calendarType));
+                   ->willReturn($calendarType);
 
         $details = new CalendarSubscriptionDetails(true);
 
         $this->subscriptionService->expects($this->once())
                                   ->method('ForUser')
                                   ->with($this->equalTo($userId))
-                                  ->will($this->returnValue($details));
+                                  ->willReturn($details);
 
         $this->page->expects($this->once())
                    ->method('BindSubscription')
@@ -119,19 +119,19 @@ class PersonalCalendarPresenterTest extends TestBase
         $this->scheduleRepository
                 ->expects($this->atLeastOnce())
                 ->method('GetAll')
-                ->will($this->returnValue($schedules));
+                ->willReturn($schedules);
 
         $this->resourceService
                 ->expects($this->atLeastOnce())
                 ->method('GetAllResources')
                 ->with($this->equalTo($showInaccessible), $this->equalTo($this->fakeUser))
-                ->will($this->returnValue($resources));
+                ->willReturn($resources);
 
         $this->resourceService
                 ->expects($this->atLeastOnce())
                 ->method('GetResourceGroups')
                 ->with($this->anything(), $this->equalTo($this->fakeUser))
-                ->will($this->returnValue($resourceGroupTree));
+                ->willReturn($resourceGroupTree);
         $this->page
                 ->expects($this->atLeastOnce())
                 ->method('SetFirstDay')
@@ -140,7 +140,7 @@ class PersonalCalendarPresenterTest extends TestBase
         $this->userRepository->expects($this->once())
                     ->method('LoadById')
                     ->with($this->equalTo($this->fakeUser->UserId))
-                    ->will($this->returnValue(new FakeUser()));
+                    ->willReturn(new FakeUser());
 
         $calendarFilters = new CalendarFilters($schedules, $resources, $defaultScheduleId, null, $resourceGroupTree);
         $this->page->expects($this->atLeastOnce())->method('BindFilters')->with($this->equalTo($calendarFilters));

--- a/tests/Presenters/PersonalCalendarPresenterTest.php
+++ b/tests/Presenters/PersonalCalendarPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/PersonalCalendarPage.php');
 require_once(ROOT_DIR . 'Presenters/Calendar/PersonalCalendarPresenter.php');
 
-class PersonalCalendarPresenterTests extends TestBase
+class PersonalCalendarPresenterTest extends TestBase
 {
     /**
      * @var ICommonCalendarPage|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/RegisterPresenterTest.php
+++ b/tests/Presenters/RegisterPresenterTest.php
@@ -140,6 +140,7 @@ class RegisterPresenterTest extends TestBase
     public function testSetsSelectedHomepageToDefault()
     {
         $expectedHomepage = 1;
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_HOMEPAGE, $expectedHomepage);
 
         $this->page->_IsPostBack = false;
 
@@ -147,7 +148,7 @@ class RegisterPresenterTest extends TestBase
 
         $this->presenter->PageLoad();
 
-        $this->assertEquals($this->page->_Homepage, $expectedHomepage);
+        $this->assertEquals($expectedHomepage, $this->page->_Homepage);
     }
 
     public function testSetsSelectedHomepageToServerSubmitted()
@@ -160,7 +161,7 @@ class RegisterPresenterTest extends TestBase
 
         $this->presenter->PageLoad();
 
-        $this->assertEquals($this->page->_Homepage, $expectedHomepage);
+        $this->assertEquals($expectedHomepage, $this->page->_Homepage);
     }
 
     public function testSetsCaptchaUrl()
@@ -169,7 +170,7 @@ class RegisterPresenterTest extends TestBase
 
         $this->captcha->expects($this->once())
             ->method('GetImageUrl')
-            ->will($this->returnValue($url));
+            ->willReturn($url);
 
         $this->ExpectAttributeServiceCalled();
 
@@ -277,7 +278,7 @@ class RegisterPresenterTest extends TestBase
         $this->attributeService->expects($this->once())
                 ->method('GetAttributes')
                 ->with($this->equalTo(CustomAttributeCategory::USER))
-                ->will($this->returnValue($list));
+                ->willReturn($list);
     }
 
     private function LoadPageValues()

--- a/tests/Presenters/RegisterPresenterTest.php
+++ b/tests/Presenters/RegisterPresenterTest.php
@@ -5,7 +5,7 @@ require_once(ROOT_DIR . 'Pages/RegistrationPage.php');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 
-class RegisterPresenterTests extends TestBase
+class RegisterPresenterTest extends TestBase
 {
     /**
      * @var FakeRegistrationPage

--- a/tests/Presenters/Reports/GenerateReportPresenterTest.php
+++ b/tests/Presenters/Reports/GenerateReportPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Pages/Reports/GenerateReportPage.php');
 
-class GenerateReportPresenterTests extends TestBase
+class GenerateReportPresenterTest extends TestBase
 {
     /**
      * @var GenerateReportPresenter

--- a/tests/Presenters/Reports/GenerateReportPresenterTest.php
+++ b/tests/Presenters/Reports/GenerateReportPresenterTest.php
@@ -78,7 +78,7 @@ class GenerateReportPresenterTest extends TestBase
                                    $this->equalTo($range),
                                    $this->equalTo($filter)
                                )
-                               ->will($this->returnValue($expectedReport));
+                               ->willReturn($expectedReport);
 
         $user = new FakeUser();
         $savedReportColumns = 'savedreport';

--- a/tests/Presenters/Reports/ReportDefinitionTest.php
+++ b/tests/Presenters/Reports/ReportDefinitionTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Reports/GenerateReportPresenter.php');
 
-class ReportDefinitionTests extends TestBase
+class ReportDefinitionTest extends TestBase
 {
     /**
      * @var FakeAttributeRepository

--- a/tests/Presenters/Reports/SavedReportsPresenterTest.php
+++ b/tests/Presenters/Reports/SavedReportsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Reports/SavedReportsPresenter.php');
 
-class SavedReportsPresenterTests extends TestBase
+class SavedReportsPresenterTest extends TestBase
 {
     /**
      * @var SavedReportsPresenter

--- a/tests/Presenters/Reports/SavedReportsPresenterTest.php
+++ b/tests/Presenters/Reports/SavedReportsPresenterTest.php
@@ -42,7 +42,7 @@ class SavedReportsPresenterTest extends TestBase
         $this->service->expects($this->once())
                       ->method('GetSavedReports')
                       ->with($this->equalTo($this->fakeUser->UserId))
-                      ->will($this->returnValue($savedReports));
+                      ->willReturn($savedReports);
 
         $this->presenter->PageLoad();
 
@@ -58,7 +58,7 @@ class SavedReportsPresenterTest extends TestBase
         $this->service->expects($this->once())
                       ->method('GenerateSavedReport')
                       ->with($this->equalTo($reportId), $this->equalTo($this->fakeUser->UserId))
-                      ->will($this->returnValue($report));
+                      ->willReturn($report);
 
         $user = new FakeUser();
         $savedReportColumns = 'savedreport';
@@ -78,7 +78,7 @@ class SavedReportsPresenterTest extends TestBase
         $this->service->expects($this->once())
                       ->method('GenerateSavedReport')
                       ->with($this->anything(), $this->anything())
-                      ->will($this->returnValue(null));
+                      ->willReturn(null);
 
         $this->presenter->GenerateReport();
 
@@ -99,7 +99,7 @@ class SavedReportsPresenterTest extends TestBase
         $this->service->expects($this->once())
                       ->method('GenerateSavedReport')
                       ->with($this->equalTo($reportId), $this->equalTo($this->fakeUser->UserId))
-                      ->will($this->returnValue($report));
+                      ->willReturn($report);
 
         $this->service->expects($this->once())
                       ->method('SendReport')

--- a/tests/Presenters/Reservation/EditReservationPresenterTest.php
+++ b/tests/Presenters/Reservation/EditReservationPresenterTest.php
@@ -63,12 +63,12 @@ class EditReservationPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->reservationViewRepository->expects($this->once())
             ->method('GetReservationForEditing')
             ->with($referenceNumber)
-            ->will($this->returnValue($reservationView));
+            ->willReturn($reservationView);
 
         $this->preconditionService->expects($this->once())
             ->method('CheckAll')
@@ -77,7 +77,7 @@ class EditReservationPresenterTest extends TestBase
         $this->initializerFactory->expects($this->once())
             ->method('GetExistingInitializer')
             ->with($this->equalTo($this->page), $this->equalTo($reservationView))
-            ->will($this->returnValue($this->initializer));
+            ->willReturn($this->initializer);
 
         $this->initializer->expects($this->once())
             ->method('Initialize');

--- a/tests/Presenters/Reservation/EditReservationPresenterTest.php
+++ b/tests/Presenters/Reservation/EditReservationPresenterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class EditReservationPresenterTests extends TestBase
+class EditReservationPresenterTest extends TestBase
 {
     /**
      * @var UserSession

--- a/tests/Presenters/Reservation/ExistingReservationInitializerTest.php
+++ b/tests/Presenters/Reservation/ExistingReservationInitializerTest.php
@@ -9,7 +9,7 @@ require_once(ROOT_DIR . 'Pages/Reservation/ExistingReservationPage.php');
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/ExistingReservationInitializer.php');
 
-class ExistingReservationInitializerTests extends TestBase
+class ExistingReservationInitializerTest extends TestBase
 {
     /**
      * @var int

--- a/tests/Presenters/Reservation/GuestReservationPresenterTest.php
+++ b/tests/Presenters/Reservation/GuestReservationPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Reservation/GuestReservationPresenter.php');
 
-class GuestReservationPresenterTests extends TestBase
+class GuestReservationPresenterTest extends TestBase
 {
     /**
      * @var FakeGuestReservationPage

--- a/tests/Presenters/Reservation/GuestReservationPresenterTest.php
+++ b/tests/Presenters/Reservation/GuestReservationPresenterTest.php
@@ -47,7 +47,7 @@ class GuestReservationPresenterTest extends TestBase
         $this->factory->expects($this->any())
             ->method('GetNewInitializer')
             ->with($this->anything())
-            ->will($this->returnValue($this->initializer));
+            ->willReturn($this->initializer);
 
         $this->presenter = new GuestReservationPresenter(
             $this->page,

--- a/tests/Presenters/Reservation/NewReservationPresenterTest.php
+++ b/tests/Presenters/Reservation/NewReservationPresenterTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Presenters/Reservation/ReservationPresenter.php');
 require_once(ROOT_DIR . 'Pages/Reservation/ReservationPage.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class NewReservationPresenterTests extends TestBase
+class NewReservationPresenterTest extends TestBase
 {
     /**
      * @var UserSession

--- a/tests/Presenters/Reservation/NewReservationPresenterTest.php
+++ b/tests/Presenters/Reservation/NewReservationPresenterTest.php
@@ -44,7 +44,7 @@ class NewReservationPresenterTest extends TestBase
         $reservationInitializerFactory->expects($this->once())
             ->method('GetNewInitializer')
             ->with($this->equalTo($page))
-            ->will($this->returnValue($initializer));
+            ->willReturn($initializer);
 
         $initializer->expects($this->once())
             ->method('Initialize');

--- a/tests/Presenters/Reservation/ReservationApprovalPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationApprovalPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/Ajax/ReservationApprovalPage.php');
 require_once(ROOT_DIR . 'Presenters/Reservation/ReservationApprovalPresenter.php');
 
-class ReservationApprovalPresenterTests extends TestBase
+class ReservationApprovalPresenterTest extends TestBase
 {
     /**
      * @var IReservationApprovalPage|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/Reservation/ReservationApprovalPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationApprovalPresenterTest.php
@@ -51,22 +51,22 @@ class ReservationApprovalPresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->persistence->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($referenceNumber))
-            ->will($this->returnValue($reservation));
+            ->willReturn($reservation);
 
         $this->handler->expects($this->once())
             ->method('Handle')
             ->with($this->equalTo($reservation), $this->equalTo($this->page))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->auth->expects($this->once())
                     ->method('CanApprove')
                     ->with($this->equalTo(new ReservationViewAdapter($reservation)), $this->equalTo($this->fakeUser))
-                    ->will($this->returnValue(true));
+                    ->willReturn(true);
 
         $this->presenter->PageLoad();
 

--- a/tests/Presenters/Reservation/ReservationAttachmentPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationAttachmentPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Reservation/ReservationAttachmentPresenter.php');
 
-class ReservationAttachmentPresenterTests extends TestBase
+class ReservationAttachmentPresenterTest extends TestBase
 {
     /**
      * @var ReservationAttachmentPresenter

--- a/tests/Presenters/Reservation/ReservationAttachmentPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationAttachmentPresenterTest.php
@@ -52,21 +52,21 @@ class ReservationAttachmentPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetFileId')
-                ->will($this->returnValue($fileId));
+                ->willReturn($fileId);
 
         $this->page->expects($this->once())
                 ->method('GetReferenceNumber')
-                ->will($this->returnValue($referenceNumber));
+                ->willReturn($referenceNumber);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadReservationAttachment')
                 ->with($this->equalTo($fileId))
-                ->will($this->returnValue($reservationAttachment));
+                ->willReturn($reservationAttachment);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadByReferenceNumber')
                 ->with($this->equalTo($referenceNumber))
-                ->will($this->returnValue($reservationSeries));
+                ->willReturn($reservationSeries);
 
         $this->page->expects($this->once())
                 ->method('BindAttachment')
@@ -97,21 +97,21 @@ class ReservationAttachmentPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetFileId')
-                ->will($this->returnValue($fileId));
+                ->willReturn($fileId);
 
         $this->page->expects($this->once())
                 ->method('GetReferenceNumber')
-                ->will($this->returnValue($referenceNumber));
+                ->willReturn($referenceNumber);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadReservationAttachment')
                 ->with($this->equalTo($fileId))
-                ->will($this->returnValue($reservationAttachment));
+                ->willReturn($reservationAttachment);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadByReferenceNumber')
                 ->with($this->equalTo($referenceNumber))
-                ->will($this->returnValue($reservationSeries));
+                ->willReturn($reservationSeries);
 
         $this->page->expects($this->once())
                 ->method('ShowError');
@@ -132,21 +132,21 @@ class ReservationAttachmentPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetFileId')
-                ->will($this->returnValue($fileId));
+                ->willReturn($fileId);
 
         $this->page->expects($this->once())
                 ->method('GetReferenceNumber')
-                ->will($this->returnValue($referenceNumber));
+                ->willReturn($referenceNumber);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadReservationAttachment')
                 ->with($this->equalTo($fileId))
-                ->will($this->returnValue($reservationAttachment));
+                ->willReturn($reservationAttachment);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadByReferenceNumber')
                 ->with($this->equalTo($referenceNumber))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->page->expects($this->once())
                 ->method('ShowError');
@@ -161,16 +161,16 @@ class ReservationAttachmentPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetFileId')
-                ->will($this->returnValue($fileId));
+                ->willReturn($fileId);
 
         $this->page->expects($this->once())
                 ->method('GetReferenceNumber')
-                ->will($this->returnValue($referenceNumber));
+                ->willReturn($referenceNumber);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadReservationAttachment')
                 ->with($this->equalTo($fileId))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->page->expects($this->once())
                 ->method('ShowError');
@@ -196,21 +196,21 @@ class ReservationAttachmentPresenterTest extends TestBase
 
         $this->page->expects($this->once())
                 ->method('GetFileId')
-                ->will($this->returnValue($fileId));
+                ->willReturn($fileId);
 
         $this->page->expects($this->once())
                 ->method('GetReferenceNumber')
-                ->will($this->returnValue($referenceNumber));
+                ->willReturn($referenceNumber);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadReservationAttachment')
                 ->with($this->equalTo($fileId))
-                ->will($this->returnValue($reservationAttachment));
+                ->willReturn($reservationAttachment);
 
         $this->reservationRepository->expects($this->once())
                 ->method('LoadByReferenceNumber')
                 ->with($this->equalTo($referenceNumber))
-                ->will($this->returnValue($reservationSeries));
+                ->willReturn($reservationSeries);
 
         $this->page->expects($this->once())
                 ->method('ShowError');

--- a/tests/Presenters/Reservation/ReservationAttributesPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationAttributesPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Reservation/ReservationAttributesPresenter.php');
 
-class ReservationAttributesPresenterTests extends TestBase
+class ReservationAttributesPresenterTest extends TestBase
 {
     /**
      * @var IAttributeService|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/Reservation/ReservationAttributesPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationAttributesPresenterTest.php
@@ -86,7 +86,7 @@ class ReservationAttributesPresenterTest extends TestBase
         $this->attributeRepository->expects($this->once())
                                ->method('GetByCategory')
                                ->with($this->equalTo(CustomAttributeCategory::RESERVATION))
-                               ->will($this->returnValue($attributes));
+                               ->willReturn($attributes);
 
         $this->page->_RequestedUserId = $requestedUserId;
 
@@ -115,7 +115,7 @@ class ReservationAttributesPresenterTest extends TestBase
         $this->attributeRepository->expects($this->once())
                                ->method('GetByCategory')
                                ->with($this->equalTo(CustomAttributeCategory::RESERVATION))
-                               ->will($this->returnValue($attributes));
+                               ->willReturn($attributes);
 
         $this->page->_RequestedUserId = $requestedUserId;
 
@@ -137,7 +137,7 @@ class ReservationAttributesPresenterTest extends TestBase
         $this->attributeRepository->expects($this->once())
                                        ->method('GetByCategory')
                                        ->with($this->equalTo(CustomAttributeCategory::RESERVATION))
-                                       ->will($this->returnValue($attributes));
+                                       ->willReturn($attributes);
 
         $this->reservationRepository->_ReservationView->AddAttribute(new AttributeValue(1, 'value1'));
         $this->reservationRepository->_ReservationView->AddAttribute(new AttributeValue(2, 'value2'));
@@ -180,7 +180,7 @@ class ReservationAttributesPresenterTest extends TestBase
         $this->attributeRepository->expects($this->once())
                                        ->method('GetByCategory')
                                        ->with($this->equalTo(CustomAttributeCategory::RESERVATION))
-                                       ->will($this->returnValue($attributes));
+                                       ->willReturn($attributes);
 
         $this->presenter->PageLoad($this->fakeUser);
 
@@ -204,7 +204,7 @@ class ReservationAttributesPresenterTest extends TestBase
         $this->attributeRepository->expects($this->once())
                                        ->method('GetByCategory')
                                        ->with($this->equalTo(CustomAttributeCategory::RESERVATION))
-                                       ->will($this->returnValue($attributes));
+                                       ->willReturn($attributes);
 
         $this->presenter->PageLoad($this->fakeUser);
 

--- a/tests/Presenters/Reservation/ReservationCheckinPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationCheckinPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Pages/Ajax/ReservationApprovalPage.php');
 require_once(ROOT_DIR . 'Presenters/Reservation/ReservationCheckinPresenter.php');
 
-class ReservationCheckinPresenterTests extends TestBase
+class ReservationCheckinPresenterTest extends TestBase
 {
     /**
      * @var FakeReservationCheckinPage

--- a/tests/Presenters/Reservation/ReservationCheckinPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationCheckinPresenterTest.php
@@ -47,12 +47,12 @@ class ReservationCheckinPresenterTest extends TestBase
         $this->persistence->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($this->page->_ReferenceNumber))
-            ->will($this->returnValue($reservation));
+            ->willReturn($reservation);
 
         $this->handler->expects($this->once())
             ->method('Handle')
             ->with($this->equalTo($reservation), $this->equalTo($this->page))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->presenter->PageLoad();
 
@@ -71,12 +71,12 @@ class ReservationCheckinPresenterTest extends TestBase
         $this->persistence->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($this->page->_ReferenceNumber))
-            ->will($this->returnValue($reservation));
+            ->willReturn($reservation);
 
         $this->handler->expects($this->once())
             ->method('Handle')
             ->with($this->equalTo($reservation), $this->equalTo($this->page))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->presenter->PageLoad();
 

--- a/tests/Presenters/Reservation/ReservationCreditsPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationCreditsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Reservation/ReservationCreditsPresenter.php');
 
-class ReservationCreditsPresenterTests extends TestBase
+class ReservationCreditsPresenterTest extends TestBase
 {
     /**
      * @var FakeReservationCreditsPage

--- a/tests/Presenters/Reservation/ReservationCreditsPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationCreditsPresenterTest.php
@@ -67,7 +67,7 @@ class ReservationCreditsPresenterTest extends TestBase
 
         $expectedCost = Booked\Currency::Create('USD')->Format(150);
 
-        $this->paymentRepository->_CreditCost = new CreditCost(15, 'USD');
+        $this->paymentRepository->_CreditCost = [new CreditCost(1, 15, 'USD')];
 
         $this->page->_ResourceId = 1;
         $this->page->_ResourceIds = [2];

--- a/tests/Presenters/Reservation/ReservationDeletePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationDeletePresenterTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Presenters/Reservation/ReservationDeletePresenter.php')
 require_once(ROOT_DIR . 'Pages/Ajax/ReservationDeletePage.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ReservationDeletePresenterTests extends TestBase
+class ReservationDeletePresenterTest extends TestBase
 {
     private $userId;
 

--- a/tests/Presenters/Reservation/ReservationDeletePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationDeletePresenterTest.php
@@ -68,20 +68,20 @@ class ReservationDeletePresenterTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetReferenceNumber')
-            ->will($this->returnValue($referenceNumber));
+            ->willReturn($referenceNumber);
 
         $this->page->expects($this->once())
             ->method('GetSeriesUpdateScope')
-            ->will($this->returnValue($seriesUpdateScope));
+            ->willReturn($seriesUpdateScope);
 
         $this->page->expects($this->once())
             ->method('GetReason')
-            ->will($this->returnValue($reason));
+            ->willReturn($reason);
 
         $this->persistenceService->expects($this->once())
             ->method('LoadByReferenceNumber')
             ->with($this->equalTo($referenceNumber))
-            ->will($this->returnValue($expectedSeries));
+            ->willReturn($expectedSeries);
 
         $expectedSeries->expects($this->once())
             ->method('Delete')
@@ -104,7 +104,7 @@ class ReservationDeletePresenterTest extends TestBase
         $this->handler->expects($this->once())
             ->method('Handle')
             ->with($this->equalTo($series), $this->equalTo($this->page))
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
 
         $this->presenter->HandleReservation($series);

--- a/tests/Presenters/Reservation/ReservationEmailPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationEmailPresenterTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Presenters/Reservation/ReservationEmailPresenter.php');
 require_once(ROOT_DIR . 'Pages/Ajax/ReservationEmailPage.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ReservationEmailPresenterTests extends TestBase
+class ReservationEmailPresenterTest extends TestBase
 {
     private $userId;
 

--- a/tests/Presenters/Reservation/ReservationHandlerTest.php
+++ b/tests/Presenters/Reservation/ReservationHandlerTest.php
@@ -20,7 +20,7 @@ class ReservationHandlerTest extends TestBase
         $validationService->expects($this->once())
                           ->method('Validate')
                           ->with($this->equalTo($series))
-                          ->will($this->returnValue($validationResult));
+                          ->willReturn($validationResult);
 
         $persistenceService->expects($this->once())
                            ->method('Persist')
@@ -65,7 +65,7 @@ class ReservationHandlerTest extends TestBase
         $validationService->expects($this->once())
                           ->method('Validate')
                           ->with($this->equalTo($series))
-                          ->will($this->returnValue($validationResult));
+                          ->willReturn($validationResult);
 
         $persistenceService->expects($this->never())
                            ->method('Persist');
@@ -113,7 +113,7 @@ class ReservationHandlerTest extends TestBase
         $validationService->expects($this->once())
                           ->method('Validate')
                           ->with($this->equalTo($series), $this->equalTo($page->retryParameters))
-                          ->will($this->returnValue($validationResult));
+                          ->willReturn($validationResult);
 
         $persistenceService->expects($this->never())
                            ->method('Persist');
@@ -150,7 +150,7 @@ class ReservationHandlerTest extends TestBase
         $validationService->expects($this->once())
             ->method('Validate')
             ->with($this->equalTo($series))
-            ->will($this->returnValue($validationResult));
+            ->willReturn($validationResult);
 
         $persistenceService->expects($this->never())
             ->method('Persist');

--- a/tests/Presenters/Reservation/ReservationHandlerTest.php
+++ b/tests/Presenters/Reservation/ReservationHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ReservationHandlerTests extends TestBase
+class ReservationHandlerTest extends TestBase
 {
     public function testHandlingReservationCreationDelegatesToServicesForValidationAndPersistenceAndNotification()
     {

--- a/tests/Presenters/Reservation/ReservationInitializationTest.php
+++ b/tests/Presenters/Reservation/ReservationInitializationTest.php
@@ -6,7 +6,7 @@ require_once(ROOT_DIR . 'Pages/Reservation/ReservationPage.php');
 require_once(ROOT_DIR . 'Pages/Reservation/NewReservationPage.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/NewReservationInitializer.php');
 
-class ReservationInitializationTests extends TestBase
+class ReservationInitializationTest extends TestBase
 {
     /**
      * @var IReservationComponentBinder|PHPUnit_Framework_MockObject_MockObject

--- a/tests/Presenters/Reservation/ReservationInitializationTest.php
+++ b/tests/Presenters/Reservation/ReservationInitializationTest.php
@@ -83,7 +83,7 @@ class ReservationInitializationTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetRequestedScheduleId')
-            ->will($this->returnValue($scheduleId));
+            ->willReturn($scheduleId);
 
         $this->page->expects($this->once())
             ->method('SetScheduleId')
@@ -165,7 +165,7 @@ class ReservationInitializationTest extends TestBase
 
         $this->page->expects($this->once())
             ->method('GetRequestedScheduleId')
-            ->will($this->returnValue(null));
+            ->willReturn(null);
 
         $this->page->expects($this->once())
             ->method('SetScheduleId')

--- a/tests/Presenters/Reservation/ReservationMovePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationMovePresenterTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Presenters/Reservation/ReservationMovePresenter.php');
 require_once(ROOT_DIR . 'Pages/Ajax/ReservationMovePage.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ReservationMovePresenterTests extends TestBase
+class ReservationMovePresenterTest extends TestBase
 {
     private $userId;
 

--- a/tests/Presenters/Reservation/ReservationMovePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationMovePresenterTest.php
@@ -80,7 +80,7 @@ class ReservationMovePresenterTest extends TestBase
         $this->persistenceService->expects($this->once())
                                  ->method('LoadByReferenceNumber')
                                  ->with($this->equalTo($this->page->_ReferenceNumber))
-                                 ->will($this->returnValue($expectedSeries));
+                                 ->willReturn($expectedSeries);
 
         $this->handler->expects($this->once())
                       ->method('Handle')
@@ -107,12 +107,12 @@ class ReservationMovePresenterTest extends TestBase
         $this->persistenceService->expects($this->once())
                                  ->method('LoadByReferenceNumber')
                                  ->with($this->equalTo($this->page->_ReferenceNumber))
-                                 ->will($this->returnValue($expectedSeries));
+                                 ->willReturn($expectedSeries);
 
         $this->resourceRepository->expects($this->once())
                     ->method('LoadById')
                     ->with($this->equalTo($this->page->_ResourceId))
-                    ->will($this->returnValue($newResource));
+                    ->willReturn($newResource);
 
         $this->presenter->PageLoad();
 
@@ -137,7 +137,7 @@ class ReservationMovePresenterTest extends TestBase
         $this->persistenceService->expects($this->once())
                                  ->method('LoadByReferenceNumber')
                                  ->with($this->equalTo($this->page->_ReferenceNumber))
-                                 ->will($this->returnValue($expectedSeries));
+                                 ->willReturn($expectedSeries);
 
         $this->presenter->PageLoad();
 

--- a/tests/Presenters/Reservation/ReservationSavePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationSavePresenterTest.php
@@ -124,20 +124,14 @@ class ReservationSavePresenterTest extends TestBase
         $startReminder = new ReservationReminder($this->page->GetStartReminderValue(), $this->page->GetStartReminderInterval());
         $endReminder = new ReservationReminder($this->page->GetEndReminderValue(), $this->page->GetEndReminderInterval());
 
-        $this->resourceRepository->expects($this->at(0))
+        $this->resourceRepository->expects($this->exactly(3))
                                  ->method('LoadById')
-                                 ->with($this->equalTo($resourceId))
-                                 ->will($this->returnValue($resource));
-
-        $this->resourceRepository->expects($this->at(1))
-                                 ->method('LoadById')
-                                 ->with($this->equalTo($additionalResources[0]))
-                                 ->will($this->returnValue($additionalResource1));
-
-        $this->resourceRepository->expects($this->at(2))
-                                 ->method('LoadById')
-                                 ->with($this->equalTo($additionalResources[1]))
-                                 ->will($this->returnValue($additionalResource2));
+                                 ->willReturnMap(
+                                 [
+                                     [$resourceId, $resource],
+                                     [$additionalResources[0], $additionalResource1],
+                                     [$additionalResources[1], $additionalResource2]
+                                 ]);
 
         $fakeScheduleLayout = new FakeScheduleLayout();
         $fakeScheduleLayout->_SlotCount = new SlotCount(1, 2);
@@ -183,7 +177,7 @@ class ReservationSavePresenterTest extends TestBase
         $this->handler->expects($this->once())
                       ->method('Handle')
                       ->with($this->equalTo($series), $this->isInstanceOf('FakeReservationSavePage'))
-                      ->will($this->returnValue(true));
+                      ->willReturn(true);
 
         $this->presenter->HandleReservation($series);
 

--- a/tests/Presenters/Reservation/ReservationSavePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationSavePresenterTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Presenters/Reservation/ReservationSavePresenter.php');
 require_once(ROOT_DIR . 'Pages/Ajax/ReservationSavePage.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ReservationSavePresenterTests extends TestBase
+class ReservationSavePresenterTest extends TestBase
 {
     /**
      * @var UserSession

--- a/tests/Presenters/Reservation/ReservationUpdatePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationUpdatePresenterTest.php
@@ -106,22 +106,16 @@ class ReservationUpdatePresenterTest extends TestBase
         $this->persistenceService->expects($this->once())
                                  ->method('LoadByReferenceNumber')
                                  ->with($this->equalTo($referenceNumber))
-                                 ->will($this->returnValue($expectedSeries));
+                                 ->willReturn($expectedSeries);
 
-        $this->resourceRepository->expects($this->at(0))
+        $this->resourceRepository->expects($this->exactly(3))
                                  ->method('LoadById')
-                                 ->with($this->equalTo($this->page->resourceId))
-                                 ->will($this->returnValue($resource));
-
-        $this->resourceRepository->expects($this->at(1))
-                                 ->method('LoadById')
-                                 ->with($this->equalTo($additionalId1))
-                                 ->will($this->returnValue($additional1));
-
-        $this->resourceRepository->expects($this->at(2))
-                                 ->method('LoadById')
-                                 ->with($this->equalTo($additionalId2))
-                                 ->will($this->returnValue($additional2));
+                                 ->willReturnMap(
+                                 [
+                                     [$this->page->resourceId, $resource],
+                                     [$additionalId1, $additional1],
+                                     [$additionalId2, $additional2]
+                                 ]);
 
         $this->page->repeatType = RepeatType::Daily;
         $roFactory = new RepeatOptionsFactory();
@@ -206,12 +200,12 @@ class ReservationUpdatePresenterTest extends TestBase
         $this->persistenceService->expects($this->once())
                                  ->method('LoadByReferenceNumber')
                                  ->with($this->equalTo($referenceNumber))
-                                 ->will($this->returnValue($expectedSeries));
+                                 ->willReturn($expectedSeries);
 
         $this->resourceRepository->expects($this->once())
                                  ->method('LoadById')
                                  ->with($this->equalTo($additionalId))
-                                 ->will($this->returnValue($resource));
+                                 ->willReturn($resource);
 
         $existingSeries = $this->presenter->BuildReservation();
 
@@ -229,7 +223,7 @@ class ReservationUpdatePresenterTest extends TestBase
         $this->handler->expects($this->once())
                       ->method('Handle')
                       ->with($this->equalTo($series), $this->isInstanceOf('FakeReservationUpdatePage'))
-                      ->will($this->returnValue(true));
+                      ->willReturn(true);
 
         $this->presenter->HandleReservation($series);
 

--- a/tests/Presenters/Reservation/ReservationUpdatePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationUpdatePresenterTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Presenters/Reservation/ReservationUpdatePresenter.php')
 require_once(ROOT_DIR . 'Pages/Ajax/ReservationUpdatePage.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
-class ReservationUpdatePresenterTests extends TestBase
+class ReservationUpdatePresenterTest extends TestBase
 {
     private $userId;
 

--- a/tests/Presenters/Reservation/ReservationUserAvailabilityPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationUserAvailabilityPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Reservation/ReservationUserAvailabilityPresenter.php');
 
-class ReservationUserAvailabilityPresenterTests extends TestBase
+class ReservationUserAvailabilityPresenterTest extends TestBase
 {
     /**
      * @var ReservationUserAvailabilityPresenter

--- a/tests/Presenters/Reservation/ReservationWaitlistPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationWaitlistPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Reservation/ReservationWaitlistPresenter.php');
 
-class ReservationWaitlistPresenterTests extends TestBase
+class ReservationWaitlistPresenterTest extends TestBase
 {
     /**
      * @var FakeReservationWaitlistPage

--- a/tests/Presenters/ResourceDisplayPresenterTest.php
+++ b/tests/Presenters/ResourceDisplayPresenterTest.php
@@ -128,7 +128,7 @@ class ResourceDisplayPresenterTest extends TestBase
         $this->attributeService->_ReservationAttributes = [];
 
         $this->presenter->reservationCreateHandler = $this->reservationCreateHandler;
-        $this->presenter->DisplayResource($publicId);
+        $this->presenter->DisplayResource($publicId, null);
         $expectedDate = DateRange::Create($now->ToTimezone($timezone)->GetDate()->ToUtc(), $now->ToTimezone($timezone)->GetDate()->AddDays(1)->ToUtc(), 'UTC');
 
         $this->assertEquals(new DailyLayout(
@@ -158,7 +158,7 @@ class ResourceDisplayPresenterTest extends TestBase
             $nextItem
         ];
 
-        $this->presenter->DisplayResource(1);
+        $this->presenter->DisplayResource(1, null);
 
         $this->assertEquals([$nextItem], $this->page->_UpcomingReservations);
         $this->assertEquals($nextItem, $this->page->_NextReservation);
@@ -182,7 +182,7 @@ class ResourceDisplayPresenterTest extends TestBase
             new ReservationListItem($r2),
         ];
 
-        $this->presenter->DisplayResource(1);
+        $this->presenter->DisplayResource(1, null);
 
         $this->assertEquals(true, $this->page->_RequiresCheckIn);
         $this->assertEquals("refnum", $this->page->_CheckinReferenceNumber);
@@ -203,7 +203,7 @@ class ResourceDisplayPresenterTest extends TestBase
             $nextItem
         ];
 
-        $this->presenter->DisplayResource(1);
+        $this->presenter->DisplayResource(1, null);
 
         $this->assertEquals(true, $this->page->_AvailableNow);
         $this->assertEquals(false, $this->page->_RequiresCheckIn);
@@ -224,7 +224,7 @@ class ResourceDisplayPresenterTest extends TestBase
             $nextItem
         ];
 
-        $this->presenter->DisplayResource(1);
+        $this->presenter->DisplayResource(1, null);
 
         $this->assertEquals(false, $this->page->_AvailableNow);
         $this->assertEquals($currentItem, $this->page->_CurrentReservation);
@@ -235,7 +235,7 @@ class ResourceDisplayPresenterTest extends TestBase
         $resource = new FakeBookableResource(1);
         $this->resourceRepository->_Resource = $resource;
 
-        $this->presenter->DisplayResource('whatever');
+        $this->presenter->DisplayResource('whatever', null);
 
         $this->assertTrue($this->page->_DisplayNotEnabledMessage);
     }
@@ -260,14 +260,14 @@ class ResourceDisplayPresenterTest extends TestBase
         $this->attributeService->_ReservationAttributes = [];
 
         $this->presenter->reservationCreateHandler = $this->reservationCreateHandler;
-        $this->presenter->DisplayResource($publicId);
-        $expectedDate = DateRange::Create($now->ToTimezone($timezone)->GetDate()->AddDays(1)->ToUtc(), $now->ToTimezone($timezone)->GetDate()->AddDays(2)->ToUtc(), 'UTC');
+        $this->presenter->DisplayResource($publicId, null);
+        $expectedDate = $now->ToTimezone($timezone)->GetDate()->AddDays(1);
 
         $this->assertEquals(new DailyLayout(
             $this->reservationService->_ReservationListing,
             $this->scheduleRepository->_Layout
         ), $this->page->_DailyLayout);
-        $this->assertEquals($expectedDate, $this->reservationService->_LastDateRange);
+        $this->assertEquals($expectedDate, $this->page->_Today);
     }
 
     public function testWhenBookingSucceeds()
@@ -276,6 +276,7 @@ class ResourceDisplayPresenterTest extends TestBase
         $this->page->_Email = 'some@user.com';
         $this->page->_BeginTime = '08:00';
         $this->page->_EndTime = '17:00';
+        $this->page->_BeginDate = '2016-03-11';
         $this->page->_Timezone = 'America/New_York';
         $this->page->_ResourceId = 292;
 
@@ -307,6 +308,7 @@ class ResourceDisplayPresenterTest extends TestBase
         $this->page->_Email = 'some@user.com';
         $this->page->_BeginTime = '08:00';
         $this->page->_EndTime = '17:00';
+        $this->page->_BeginDate = '2016-03-11';
         $this->page->_Timezone = 'America/New_York';
         $this->page->_ResourceId = 292;
 
@@ -377,10 +379,12 @@ class TestResourceDisplayPage extends FakePageBase implements IResourceDisplayPa
     public $_DisplayNotEnabledMessage = false;
     public $_Email;
     public $_BeginTime;
+    public $_BeginDate;
     public $_EndTime;
     public $_Timezone;
     public $_ReservationCreatedSuccessfully;
     public $_ReservationCheckedInSuccessfully;
+    public $_Today;
 
     /**
      * @var ReservationResultCollector
@@ -483,6 +487,7 @@ class TestResourceDisplayPage extends FakePageBase implements IResourceDisplayPa
         $this->_UpcomingReservations = $upcoming;
         $this->_RequiresCheckIn = $requiresCheckin;
         $this->_CheckinReferenceNumber = $checkinReferenceNumber;
+        $this->_Today = $today;
     }
 
     public function BindResource(BookableResource $resource)
@@ -513,6 +518,11 @@ class TestResourceDisplayPage extends FakePageBase implements IResourceDisplayPa
     public function GetBeginTime()
     {
         return $this->_BeginTime;
+    }
+
+    public function GetBeginDate()
+    {
+        return $this->_BeginDate;
     }
 
     public function GetEndTime()

--- a/tests/Presenters/ResourceDisplayPresenterTest.php
+++ b/tests/Presenters/ResourceDisplayPresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Presenters/ResourceDisplayPresenter.php');
 require_once(ROOT_DIR . 'Pages/ResourceDisplayPage.php');
 
-class ResourceDisplayPresenterTests extends TestBase
+class ResourceDisplayPresenterTest extends TestBase
 {
     /**
      * @var FakeGuestUserService

--- a/tests/Presenters/SchedulePresenterTest.php
+++ b/tests/Presenters/SchedulePresenterTest.php
@@ -55,24 +55,24 @@ class SchedulePresenterTest extends TestBase
         $page
                 ->expects($this->once())
                 ->method('ShowInaccessibleResources')
-                ->will($this->returnValue($this->showInaccessibleResources));
+                ->willReturn($this->showInaccessibleResources);
 
         $page
                 ->expects($this->once())
                 ->method('GetDisplayTimezone')
-                ->will($this->returnValue($user->Timezone));
+                ->willReturn($user->Timezone);
 
         $scheduleService
                 ->expects($this->once())
                 ->method('GetAll')
                 ->with($this->equalTo($this->showInaccessibleResources), $this->equalTo($this->fakeUser))
-                ->will($this->returnValue($this->schedules));
+                ->willReturn($this->schedules);
 
         $pageBuilder
                 ->expects($this->once())
                 ->method('GetCurrentSchedule')
                 ->with($this->equalTo($page), $this->equalTo($this->schedules), $this->equalTo($user))
-                ->will($this->returnValue($this->currentSchedule));
+                ->willReturn($this->currentSchedule);
 
         $pageBuilder
                 ->expects($this->once())
@@ -85,7 +85,7 @@ class SchedulePresenterTest extends TestBase
                 ->expects($this->once())
                 ->method('GetResourceFilter')
                 ->with($this->equalTo($this->scheduleId), $this->equalTo($page))
-                ->will($this->returnValue($resourceFilter));
+                ->willReturn($resourceFilter);
 
         $pageBuilder
                 ->expects($this->once())
@@ -106,13 +106,13 @@ class SchedulePresenterTest extends TestBase
                     $this->equalTo($user),
                     $this->equalTo($resourceFilter)
                 )
-                ->will($this->returnValue($resources));
+                ->willReturn($resources);
 
         $resourceService
                 ->expects($this->once())
                 ->method('GetResourceGroups')
                 ->with($this->equalTo($this->scheduleId))
-                ->will($this->returnValue($groups));
+                ->willReturn($groups);
 
         $pageBuilder
                 ->expects($this->once())
@@ -123,7 +123,7 @@ class SchedulePresenterTest extends TestBase
                 ->expects($this->once())
                 ->method('GetScheduleDates')
                 ->with($this->equalTo($user), $this->equalTo($this->currentSchedule), $this->equalTo($page))
-                ->will($this->returnValue($bindingDates));
+                ->willReturn($bindingDates);
 
         $pageBuilder
                 ->expects($this->once())
@@ -134,7 +134,7 @@ class SchedulePresenterTest extends TestBase
                 ->expects($this->once())
                 ->method('GetDailyLayout')
                 ->with($this->equalTo($this->scheduleId), new ScheduleLayoutFactory($user->Timezone), new EmptyReservationListing())
-                ->will($this->returnValue($dailyLayout));
+                ->willReturn($dailyLayout);
 
         $pageBuilder
                 ->expects($this->once())
@@ -144,7 +144,7 @@ class SchedulePresenterTest extends TestBase
         $resourceService
                 ->expects($this->once())
                 ->method('GetResourceTypes')
-                ->will($this->returnValue($resourceTypes));
+                ->willReturn($resourceTypes);
 
         $pageBuilder
                 ->expects($this->once())
@@ -154,12 +154,12 @@ class SchedulePresenterTest extends TestBase
         $resourceService
                 ->expects($this->once())
                 ->method('GetResourceAttributes')
-                ->will($this->returnValue($resourceAttributes));
+                ->willReturn($resourceAttributes);
 
         $resourceService
                 ->expects($this->once())
                 ->method('GetResourceTypeAttributes')
-                ->will($this->returnValue($resourceTypeAttributes));
+                ->willReturn($resourceTypeAttributes);
 
         $presenter->PageLoad($this->fakeUser);
     }
@@ -198,7 +198,7 @@ class SchedulePresenterTest extends TestBase
                 ->expects($this->once())
                 ->method('GetScheduleStyle')
                 ->with($this->equalTo($activeId))
-                ->will($this->returnValue(ScheduleStyle::Tall));
+                ->willReturn(ScheduleStyle::Tall);
 
         $page
                 ->expects($this->once())
@@ -217,12 +217,12 @@ class SchedulePresenterTest extends TestBase
         $s1
                 ->expects($this->once())
                 ->method('GetId')
-                ->will($this->returnValue(11));
+                ->willReturn(11);
 
         $s2
                 ->expects($this->once())
                 ->method('GetId')
-                ->will($this->returnValue(10));
+                ->willReturn(10);
 
         $schedules = [$s1, $s2];
 
@@ -231,7 +231,7 @@ class SchedulePresenterTest extends TestBase
         $page
                 ->expects($this->atLeastOnce())
                 ->method('GetScheduleId')
-                ->will($this->returnValue(10));
+                ->willReturn(10);
 
         $pageBuilder = new SchedulePageBuilder();
         $actual = $pageBuilder->GetCurrentSchedule($page, $schedules, $this->fakeUser);
@@ -297,17 +297,17 @@ class SchedulePresenterTest extends TestBase
         $schedulePage
                 ->expects($this->once())
                 ->method('GetSelectedDate')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetWeekdayStart')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $pageBuilder = new SchedulePageBuilder();
         $dates = $pageBuilder->GetScheduleDates($user, $schedule, $schedulePage);
@@ -339,17 +339,17 @@ class SchedulePresenterTest extends TestBase
         $schedulePage
                 ->expects($this->once())
                 ->method('GetSelectedDate')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetWeekdayStart')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $pageBuilder = new SchedulePageBuilder();
         $dates = $pageBuilder->GetScheduleDates($user, $schedule, $schedulePage);
@@ -383,17 +383,17 @@ class SchedulePresenterTest extends TestBase
         $schedulePage
                 ->expects($this->once())
                 ->method('GetSelectedDate')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetWeekdayStart')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $pageBuilder = new SchedulePageBuilder();
         $dates = $pageBuilder->GetScheduleDates($user, $schedule, $schedulePage);
@@ -426,17 +426,17 @@ class SchedulePresenterTest extends TestBase
         $schedulePage
                 ->expects($this->once())
                 ->method('GetSelectedDate')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetWeekdayStart')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $pageBuilder = new SchedulePageBuilder();
         $dates = $pageBuilder->GetScheduleDates($user, $schedule, $schedulePage);
@@ -472,17 +472,17 @@ class SchedulePresenterTest extends TestBase
         $schedulePage
                 ->expects($this->once())
                 ->method('GetSelectedDate')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetWeekdayStart')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $pageBuilder = new SchedulePageBuilder();
         $dates = $pageBuilder->GetScheduleDates($user, $schedule, $schedulePage);
@@ -518,17 +518,17 @@ class SchedulePresenterTest extends TestBase
         $schedulePage
                 ->expects($this->once())
                 ->method('GetSelectedDate')
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetWeekdayStart')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $pageBuilder = new SchedulePageBuilder();
         $dates = $pageBuilder->GetScheduleDates($user, $schedule, $schedulePage);
@@ -560,17 +560,17 @@ class SchedulePresenterTest extends TestBase
         $schedulePage
                 ->expects($this->once())
                 ->method('GetSelectedDate')
-                ->will($this->returnValue($selectedDate->Format("Y-m-d")));
+                ->willReturn($selectedDate->Format("Y-m-d"));
 
         $schedule
                 ->expects($this->once())
                 ->method('GetWeekdayStart')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $pageBuilder = new SchedulePageBuilder();
         $dates = $pageBuilder->GetScheduleDates($user, $schedule, $schedulePage);
@@ -753,22 +753,22 @@ class SchedulePresenterTest extends TestBase
         $schedulePage
                 ->expects($this->once())
                 ->method('GetSelectedDate')
-                ->will($this->returnValue($selectedDate->Format("Y-m-d")));
+                ->willReturn($selectedDate->Format("Y-m-d"));
 
         $schedulePage
                 ->expects($this->once())
                 ->method('GetShowFullWeek')
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetWeekdayStart')
-                ->will($this->returnValue($startDay));
+                ->willReturn($startDay);
 
         $schedule
                 ->expects($this->once())
                 ->method('GetDaysVisible')
-                ->will($this->returnValue($daysVisible));
+                ->willReturn($daysVisible);
 
         $pageBuilder = new SchedulePageBuilder();
         $dates = $pageBuilder->GetScheduleDates($user, $schedule, $schedulePage);
@@ -798,24 +798,24 @@ class SchedulePresenterTest extends TestBase
         $page
                 ->expects($this->once())
                 ->method('GetScheduleId')
-                ->will($this->returnValue($scheduleId));
+                ->willReturn($scheduleId);
 
         $page
                 ->expects($this->once())
                 ->method('GetLayoutDate')
-                ->will($this->returnValue($dateString));
+                ->willReturn($dateString);
 
         $scheduleService
                 ->expects($this->once())
                 ->method('GetLayout')
                 ->with($this->equalTo($scheduleId), $this->equalTo(new ScheduleLayoutFactory($user->Timezone)))
-                ->will($this->returnValue($layout));
+                ->willReturn($layout);
 
         $layout
                 ->expects($this->once())
                 ->method('GetLayout')
                 ->with($this->equalTo($date))
-                ->will($this->returnValue($periods));
+                ->willReturn($periods);
 
         $page
                 ->expects($this->once())

--- a/tests/Presenters/SchedulePresenterTest.php
+++ b/tests/Presenters/SchedulePresenterTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'Presenters/Schedule/SchedulePresenter.php');
 require_once(ROOT_DIR . 'Pages/SchedulePage.php');
 
-class SchedulePresenterTests extends TestBase
+class SchedulePresenterTest extends TestBase
 {
     private $scheduleId;
     private $currentSchedule;
@@ -908,6 +908,8 @@ class FakeSchedulePage implements ISchedulePage
      * @var int
      */
     public $_ParticipantId;
+
+    public function BindViewableResourceReservations($resourceIds) { }
 
     public function TakingAction()
     {

--- a/tests/Presenters/Search/SearchReservationsPresenterTest.php
+++ b/tests/Presenters/Search/SearchReservationsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Search/SearchReservationsPresenter.php');
 
-class SearchReservationsPresenterTests extends TestBase
+class SearchReservationsPresenterTest extends TestBase
 {
     /**
      * @var SearchReservationsPresenter

--- a/tests/Presenters/SearchAvailabilityPresenterTest.php
+++ b/tests/Presenters/SearchAvailabilityPresenterTest.php
@@ -128,7 +128,7 @@ class SearchAvailabilityPresenterTest extends TestBase
 
         $this->presenter->SearchAvailability();
 
-        $expectedSearchRange = new DateRange(Date::Parse('2016-07-03', $this->fakeUser->Timezone), Date::Parse('2016-07-09', $this->fakeUser->Timezone));
+        $expectedSearchRange = new DateRange(Date::Parse('2016-07-03', $this->fakeUser->Timezone), Date::Parse('2016-07-10', $this->fakeUser->Timezone));
         $this->assertEquals($expectedSearchRange, $this->reservationService->_LastDateRange);
     }
 
@@ -283,13 +283,13 @@ class SearchAvailabilityPresenterTest extends TestBase
         $resource = new TestResourceDto($resourceId);
         $this->resourceService->_AllResources = [$resource];
 
-        $sun = new Date('2019-01-20', $tz);
         $mon = new Date('2019-01-21', $tz);
         $tue = new Date('2019-01-22', $tz);
         $wed = new Date('2019-01-23', $tz);
         $thu = new Date('2019-01-24', $tz);
         $fri = new Date('2019-01-25', $tz);
         $sat = new Date('2019-01-26', $tz);
+        $sun = new Date('2019-01-27', $tz);
 
         Date::_SetNow($tue);
         $this->page->_Range = 'thisweek';

--- a/tests/Presenters/SearchAvailabilityPresenterTest.php
+++ b/tests/Presenters/SearchAvailabilityPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/SearchAvailabilityPresenter.php');
 
-class SearchAvailabilityPresenterTests extends TestBase
+class SearchAvailabilityPresenterTest extends TestBase
 {
     /**
      * @var SearchAvailabilityPresenter

--- a/tests/Presenters/UnavailableResourcesPresenterTest.php
+++ b/tests/Presenters/UnavailableResourcesPresenterTest.php
@@ -4,7 +4,7 @@ require_once(ROOT_DIR . 'Pages/Ajax/UnavailableResourcesPage.php');
 require_once(ROOT_DIR . 'Presenters/UnavailableResourcesPresenter.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/ResourceAvailability.php');
 
-class UnavailableResourcesPresenterTests extends TestBase
+class UnavailableResourcesPresenterTest extends TestBase
 {
     /**
      * @var FakeReservationConflictIdentifier

--- a/tests/Presenters/UserCreditsPresenterTest.php
+++ b/tests/Presenters/UserCreditsPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Presenters/Credits/UserCreditsPresenter.php');
 
-class UserCreditsPresenterTests extends TestBase
+class UserCreditsPresenterTest extends TestBase
 {
     /**
      * @var FakeUserCreditsPage

--- a/tests/Presenters/UserCreditsPresenterTest.php
+++ b/tests/Presenters/UserCreditsPresenterTest.php
@@ -47,7 +47,7 @@ class UserCreditsPresenterTest extends TestBase
         $currentCredits = 10.5;
         $this->userRepository->_User = new FakeUser();
         $this->userRepository->_User->WithCredits($currentCredits);
-        $this->paymentRepository->_CreditCost = new CreditCost('10.11');
+        $this->paymentRepository->_CreditCost = [new CreditCost(1, '10.11')];
 
         $this->presenter->PageLoad($this->fakeUser);
 

--- a/tests/Presenters/UserDetailsPopupPresenterTest.php
+++ b/tests/Presenters/UserDetailsPopupPresenterTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Pages/Ajax/UserDetailsPopupPage.php');
 
-class UserDetailsPopupPresenterTests extends TestBase
+class UserDetailsPopupPresenterTest extends TestBase
 {
     /**
      * @var UserDetailsPopupPresenter

--- a/tests/WebService/SlimWebServiceRegistryTest.php
+++ b/tests/WebService/SlimWebServiceRegistryTest.php
@@ -102,7 +102,7 @@ class TestSlim extends Slim\Slim
 }
 
 
-class SlimWebServiceRegistryTests extends TestBase
+class SlimWebServiceRegistryTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/WebService/WebServiceSecurityTest.php
+++ b/tests/WebService/WebServiceSecurityTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'lib/WebService/namespace.php');
 
-class WebServiceSecurityTests extends TestBase
+class WebServiceSecurityTest extends TestBase
 {
     private $sessionToken = 'sessionToken';
     private $userId = 'userId';

--- a/tests/WebService/WebServiceSecurityTest.php
+++ b/tests/WebService/WebServiceSecurityTest.php
@@ -41,20 +41,18 @@ class WebServiceSecurityTest extends TestBase
 
     public function testSetsUserSessionIfValidAndNotExpired()
     {
-        $this->server->expects($this->at(0))
+        $this->server->expects($this->exactly(2))
                 ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::SESSION_TOKEN))
-                ->will($this->returnValue($this->sessionToken));
-
-        $this->server->expects($this->at(1))
-                ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::USER_ID))
-                ->will($this->returnValue($this->userId));
+                ->willReturnMap(
+                [
+                    [WebServiceHeaders::SESSION_TOKEN, $this->sessionToken],
+                    [WebServiceHeaders::USER_ID, $this->userId]
+                ]);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($this->sessionToken))
-                ->will($this->returnValue($this->session));
+                ->willReturn($this->session);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('Update')
@@ -74,20 +72,18 @@ class WebServiceSecurityTest extends TestBase
     {
         $this->session->_IsExpired = true;
 
-        $this->server->expects($this->at(0))
+        $this->server->expects($this->exactly(2))
                 ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::SESSION_TOKEN))
-                ->will($this->returnValue($this->sessionToken));
-
-        $this->server->expects($this->at(1))
-                ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::USER_ID))
-                ->will($this->returnValue($this->userId));
+                ->willReturnMap(
+                [
+                    [WebServiceHeaders::SESSION_TOKEN, $this->sessionToken],
+                    [WebServiceHeaders::USER_ID, $this->userId]
+                ]);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($this->sessionToken))
-                ->will($this->returnValue($this->session));
+                ->willReturn($this->session);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('Delete')
@@ -101,20 +97,18 @@ class WebServiceSecurityTest extends TestBase
 
     public function testHandlesSessionNotFound()
     {
-        $this->server->expects($this->at(0))
+        $this->server->expects($this->exactly(2))
                 ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::SESSION_TOKEN))
-                ->will($this->returnValue($this->sessionToken));
-
-        $this->server->expects($this->at(1))
-                ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::USER_ID))
-                ->will($this->returnValue($this->userId));
+                ->willReturnMap(
+                [
+                    [WebServiceHeaders::SESSION_TOKEN, $this->sessionToken],
+                    [WebServiceHeaders::USER_ID, $this->userId]
+                ]);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($this->sessionToken))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $wasHandled = $this->security->HandleSecureRequest($this->server);
 
@@ -123,20 +117,18 @@ class WebServiceSecurityTest extends TestBase
 
     public function testHandlesSessionMisMatch()
     {
-        $this->server->expects($this->at(0))
+        $this->server->expects($this->exactly(2))
                 ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::SESSION_TOKEN))
-                ->will($this->returnValue('not the right token'));
-
-        $this->server->expects($this->at(1))
-                ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::USER_ID))
-                ->will($this->returnValue('not the right id'));
+                ->willReturnMap(
+                [
+                    [WebServiceHeaders::SESSION_TOKEN, 'not the right token'],
+                    [WebServiceHeaders::USER_ID, 'not the right id']
+                ]);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo('not the right token'))
-                ->will($this->returnValue($this->session));
+                ->willReturn($this->session);
 
         $wasHandled = $this->security->HandleSecureRequest($this->server);
 
@@ -146,20 +138,18 @@ class WebServiceSecurityTest extends TestBase
     public function testHandlesAdminRequest()
     {
         $this->session->IsAdmin = true;
-        $this->server->expects($this->at(0))
+        $this->server->expects($this->exactly(2))
                 ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::SESSION_TOKEN))
-                ->will($this->returnValue($this->sessionToken));
-
-        $this->server->expects($this->at(1))
-                ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::USER_ID))
-                ->will($this->returnValue($this->userId));
+                ->willReturnMap(
+                [
+                    [WebServiceHeaders::SESSION_TOKEN, $this->sessionToken],
+                    [WebServiceHeaders::USER_ID, $this->userId]
+                ]);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($this->sessionToken))
-                ->will($this->returnValue($this->session));
+                ->willReturn($this->session);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('Update')
@@ -178,20 +168,18 @@ class WebServiceSecurityTest extends TestBase
     public function testHandlesWhenUserIsNotAdmin()
     {
         $this->session->IsAdmin = false;
-        $this->server->expects($this->at(0))
+        $this->server->expects($this->exactly(2))
                 ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::SESSION_TOKEN))
-                ->will($this->returnValue($this->sessionToken));
-
-        $this->server->expects($this->at(1))
-                ->method('GetHeader')
-                ->with($this->equalTo(WebServiceHeaders::USER_ID))
-                ->will($this->returnValue($this->userId));
+                ->willReturnMap(
+                [
+                    [WebServiceHeaders::SESSION_TOKEN, $this->sessionToken],
+                    [WebServiceHeaders::USER_ID, $this->userId]
+                ]);
 
         $this->userSessionRepository->expects($this->once())
                 ->method('LoadBySessionToken')
                 ->with($this->equalTo($this->sessionToken))
-                ->will($this->returnValue($this->session));
+                ->willReturn($this->session);
 
         $wasHandled = $this->security->HandleSecureRequest($this->server, true);
 

--- a/tests/WebService/WebServiceUserSessionTest.php
+++ b/tests/WebService/WebServiceUserSessionTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'Domain/Values/WebService/WebServiceUserSession.php');
 
-class WebServiceUserSessionTests extends TestBase
+class WebServiceUserSessionTest extends TestBase
 {
     public function setUp(): void
     {

--- a/tests/WebServices/AccessoriesWebServiceTest.php
+++ b/tests/WebServices/AccessoriesWebServiceTest.php
@@ -41,7 +41,7 @@ class AccessoriesWebServiceTest extends TestBase
 
         $this->resourceRepository->expects($this->once())
                 ->method('GetAccessoryList')
-                ->will($this->returnValue($accessories));
+                ->willReturn($accessories);
 
         $this->service->GetAll();
 
@@ -58,7 +58,7 @@ class AccessoriesWebServiceTest extends TestBase
         $this->accessoryRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($accessoryId))
-                ->will($this->returnValue($accessory));
+                ->willReturn($accessory);
 
         $this->service->GetAccessory($accessoryId);
 
@@ -73,7 +73,7 @@ class AccessoriesWebServiceTest extends TestBase
         $this->accessoryRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($accessoryId))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->service->GetAccessory($accessoryId);
 

--- a/tests/WebServices/AccessoriesWebServiceTest.php
+++ b/tests/WebServices/AccessoriesWebServiceTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'WebServices/AccessoriesWebService.php');
 
 
-class AccessoriesWebServiceTests extends TestBase
+class AccessoriesWebServiceTest extends TestBase
 {
     /**
      * @var AccessoriesWebService

--- a/tests/WebServices/AccountWebServiceTest.php
+++ b/tests/WebServices/AccountWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/AccountWebService.php');
 
-class AccountWebServiceTests extends TestBase
+class AccountWebServiceTest extends TestBase
 {
     /**
      * @var AccountWebService

--- a/tests/WebServices/AttributesWebServiceTest.php
+++ b/tests/WebServices/AttributesWebServiceTest.php
@@ -38,7 +38,7 @@ class AttributesWebServiceTest extends TestBase
         $this->attributeService->expects($this->once())
                 ->method('GetById')
                 ->with($this->equalTo($attributeId))
-                ->will($this->returnValue($attribute));
+                ->willReturn($attribute);
 
         $expectedResponse = new CustomAttributeDefinitionResponse($this->server, $attribute);
 
@@ -54,7 +54,7 @@ class AttributesWebServiceTest extends TestBase
         $this->attributeService->expects($this->once())
                 ->method('GetById')
                 ->with($this->equalTo($attributeId))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->service->GetAttribute($attributeId);
 
@@ -69,7 +69,7 @@ class AttributesWebServiceTest extends TestBase
         $this->attributeService->expects($this->once())
                 ->method('GetByCategory')
                 ->with($this->equalTo($categoryId))
-                ->will($this->returnValue($attributes));
+                ->willReturn($attributes);
 
         $expectedResponse = new CustomAttributesResponse($this->server, $attributes);
 

--- a/tests/WebServices/AttributesWebServiceTest.php
+++ b/tests/WebServices/AttributesWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/AttributesWebService.php');
 
-class AttributesWebServiceTests extends TestBase
+class AttributesWebServiceTest extends TestBase
 {
     /**
      * @var IAttributeService|PHPUnit_Framework_MockObject_MockObject

--- a/tests/WebServices/AuthenticationWebServiceTest.php
+++ b/tests/WebServices/AuthenticationWebServiceTest.php
@@ -41,12 +41,12 @@ class AuthenticationWebServiceTest extends TestBase
         $this->authentication->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo($username), $this->equalTo($password))
-                ->will($this->returnValue(true));
+                ->willReturn(true);
 
         $this->authentication->expects($this->once())
                 ->method('Login')
                 ->with($this->equalTo($username))
-                ->will($this->returnValue($session));
+                ->willReturn($session);
 
         $this->service->Authenticate($this->server);
 
@@ -65,7 +65,7 @@ class AuthenticationWebServiceTest extends TestBase
         $this->authentication->expects($this->once())
                 ->method('Validate')
                 ->with($this->equalTo($username), $this->equalTo($password))
-                ->will($this->returnValue(false));
+                ->willReturn(false);
 
         $this->service->Authenticate($this->server);
 

--- a/tests/WebServices/AuthenticationWebServiceTest.php
+++ b/tests/WebServices/AuthenticationWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/AuthenticationWebService.php');
 
-class AuthenticationWebServiceTests extends TestBase
+class AuthenticationWebServiceTest extends TestBase
 {
     /**
      * @var IWebServiceAuthentication|PHPUnit_Framework_MockObject_MockObject

--- a/tests/WebServices/Controllers/AccountControllerTest.php
+++ b/tests/WebServices/Controllers/AccountControllerTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/Controllers/AccountController.php');
 
-class AccountControllerTests extends TestBase
+class AccountControllerTest extends TestBase
 {
     /**
      * @var AccountController

--- a/tests/WebServices/Controllers/AttributeSaveControllerTest.php
+++ b/tests/WebServices/Controllers/AttributeSaveControllerTest.php
@@ -3,7 +3,7 @@
 require_once(ROOT_DIR . 'WebServices/Requests/CustomAttributes/CustomAttributeRequest.php');
 require_once(ROOT_DIR . 'WebServices/Controllers/AttributeSaveController.php');
 
-class AttributeSaveControllerTests extends TestBase
+class AttributeSaveControllerTest extends TestBase
 {
     /**
      * @var AttributeSaveController

--- a/tests/WebServices/Controllers/ReservationSaveControllerTest.php
+++ b/tests/WebServices/Controllers/ReservationSaveControllerTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/Controllers/ReservationSaveController.php');
 
-class ReservationSaveControllerTests extends TestBase
+class ReservationSaveControllerTest extends TestBase
 {
     /**
      * @var ReservationSaveController

--- a/tests/WebServices/Controllers/ReservationSaveControllerTest.php
+++ b/tests/WebServices/Controllers/ReservationSaveControllerTest.php
@@ -37,11 +37,11 @@ class ReservationSaveControllerTest extends TestBase
         $this->presenterFactory->expects($this->once())
                                ->method('Create')
                                ->with($this->equalTo($facade), $this->equalTo($session))
-                               ->will($this->returnValue($presenter));
+                               ->willReturn($presenter);
 
         $presenter->expects($this->once())
                   ->method('BuildReservation')
-                  ->will($this->returnValue($series));
+                  ->willReturn($series);
 
         $presenter->expects($this->once())
                   ->method('HandleReservation')
@@ -70,10 +70,10 @@ class ReservationSaveControllerTest extends TestBase
         $this->presenterFactory->expects($this->once())
                                ->method('Update')
                                ->with($this->equalTo($facade), $this->equalTo($session))
-                               ->will($this->returnValue($presenter));
+                               ->willReturn($presenter);
         $presenter->expects($this->once())
                   ->method('BuildReservation')
-                  ->will($this->returnValue($series));
+                  ->willReturn($series);
 
         $presenter->expects($this->once())
                   ->method('HandleReservation')
@@ -97,7 +97,7 @@ class ReservationSaveControllerTest extends TestBase
         $this->presenterFactory->expects($this->once())
                                ->method('Approve')
                                ->with($this->equalTo($facade), $this->equalTo($session))
-                               ->will($this->returnValue($presenter));
+                               ->willReturn($presenter);
 
         $presenter->expects($this->once())
                   ->method('PageLoad');
@@ -123,11 +123,11 @@ class ReservationSaveControllerTest extends TestBase
         $this->presenterFactory->expects($this->once())
                                ->method('Delete')
                                ->with($this->equalTo($facade), $this->equalTo($session))
-                               ->will($this->returnValue($presenter));
+                               ->willReturn($presenter);
 
         $presenter->expects($this->once())
                   ->method('BuildReservation')
-                  ->will($this->returnValue($reservation));
+                  ->willReturn($reservation);
 
         $presenter->expects($this->once())
                   ->method('HandleReservation')

--- a/tests/WebServices/Controllers/ResourceSaveControllerTest.php
+++ b/tests/WebServices/Controllers/ResourceSaveControllerTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/Controllers/ResourceSaveController.php');
 
-class ResourceSaveControllerTests extends TestBase
+class ResourceSaveControllerTest extends TestBase
 {
     /**
      * @var ResourceSaveController

--- a/tests/WebServices/Controllers/ResourceSaveControllerTest.php
+++ b/tests/WebServices/Controllers/ResourceSaveControllerTest.php
@@ -57,10 +57,15 @@ class ResourceSaveControllerTest extends TestBase
             $request->requiresApproval,
             $request->allowMultiday,
             $request->maxParticipants,
-            $request->minNotice,
+            $request->minNoticeAdd,
             $request->maxNotice,
             $request->description,
-            $request->scheduleId
+            $request->scheduleId,
+            minNoticeDelete: $request->minNoticeDelete,
+            minNoticeUpdate: $request->minNoticeUpdate,
+            bufferTime: $request->bufferTime,
+            groupIds: $request->groupIds,
+            resourceTypeId: $request->typeId
         );
 
         $expectedUpdateResource->SetSortOrder($request->sortOrder);
@@ -75,12 +80,12 @@ class ResourceSaveControllerTest extends TestBase
         $this->validator->expects($this->once())
                 ->method('ValidateCreateRequest')
                 ->with($this->equalTo($request))
-                ->will($this->returnValue([]));
+                ->willReturn([]);
 
         $this->repository->expects($this->once())
                 ->method('Add')
                 ->with($this->equalTo($expectedCreateResource))
-                ->will($this->returnValue($resourceId));
+                ->willReturn($resourceId);
 
         $this->repository->expects($this->once())
                 ->method('Update')
@@ -101,7 +106,7 @@ class ResourceSaveControllerTest extends TestBase
         $this->validator->expects($this->once())
                 ->method('ValidateCreateRequest')
                 ->with($this->anything())
-                ->will($this->returnValue($errors));
+                ->willReturn($errors);
 
         $response = $this->controller->Create($request, $this->session);
 
@@ -126,10 +131,15 @@ class ResourceSaveControllerTest extends TestBase
             $request->requiresApproval,
             $request->allowMultiday,
             $request->maxParticipants,
-            $request->minNotice,
+            $request->minNoticeAdd,
             $request->maxNotice,
             $request->description,
-            $request->scheduleId
+            $request->scheduleId,
+            minNoticeDelete: $request->minNoticeDelete,
+            minNoticeUpdate: $request->minNoticeUpdate,
+            bufferTime: $request->bufferTime,
+            groupIds: $request->groupIds,
+            resourceTypeId: $request->typeId
         );
 
         $expectedUpdateResource->SetSortOrder($request->sortOrder);
@@ -144,11 +154,18 @@ class ResourceSaveControllerTest extends TestBase
         $this->validator->expects($this->once())
                 ->method('ValidateUpdateRequest')
                 ->with($this->equalTo($resourceId), $this->equalTo($request))
-                ->will($this->returnValue([]));
+                ->willReturn([]);
 
         $this->repository->expects($this->once())
                 ->method('Update')
                 ->with($this->equalTo($expectedUpdateResource));
+
+        $this->repository->expects($this->once())
+                ->method('LoadById')
+                ->willReturnMap(
+                [
+                    [$resourceId, $expectedUpdateResource]
+                ]);
 
         $response = $this->controller->Update($resourceId, $request, $this->session);
 
@@ -166,7 +183,7 @@ class ResourceSaveControllerTest extends TestBase
         $this->validator->expects($this->once())
                 ->method('ValidateUpdateRequest')
                 ->with($this->anything(), $this->anything())
-                ->will($this->returnValue($errors));
+                ->willReturn($errors);
 
         $response = $this->controller->Update($resourceId, $request, $this->session);
 
@@ -183,12 +200,12 @@ class ResourceSaveControllerTest extends TestBase
         $this->validator->expects($this->once())
                 ->method('ValidateDeleteRequest')
                 ->with($this->equalTo($resourceId))
-                ->will($this->returnValue([]));
+                ->willReturn([]);
 
         $this->repository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($resourceId))
-                ->will($this->returnValue($resource));
+                ->willReturn($resource);
 
         $this->repository->expects($this->once())
                 ->method('Delete')
@@ -209,7 +226,7 @@ class ResourceSaveControllerTest extends TestBase
         $this->validator->expects($this->once())
                 ->method('ValidateDeleteRequest')
                 ->with($this->equalTo($resourceId))
-                ->will($this->returnValue($errors));
+                ->willReturn($errors);
 
         $response = $this->controller->Delete($resourceId, $this->session);
 

--- a/tests/WebServices/Controllers/UserSaveControllerTest.php
+++ b/tests/WebServices/Controllers/UserSaveControllerTest.php
@@ -46,11 +46,11 @@ class UserSaveControllerTest extends TestBase
         $this->requestValidator->expects($this->once())
                                ->method('ValidateCreateRequest')
                                ->with($this->equalTo($request))
-                               ->will($this->returnValue(null));
+                               ->willReturn(null);
 
         $this->manageUserServiceFactory->expects($this->once())
                                        ->method('CreateAdmin')
-                                       ->will($this->returnValue($this->manageUsersService));
+                                       ->willReturn($this->manageUsersService);
 
         $this->manageUsersService->expects($this->once())
                                  ->method('AddUser')
@@ -69,7 +69,7 @@ class UserSaveControllerTest extends TestBase
                                          $request->customAttributes[0]->attributeValue
                                      )])
                                  )
-                                 ->will($this->returnValue($createdUser));
+                                 ->willReturn($createdUser);
 
         $result = $this->controller->Create($request, $session);
 
@@ -88,7 +88,7 @@ class UserSaveControllerTest extends TestBase
         $this->requestValidator->expects($this->once())
                                ->method('ValidateCreateRequest')
                                ->with($this->equalTo($request))
-                               ->will($this->returnValue($errors));
+                               ->willReturn($errors);
 
         $result = $this->controller->Create($request, $session);
 
@@ -106,11 +106,11 @@ class UserSaveControllerTest extends TestBase
         $this->requestValidator->expects($this->once())
                                ->method('ValidateUpdateRequest')
                                ->with($this->equalTo($userId), $this->equalTo($request))
-                               ->will($this->returnValue(null));
+                               ->willReturn(null);
 
         $this->manageUserServiceFactory->expects($this->once())
                                        ->method('CreateAdmin')
-                                       ->will($this->returnValue($this->manageUsersService));
+                                       ->willReturn($this->manageUsersService);
 
         $this->manageUsersService->expects($this->once())
                                  ->method('UpdateUser')
@@ -127,7 +127,7 @@ class UserSaveControllerTest extends TestBase
                                          $request->customAttributes[0]->attributeValue
                                      )])
                                  )
-                                 ->will($this->returnValue($user));
+                                 ->willReturn($user);
 
 
         $result = $this->controller->Update($userId, $request, $session);
@@ -147,7 +147,7 @@ class UserSaveControllerTest extends TestBase
         $this->requestValidator->expects($this->once())
                                ->method('ValidateUpdateRequest')
                                ->with($this->equalTo(1), $this->equalTo($request))
-                               ->will($this->returnValue($errors));
+                               ->willReturn($errors);
 
         $result = $this->controller->Update(1, $request, $session);
 
@@ -162,7 +162,7 @@ class UserSaveControllerTest extends TestBase
 
         $this->manageUserServiceFactory->expects($this->once())
                                        ->method('CreateAdmin')
-                                       ->will($this->returnValue($this->manageUsersService));
+                                       ->willReturn($this->manageUsersService);
 
         $this->manageUsersService->expects($this->once())
                                  ->method('DeleteUser')
@@ -182,11 +182,11 @@ class UserSaveControllerTest extends TestBase
         $this->requestValidator->expects($this->once())
                                ->method('ValidateUpdatePasswordRequest')
                                ->with($this->equalTo($userId), $this->equalTo($password))
-                               ->will($this->returnValue(null));
+                               ->willReturn(null);
 
         $this->manageUserServiceFactory->expects($this->once())
                                        ->method('CreateAdmin')
-                                       ->will($this->returnValue($this->manageUsersService));
+                                       ->willReturn($this->manageUsersService);
 
         $this->manageUsersService->expects($this->once())
                                  ->method('UpdatePassword')

--- a/tests/WebServices/Controllers/UserSaveControllerTest.php
+++ b/tests/WebServices/Controllers/UserSaveControllerTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/Controllers/UserSaveController.php');
 
-class UserSaveControllerTests extends TestBase
+class UserSaveControllerTest extends TestBase
 {
     /**
      * @var UserSaveController

--- a/tests/WebServices/GroupsWebServiceTest.php
+++ b/tests/WebServices/GroupsWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/GroupsWebService.php');
 
-class GroupsWebServiceTests extends TestBase
+class GroupsWebServiceTest extends TestBase
 {
     /**
      * @var FakeRestServer

--- a/tests/WebServices/GroupsWebServiceTest.php
+++ b/tests/WebServices/GroupsWebServiceTest.php
@@ -47,7 +47,7 @@ class GroupsWebServiceTest extends TestBase
         $this->groupViewRepository->expects($this->once())
                 ->method('GetList')
                 ->with($this->isNull(), $this->isNull())
-                ->will($this->returnValue($groups));
+                ->willReturn($groups);
 
         $this->service->GetGroups();
 
@@ -63,7 +63,7 @@ class GroupsWebServiceTest extends TestBase
         $this->groupRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($groupId))
-                ->will($this->returnValue($group));
+                ->willReturn($group);
 
         $expectedResponse = new GroupResponse($this->server, $group);
 
@@ -78,7 +78,7 @@ class GroupsWebServiceTest extends TestBase
         $this->groupRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($groupId))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $expectedResponse = RestResponse::NotFound();
 

--- a/tests/WebServices/ReservationWriteWebServiceTest.php
+++ b/tests/WebServices/ReservationWriteWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/ReservationWriteWebService.php');
 
-class ReservationWriteWebServiceTests extends TestBase
+class ReservationWriteWebServiceTest extends TestBase
 {
     /**
      * @var ReservationWriteWebService

--- a/tests/WebServices/ReservationWriteWebServiceTest.php
+++ b/tests/WebServices/ReservationWriteWebServiceTest.php
@@ -41,7 +41,7 @@ class ReservationWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($reservationRequest), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Create();
 
@@ -69,7 +69,7 @@ class ReservationWriteWebServiceTest extends TestBase
                     $this->equalTo($referenceNumber),
                     $this->equalTo($updateScope)
                 )
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Update($referenceNumber);
 
@@ -92,7 +92,7 @@ class ReservationWriteWebServiceTest extends TestBase
                     $this->equalTo($this->server->GetSession()),
                     $this->equalTo($referenceNumber)
                 )
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Approve($referenceNumber);
 
@@ -116,7 +116,7 @@ class ReservationWriteWebServiceTest extends TestBase
                     $this->equalTo($referenceNumber),
                     $this->equalTo($updateScope)
                 )
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Delete($referenceNumber);
 
@@ -137,7 +137,7 @@ class ReservationWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($reservationRequest), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Create();
 
@@ -159,7 +159,7 @@ class ReservationWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Update')
                 ->with($this->anything(), $this->anything(), $this->anything(), $this->anything())
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Update($referenceNumber);
 
@@ -182,7 +182,7 @@ class ReservationWriteWebServiceTest extends TestBase
                     $this->equalTo($this->server->GetSession()),
                     $this->equalTo($referenceNumber)
                 )
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Approve($referenceNumber);
 
@@ -201,7 +201,7 @@ class ReservationWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Delete')
                 ->with($this->anything(), $this->anything(), $this->anything())
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Delete($referenceNumber);
 

--- a/tests/WebServices/ReservationsWebServiceTest.php
+++ b/tests/WebServices/ReservationsWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/ReservationsWebService.php');
 
-class ReservationsWebServiceTests extends TestBase
+class ReservationsWebServiceTest extends TestBase
 {
     /**
      * @var FakeRestServer

--- a/tests/WebServices/ReservationsWebServiceTest.php
+++ b/tests/WebServices/ReservationsWebServiceTest.php
@@ -80,7 +80,7 @@ class ReservationsWebServiceTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->equalTo($this->defaultStartDate), $this->equalTo($this->defaultEndDate))
-                ->will($this->returnValue($reservations));
+                ->willReturn($reservations);
 
         $this->service->GetReservations();
 
@@ -99,7 +99,7 @@ class ReservationsWebServiceTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                 ->method('GetReservations')
                 ->with($this->anything(), $this->anything(), $this->equalTo($userId))
-                ->will($this->returnValue([]));
+                ->willReturn([]);
 
         $this->service->GetReservations();
     }
@@ -120,7 +120,7 @@ class ReservationsWebServiceTest extends TestBase
                     $this->isNull(),
                     $this->equalTo($resourceId)
                 )
-                ->will($this->returnValue([]));
+                ->willReturn([]);
 
         $this->service->GetReservations();
     }
@@ -141,7 +141,7 @@ class ReservationsWebServiceTest extends TestBase
                     $this->equalTo($scheduleId),
                     $this->isNull()
                 )
-                ->will($this->returnValue([]));
+                ->willReturn([]);
 
         $this->service->GetReservations();
     }
@@ -158,12 +158,12 @@ class ReservationsWebServiceTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                 ->method('GetReservationForEditing')
                 ->with($this->equalTo($referenceNumber))
-                ->will($this->returnValue($reservation));
+                ->willReturn($reservation);
 
         $this->attributeService->expects($this->once())
                 ->method('GetByCategory')
                 ->with($this->equalTo(CustomAttributeCategory::RESERVATION))
-                ->will($this->returnValue($attributes));
+                ->willReturn($attributes);
 
         $this->service->GetReservation($referenceNumber);
 
@@ -181,7 +181,7 @@ class ReservationsWebServiceTest extends TestBase
         $this->reservationViewRepository->expects($this->once())
                 ->method('GetReservationForEditing')
                 ->with($this->equalTo($referenceNumber))
-                ->will($this->returnValue($reservation));
+                ->willReturn($reservation);
 
         $this->service->GetReservation($referenceNumber);
 

--- a/tests/WebServices/ResourcesWebServiceTest.php
+++ b/tests/WebServices/ResourcesWebServiceTest.php
@@ -52,7 +52,11 @@ class ResourcesWebServiceTest extends TestBase
         $this->repository->expects($this->once())
                          ->method('LoadById')
                          ->with($this->equalTo($resourceId))
-                         ->will($this->returnValue($resource));
+                         ->willReturn($resource);
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceIdList')
+                         ->willReturn([$resourceId]);
 
         $this->attributeService->expects($this->once())
                                ->method('GetAttributes')
@@ -60,7 +64,7 @@ class ResourcesWebServiceTest extends TestBase
                                    $this->equalTo(CustomAttributeCategory::RESOURCE),
                                    $this->equalTo([$resourceId])
                                )
-                               ->will($this->returnValue($attributes));
+                               ->willReturn($attributes);
 
         $this->service->GetResource($resourceId);
 
@@ -73,7 +77,11 @@ class ResourcesWebServiceTest extends TestBase
         $this->repository->expects($this->once())
                          ->method('LoadById')
                          ->with($this->equalTo($resourceId))
-                         ->will($this->returnValue(BookableResource::Null()));
+                         ->willReturn(BookableResource::Null());
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceIdList')
+                         ->willReturn([$resourceId]);
 
         $this->service->GetResource($resourceId);
 
@@ -87,8 +95,8 @@ class ResourcesWebServiceTest extends TestBase
         $attributes = new AttributeList();
 
         $this->repository->expects($this->once())
-                         ->method('GetResourceList')
-                         ->will($this->returnValue($resources));
+                         ->method('GetUserResourceList')
+                         ->willReturn($resources);
 
         $this->attributeService->expects($this->once())
                                ->method('GetAttributes')
@@ -96,7 +104,7 @@ class ResourcesWebServiceTest extends TestBase
                                    $this->equalTo(CustomAttributeCategory::RESOURCE),
                                    $this->equalTo([$resourceId])
                                )
-                               ->will($this->returnValue($attributes));
+                               ->willReturn($attributes);
 
         $this->service->GetAll();
 
@@ -119,7 +127,7 @@ class ResourcesWebServiceTest extends TestBase
 
         $this->repository->expects($this->once())
                          ->method('GetStatusReasons')
-                         ->will($this->returnValue($reasons));
+                         ->willReturn($reasons);
 
         $this->service->GetStatusReasons();
 
@@ -137,8 +145,8 @@ class ResourcesWebServiceTest extends TestBase
         $resources = [new FakeBookableResource($resourceId1), new FakeBookableResource($resourceId2), new FakeBookableResource($resourceId3)];
 
         $this->repository->expects($this->once())
-                         ->method('GetResourceList')
-                         ->will($this->returnValue($resources));
+                         ->method('GetUserResourceList')
+                         ->willReturn($resources);
 
         $conflicting = new TestReservationItemView(1, $startTime, $endTime, $resourceId1);
         $upcoming = new TestReservationItemView(2, $endTime, $endTime->AddHours(3), $resourceId1);
@@ -148,11 +156,10 @@ class ResourcesWebServiceTest extends TestBase
         $upcoming5 = new TestReservationItemView(6, $startTime, $endTime->AddHours(2), $resourceId3);
         $reservations = [$conflicting, $upcoming, $upcoming2, $upcoming3, $upcoming4, $upcoming5];
 
-        $endDate = Date::Now()->AddDays(30);
+        $endDate = Date::Now()->AddDays(7);
         $this->reservationRepository->expects($this->once())
                                     ->method('GetReservations')
-                                    ->with($this->equalTo(Date::Now()), $this->equalTo($endDate))
-                                    ->will($this->returnValue($reservations));
+                                    ->willReturn($reservations);
 
         $this->service->GetAvailability();
 
@@ -173,19 +180,19 @@ class ResourcesWebServiceTest extends TestBase
         $resources = [new FakeBookableResource(1)];
 
         $this->repository->expects($this->once())
-                         ->method('GetResourceList')
-                         ->will($this->returnValue($resources));
+                         ->method('GetUserResourceList')
+                         ->willReturn($resources);
 
         $reservations = [];
 
-        $endDate = $date->AddDays(30);
+        $endDate = $date->AddDays(7);
         $this->reservationRepository->expects($this->once())
                                     ->method('GetReservations')
                                     ->with(
                                         $this->equalTo($date->ToUtc()),
                                         $this->equalTo($endDate->ToUtc())
                                     )
-                                    ->will($this->returnValue($reservations));
+                                    ->willReturn($reservations);
 
         $this->service->GetAvailability();
     }
@@ -194,15 +201,20 @@ class ResourcesWebServiceTest extends TestBase
     {
         $resourceId1 = 1;
         $resource = new FakeBookableResource($resourceId1);
+        $this->server->SetQueryString(WebServiceQueryStringKeys::RESOURCE_ID, $resourceId1);
 
         $this->repository->expects($this->once())
                          ->method('LoadById')
                          ->with($this->equalTo($resourceId1))
-                         ->will($this->returnValue($resource));
+                         ->willReturn($resource);
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceIdList')
+                         ->willReturn([$resourceId1]);
 
         $reservations = [];
 
-        $endDate = Date::Now()->AddDays(30);
+        $endDate = Date::Now()->AddDays(7);
         $this->reservationRepository->expects($this->once())
                                     ->method('GetReservations')
                                     ->with(
@@ -213,7 +225,7 @@ class ResourcesWebServiceTest extends TestBase
                                         $this->isEmpty(),
                                         $this->equalTo($resourceId1)
                                     )
-                                    ->will($this->returnValue($reservations));
+                                    ->willReturn($reservations);
 
         $this->service->GetAvailability($resourceId1);
     }
@@ -224,15 +236,20 @@ class ResourcesWebServiceTest extends TestBase
         $this->server->SetQueryString(WebServiceQueryStringKeys::DATE_TIME, $date->ToIso());
         $resourceId1 = 1;
         $resource = new FakeBookableResource($resourceId1);
+        $this->server->SetQueryString(WebServiceQueryStringKeys::RESOURCE_ID, $resourceId1);
 
         $this->repository->expects($this->once())
                          ->method('LoadById')
                          ->with($this->equalTo($resourceId1))
-                         ->will($this->returnValue($resource));
+                         ->willReturn($resource);
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceIdList')
+                         ->willReturn([$resourceId1]);
 
         $reservations = [];
 
-        $endDate = $date->AddDays(30);
+        $endDate = $date->AddDays(7);
         $this->reservationRepository->expects($this->once())
                                     ->method('GetReservations')
                                     ->with(
@@ -243,7 +260,7 @@ class ResourcesWebServiceTest extends TestBase
                                         $this->isEmpty(),
                                         $this->equalTo($resourceId1)
                                     )
-                                    ->will($this->returnValue($reservations));
+                                    ->willReturn($reservations);
 
         $this->service->GetAvailability($resourceId1);
     }

--- a/tests/WebServices/ResourcesWebServiceTest.php
+++ b/tests/WebServices/ResourcesWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/ResourcesWebService.php');
 
-class ResourcesWebServiceTests extends TestBase
+class ResourcesWebServiceTest extends TestBase
 {
     /**
      * @var FakeRestServer

--- a/tests/WebServices/ResourcesWriteWebServiceTest.php
+++ b/tests/WebServices/ResourcesWriteWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/ResourcesWriteWebService.php');
 
-class ResourcesWriteWebServiceTests extends TestBase
+class ResourcesWriteWebServiceTest extends TestBase
 {
     /**
      * @var ResourcesWriteWebService

--- a/tests/WebServices/ResourcesWriteWebServiceTest.php
+++ b/tests/WebServices/ResourcesWriteWebServiceTest.php
@@ -41,7 +41,7 @@ class ResourcesWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($request), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Create();
 
@@ -59,7 +59,7 @@ class ResourcesWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($request), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Create();
 
@@ -83,7 +83,7 @@ class ResourcesWriteWebServiceTest extends TestBase
                     $this->equalTo($request),
                     $this->equalTo($this->server->GetSession())
                 )
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Update($resourceId);
 
@@ -106,7 +106,7 @@ class ResourcesWriteWebServiceTest extends TestBase
                     $this->equalTo($request),
                     $this->equalTo($this->server->GetSession())
                 )
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Update($resourceId);
 
@@ -123,7 +123,7 @@ class ResourcesWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Delete')
                 ->with($this->equalTo($resourceId), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Delete($resourceId);
 
@@ -140,7 +140,7 @@ class ResourcesWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Delete')
                 ->with($this->equalTo($resourceId), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Delete($resourceId);
 

--- a/tests/WebServices/SchedulesWebServiceTest.php
+++ b/tests/WebServices/SchedulesWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/SchedulesWebService.php');
 
-class SchedulesWebServiceTests extends TestBase
+class SchedulesWebServiceTest extends TestBase
 {
     /**
      * @var SchedulesWebService

--- a/tests/WebServices/SchedulesWebServiceTest.php
+++ b/tests/WebServices/SchedulesWebServiceTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use function PHPSTORM_META\map;
+use function PHPUnit\Framework\matches;
+
 require_once(ROOT_DIR . 'WebServices/SchedulesWebService.php');
 
 class SchedulesWebServiceTest extends TestBase
@@ -41,7 +44,7 @@ class SchedulesWebServiceTest extends TestBase
 
         $this->scheduleRepository->expects($this->once())
                 ->method('GetAll')
-                ->will($this->returnValue($schedules));
+                ->willReturn($schedules);
 
         $this->service->GetSchedules();
 
@@ -59,12 +62,12 @@ class SchedulesWebServiceTest extends TestBase
         $layout->expects($this->any())
                 ->method('GetLayout')
                 ->with($this->anything())
-                ->will($this->returnValue([]));
+                ->willReturn([]);
 
         $this->scheduleRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($scheduleId))
-                ->will($this->returnValue($schedule));
+                ->willReturn($schedule);
 
         $this->scheduleRepository->expects($this->once())
                 ->method('GetLayout')
@@ -72,7 +75,7 @@ class SchedulesWebServiceTest extends TestBase
                     $this->equalTo($scheduleId),
                     $this->equalTo(new ScheduleLayoutFactory($this->server->GetSession()->Timezone))
                 )
-                ->will($this->returnValue($layout));
+                ->willReturn($layout);
 
         $this->service->GetSchedule($scheduleId);
 
@@ -86,7 +89,7 @@ class SchedulesWebServiceTest extends TestBase
         $this->scheduleRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($scheduleId))
-                ->will($this->returnValue(null));
+                ->willReturn(null);
 
         $this->service->GetSchedule($scheduleId);
 
@@ -115,34 +118,24 @@ class SchedulesWebServiceTest extends TestBase
         $periods6 = [new SchedulePeriod($date6, $date6)];
         $periods7 = [new SchedulePeriod($date7, $date7)];
 
-        $layout->expects($this->at(0))
+        $matcher = $this->exactly(7);
+        $layout->expects($matcher)
                 ->method('GetLayout')
-                ->with($this->equalTo($date1))
-                ->will($this->returnValue($periods1));
-        $layout->expects($this->at(1))
-                ->method('GetLayout')
-                ->with($this->equalTo($date2))
-                ->will($this->returnValue($periods2));
-        $layout->expects($this->at(2))
-                ->method('GetLayout')
-                ->with($this->equalTo($date3))
-                ->will($this->returnValue($periods3));
-        $layout->expects($this->at(3))
-                ->method('GetLayout')
-                ->with($this->equalTo($date4))
-                ->will($this->returnValue($periods4));
-        $layout->expects($this->at(4))
-                ->method('GetLayout')
-                ->with($this->equalTo($date5))
-                ->will($this->returnValue($periods5));
-        $layout->expects($this->at(5))
-                ->method('GetLayout')
-                ->with($this->equalTo($date6))
-                ->will($this->returnValue($periods6));
-        $layout->expects($this->at(6))
-                ->method('GetLayout')
-                ->with($this->equalTo($date7))
-                ->will($this->returnValue($periods7));
+                ->willReturnCallback(function($date) use (
+                        $periods1, $periods2, $periods3, $periods4, $periods5,
+                        $periods6, $periods7,
+                        $date1, $date2, $date3, $date4, $date5, $date6, $date7) {
+                    return match (true) {
+                        $this->equalTo($date1)->evaluate($date, returnResult: true) => $periods1,
+                        $this->equalTo($date2)->evaluate($date, returnResult: true) => $periods2,
+                        $this->equalTo($date3)->evaluate($date, returnResult: true) => $periods3,
+                        $this->equalTo($date4)->evaluate($date, returnResult: true) => $periods4,
+                        $this->equalTo($date5)->evaluate($date, returnResult: true) => $periods5,
+                        $this->equalTo($date6)->evaluate($date, returnResult: true) => $periods6,
+                        $this->equalTo($date7)->evaluate($date, returnResult: true) => $periods7,
+                        default => throw new Exception('Unexpected date')
+                    };
+                });
 
         $response = new ScheduleResponse($this->server, $schedule, $layout);
 

--- a/tests/WebServices/UsersWebServiceTest.php
+++ b/tests/WebServices/UsersWebServiceTest.php
@@ -66,17 +66,17 @@ class UsersWebServiceTest extends TestBase
         $this->userRepositoryFactory->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($this->userRepository));
+                ->willReturn($this->userRepository);
 
         $this->userRepository->expects($this->once())
                 ->method('GetList')
                 ->with($this->isNull(), $this->isNull(), $this->isNull(), $this->isNull(), $expectedFilter->GetFilter(), AccountStatus::ACTIVE)
-                ->will($this->returnValue($users));
+                ->willReturn($users);
 
         $this->attributeService->expects($this->once())
                 ->method('GetByCategory')
                 ->with($this->equalTo(CustomAttributeCategory::USER))
-                ->will($this->returnValue($attributes));
+                ->willReturn($attributes);
 
         $expectedResponse = new UsersResponse($this->server, $userList, [1=>'fakeCustomAttribute1', 2=>'fakeCustomAttribute2']);
 
@@ -101,22 +101,20 @@ class UsersWebServiceTest extends TestBase
         $this->userRepositoryFactory->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($this->userRepository));
+                ->willReturn($this->userRepository);
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(2))
                 ->method('LoadById')
-                ->with($this->equalTo($userId))
-                ->will($this->returnValue($user));
-
-        $this->userRepository->expects($this->at(1))
-                ->method('LoadById')
-                ->with($this->equalTo($sessionUserId))
-                ->will($this->returnValue($me));
+                ->willReturnMap(
+                [
+                    [$userId, $user],
+                    [$sessionUserId, $me]
+                ]);
 
         $this->attributeService->expects($this->once())
                 ->method('GetAttributes')
                 ->with($this->equalTo(CustomAttributeCategory::USER), $this->equalTo([$userId]))
-                ->will($this->returnValue($attributes));
+                ->willReturn($attributes);
 
         $expectedResponse = new UserResponse($this->server, $user, $attributes);
 
@@ -137,17 +135,17 @@ class UsersWebServiceTest extends TestBase
         $this->userRepositoryFactory->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($this->userRepository));
+                ->willReturn($this->userRepository);
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($userId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $this->attributeService->expects($this->once())
                 ->method('GetAttributes')
                 ->with($this->equalTo(CustomAttributeCategory::USER), $this->equalTo([$userId]))
-                ->will($this->returnValue($attributes));
+                ->willReturn($attributes);
 
         $expectedResponse = new UserResponse($this->server, $user, $attributes);
 
@@ -164,12 +162,12 @@ class UsersWebServiceTest extends TestBase
         $this->userRepositoryFactory->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($this->userRepository));
+                ->willReturn($this->userRepository);
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($userId))
-                ->will($this->returnValue(User::Null()));
+                ->willReturn(User::Null());
 
         $expectedResponse = RestResponse::NotFound();
 
@@ -194,22 +192,20 @@ class UsersWebServiceTest extends TestBase
         $this->userRepositoryFactory->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($this->userRepository));
+                ->willReturn($this->userRepository);
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(2))
                 ->method('LoadById')
-                ->with($this->equalTo($userId))
-                ->will($this->returnValue($user));
-
-        $this->userRepository->expects($this->at(1))
-                ->method('LoadById')
-                ->with($this->equalTo($sessionUserId))
-                ->will($this->returnValue($me));
+                ->willReturnMap(
+                [
+                    [$userId, $user],
+                    [$sessionUserId, $me]
+                ]);
 
         $this->attributeService->expects($this->once())
                 ->method('GetAttributes')
                 ->with($this->equalTo(CustomAttributeCategory::USER), $this->equalTo([$userId]))
-                ->will($this->returnValue($attributes));
+                ->willReturn($attributes);
 
         $this->service->GetUser($userId);
 
@@ -229,17 +225,17 @@ class UsersWebServiceTest extends TestBase
         $this->userRepositoryFactory->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($this->userRepository));
+                ->willReturn($this->userRepository);
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->once())
                 ->method('LoadById')
                 ->with($this->equalTo($userId))
-                ->will($this->returnValue($user));
+                ->willReturn($user);
 
         $this->attributeService->expects($this->once())
                 ->method('GetAttributes')
                 ->with($this->equalTo(CustomAttributeCategory::USER), $this->equalTo([$userId]))
-                ->will($this->returnValue($attributes));
+                ->willReturn($attributes);
 
         $expectedResponse = new UserResponse($this->server, $user, $attributes);
 

--- a/tests/WebServices/UsersWebServiceTest.php
+++ b/tests/WebServices/UsersWebServiceTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/UsersWebService.php');
 
-class UsersWebServiceTests extends TestBase
+class UsersWebServiceTest extends TestBase
 {
     /**
      * @var FakeRestServer

--- a/tests/WebServices/UsersWriteWebServiceTest.php
+++ b/tests/WebServices/UsersWriteWebServiceTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 require_once(ROOT_DIR . 'WebServices/UsersWriteWebService.php');
 
-class UsersWriteWebServiceTests extends TestBase
+class UsersWriteWebServiceTest extends TestBase
 {
     /**
      * @var UsersWriteWebService

--- a/tests/WebServices/UsersWriteWebServiceTest.php
+++ b/tests/WebServices/UsersWriteWebServiceTest.php
@@ -43,7 +43,7 @@ class UsersWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($userRequest), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Create();
 
@@ -61,7 +61,7 @@ class UsersWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Create')
                 ->with($this->equalTo($userRequest), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Create();
 
@@ -85,7 +85,7 @@ class UsersWriteWebServiceTest extends TestBase
                     $this->equalTo($userRequest),
                     $this->equalTo($this->server->GetSession())
                 )
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Update($userId);
 
@@ -108,7 +108,7 @@ class UsersWriteWebServiceTest extends TestBase
                     $this->equalTo($userRequest),
                     $this->equalTo($this->server->GetSession())
                 )
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Update($userId);
 
@@ -125,7 +125,7 @@ class UsersWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Delete')
                 ->with($this->equalTo($userId), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Delete($userId);
 
@@ -142,7 +142,7 @@ class UsersWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('Delete')
                 ->with($this->equalTo($userId), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->Delete($userId);
 
@@ -163,7 +163,7 @@ class UsersWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
                 ->method('UpdatePassword')
                 ->with($this->equalTo($userId), $this->equalTo($password), $this->equalTo($this->server->GetSession()))
-                ->will($this->returnValue($controllerResult));
+                ->willReturn($controllerResult);
 
         $this->service->UpdatePassword($userId);
 
@@ -184,7 +184,7 @@ class UsersWriteWebServiceTest extends TestBase
         $this->controller->expects($this->once())
             ->method('UpdatePassword')
             ->with($this->equalTo($userId), $this->equalTo($password), $this->equalTo($this->server->GetSession()))
-            ->will($this->returnValue($controllerResult));
+            ->willReturn($controllerResult);
 
         $this->service->UpdatePassword($userId);
 

--- a/tests/WebServices/Validators/AccountRequestValidatorTest.php
+++ b/tests/WebServices/Validators/AccountRequestValidatorTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/Validators/AccountRequestValidator.php');
 
-class AccountRequestValidatorTests extends TestBase
+class AccountRequestValidatorTest extends TestBase
 {
     /**
      * @var FakeAttributeService

--- a/tests/WebServices/Validators/ResourceRequestValidatorTest.php
+++ b/tests/WebServices/Validators/ResourceRequestValidatorTest.php
@@ -59,7 +59,7 @@ class ResourceRequestValidatorTest extends TestBase
                     $this->equalTo(CustomAttributeCategory::RESOURCE),
                     $this->equalTo([new AttributeValue($request->customAttributes[0]->attributeId, $request->customAttributes[0]->attributeValue)])
                 )
-                ->will($this->returnValue($result));
+                ->willReturn($result);
 
         $createErrors = $this->validator->ValidateCreateRequest($request);
         $updateErrors = $this->validator->ValidateUpdateRequest(1, $request);

--- a/tests/WebServices/Validators/ResourceRequestValidatorTest.php
+++ b/tests/WebServices/Validators/ResourceRequestValidatorTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/Validators/ResourceRequestValidator.php');
 
-class ResourceRequestValidatorTests extends TestBase
+class ResourceRequestValidatorTest extends TestBase
 {
     /**
      * @var ResourceRequestValidator

--- a/tests/WebServices/Validators/UserRequestValidatorTest.php
+++ b/tests/WebServices/Validators/UserRequestValidatorTest.php
@@ -2,7 +2,7 @@
 
 require_once(ROOT_DIR . 'WebServices/Validators/UserRequestValidator.php');
 
-class UserRequestValidatorTests extends TestBase
+class UserRequestValidatorTest extends TestBase
 {
     /**
      * @var IAttributeService

--- a/tests/WebServices/Validators/UserRequestValidatorTest.php
+++ b/tests/WebServices/Validators/UserRequestValidatorTest.php
@@ -59,32 +59,21 @@ class UserRequestValidatorTest extends TestBase
         $this->assertTrue(count($errors) == 1);
     }
 
-    public function testCreateValidatesExistingEmail()
+    public function testCreateValidatesExistingEmailAndUsername()
     {
         $this->expectsAttributeValidator();
         $request = CreateUserRequest::Example();
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(2))
                 ->method('UserExists')
-                ->with($this->equalTo($request->emailAddress), $this->isNull())
-                ->will($this->returnValue(1));
+                ->willReturnMap(
+                [
+                    [$request->emailAddress, null, 1],
+                    [null, $request->userName, 1]
+                ]);
 
         $errors = $this->validator->ValidateCreateRequest($request);
-        $this->assertTrue(count($errors) == 1);
-    }
-
-    public function testCreateValidatesExistingUsername()
-    {
-        $this->expectsAttributeValidator();
-        $request = CreateUserRequest::Example();
-
-        $this->userRepository->expects($this->at(1))
-                ->method('UserExists')
-                ->with($this->isNull(), $this->equalTo($request->userName))
-                ->will($this->returnValue(1));
-
-        $errors = $this->validator->ValidateCreateRequest($request);
-        $this->assertTrue(count($errors) == 1);
+        $this->assertTrue(count($errors) == 2);
     }
 
     public function testCreateValidatesAttributes()
@@ -97,7 +86,7 @@ class UserRequestValidatorTest extends TestBase
                     $this->equalTo(CustomAttributeCategory::USER),
                     $this->equalTo([new AttributeValue($request->customAttributes[0]->attributeId, $request->customAttributes[0]->attributeValue)])
                 )
-                ->will($this->returnValue($result));
+                ->willReturn($result);
 
         $errors = $this->validator->ValidateCreateRequest($request);
         $this->assertTrue(count($errors) == 1);
@@ -136,10 +125,13 @@ class UserRequestValidatorTest extends TestBase
         $this->expectsAttributeValidator();
         $request = UpdateUserRequest::Example();
 
-        $this->userRepository->expects($this->at(0))
+        $this->userRepository->expects($this->exactly(2))
                 ->method('UserExists')
-                ->with($this->equalTo($request->emailAddress), $this->isNull())
-                ->will($this->returnValue(2));
+                ->willReturnMap(
+                [
+                    [$request->emailAddress, null, 2],
+                    [null, $request->userName, 1]
+                ]);
 
         $errors = $this->validator->ValidateUpdateRequest(1, $request);
         $this->assertTrue(count($errors) == 1);
@@ -150,10 +142,13 @@ class UserRequestValidatorTest extends TestBase
         $this->expectsAttributeValidator();
         $request = UpdateUserRequest::Example();
 
-        $this->userRepository->expects($this->at(1))
+        $this->userRepository->expects($this->exactly(2))
                 ->method('UserExists')
-                ->with($this->isNull(), $this->equalTo($request->userName))
-                ->will($this->returnValue(2));
+                ->willReturnMap(
+                    [
+                        [$request->emailAddress, null, 1],
+                        [null, $request->userName, 2]
+                    ]);
 
         $errors = $this->validator->ValidateUpdateRequest(1, $request);
         $this->assertTrue(count($errors) == 1);
@@ -169,7 +164,7 @@ class UserRequestValidatorTest extends TestBase
                     $this->equalTo(CustomAttributeCategory::USER),
                     $this->equalTo([new AttributeValue($request->customAttributes[0]->attributeId, $request->customAttributes[0]->attributeValue)])
                 )
-                ->will($this->returnValue($result));
+                ->willReturn($result);
 
         $errors = $this->validator->ValidateUpdateRequest(1, $request);
         $this->assertTrue(count($errors) == 1);
@@ -180,6 +175,6 @@ class UserRequestValidatorTest extends TestBase
         $this->attributeService->expects($this->any())
                 ->method('Validate')
                 ->with($this->anything(), $this->anything())
-                ->will($this->returnValue(new AttributeServiceValidationResult(true, null)));
+                ->willReturn(new AttributeServiceValidationResult(true, null));
     }
 }

--- a/tests/fakes/FakeExistingReservationPage.php
+++ b/tests/fakes/FakeExistingReservationPage.php
@@ -8,6 +8,8 @@ class FakeExistingReservationPage extends FakePageBase implements IExistingReser
     public $_CheckOutRequired = false;
     public $_AutoReleaseMinutes = null;
 
+    public function BindViewableResourceReservations($resourceIds) { }
+
     public function GetReferenceNumber()
     {
     }

--- a/tests/fakes/FakePaymentRepository.php
+++ b/tests/fakes/FakePaymentRepository.php
@@ -48,7 +48,11 @@ class FakePaymentRepository implements IPaymentRepository
         $this->_CreditCost = new CreditCost();
     }
 
-    public function UpdateCreditCost(CreditCost $cost)
+    public function DeleteCreditCost($creditCount) { }
+
+    public function GetCreditCosts() { }
+
+    public function UpdateCreditCost($cost)
     {
         $this->_LastCost = $cost;
     }

--- a/tests/fakes/FakePaymentRepository.php
+++ b/tests/fakes/FakePaymentRepository.php
@@ -45,12 +45,15 @@ class FakePaymentRepository implements IPaymentRepository
     {
         $this->_PayPal = new FakePayPalGateway();
         $this->_Stripe = new FakeStripeGateway();
-        $this->_CreditCost = new CreditCost();
+        $this->_CreditCost = [new CreditCost()];
     }
 
     public function DeleteCreditCost($creditCount) { }
 
-    public function GetCreditCosts() { }
+    public function GetCreditCosts()
+    {
+        return $this->_CreditCost;
+    }
 
     public function UpdateCreditCost($cost)
     {

--- a/tests/fakes/FakeReservationViewRepository.php
+++ b/tests/fakes/FakeReservationViewRepository.php
@@ -51,6 +51,10 @@ class FakeReservationViewRepository implements IReservationViewRepository
         $this->_FilterResults = new PageableData();
     }
 
+    public function GetReservationsPendingApproval(Date $startDate, $userIds = ReservationViewRepository::ALL_USERS, $userLevel = ReservationUserLevel::OWNER, $scheduleIds = ReservationViewRepository::ALL_SCHEDULES, $resourceIds = ReservationViewRepository::ALL_RESOURCES, $consolidateByReferenceNumber = false, $participantIds = ReservationViewRepository::ALL_USERS) { }
+
+    public function GetReservationsMissingCheckInCheckOut(?Date $startDate = null, Date $endDate, $userIds = ReservationViewRepository::ALL_USERS, $userLevel = ReservationUserLevel::OWNER, $scheduleIds = ReservationViewRepository::ALL_SCHEDULES, $resourceIds = ReservationViewRepository::ALL_RESOURCES, $consolidateByReferenceNumber = false, $participantIds = ReservationViewRepository::ALL_USERS) { }
+
     public function GetReservationForEditing($referenceNumber)
     {
         return $this->_ReservationView;

--- a/tests/fakes/FakeResourceAccess.php
+++ b/tests/fakes/FakeResourceAccess.php
@@ -30,7 +30,7 @@ class FakeResourceAccess extends ResourceRepository
 
     private function FillRows()
     {
-        $rows = $this->GetRows();
+        $rows = $this->BuildRows();
         foreach ($rows as $row) {
             $this->_Resources[] = BookableResource::Create($row);
         }
@@ -115,7 +115,7 @@ class FakeResourceAccess extends ResourceRepository
         return $this;
     }
 
-    public function GetRows()
+    private function BuildRows()
     {
         $this->With(
             1,

--- a/tests/fakes/FakeResourceRepository.php
+++ b/tests/fakes/FakeResourceRepository.php
@@ -27,6 +27,25 @@ class FakeResourceRepository implements IResourceRepository
 
     public $_PublicResourceIds = [];
 
+    public function GetResourceIdList(): array
+    {
+         throw new Exception('Not implemented');
+    }
+
+    public function GetUserResourceList() { }
+
+    public function GetUserResourceIdList() { }
+
+    public function GetUserList($resourceIds, $pageNumber, $pageSize, $sortField = null, $sortDirection = null, $filter = null) { }
+
+    public function GetUserResourcePermissions($userId, $resourceIds = []) { }
+
+    public function GetUserGroupResourcePermissions($userId, $resourceIds = []) { }
+
+    public function GetResourceAdminResourceIds($userId, $resourceIds = []) { }
+
+    public function GetScheduleAdminResourceIds($userId, $resourceIds = []) { }
+
     public function GetScheduleResources($scheduleId)
     {
         return $this->_ScheduleResourceList;

--- a/tests/fakes/FakeWebAuthentication.php
+++ b/tests/fakes/FakeWebAuthentication.php
@@ -168,6 +168,8 @@ class FakeWebAuthentication implements IWebAuthentication
     public $_IsLoggedIn = false;
     public $_AreCredentialsKnown = false;
 
+    public function postLogout(UserSession $user) { }
+
     public function Validate($username, $password)
     {
         $this->_LastLogin = $username;


### PR DESCRIPTION
The unit tests seem to be broken for quite a long time. This makes it difficult to contribute to the project without breaking something essential.

So this PR is focused on fixing the phpunit tests. It covers the following changes.

- Add phpunit 11 to composer
- Fix the most obvious deprecation warnings
- Fix the tests and adapt them to phpunit 11
- Add some missing implementations and interface definitions
- Run tests in github workflow

I also adapted the script part in the composer.json. However without the .phive environment the `lint` call will fail because of the missing tools directory.

Actually I'd suggest to get rid of the .phive stuff.