### PR TITLE
Replace use of deprecated ldap_connect function with supported one

### DIFF
--- a/plugins/Authentication/ActiveDirectory/adLDAP.php
+++ b/plugins/Authentication/ActiveDirectory/adLDAP.php
@@ -654,9 +654,9 @@ class adLDAP
         // Connect to the AD/LDAP server as the username/password
         $domainController = $this->randomController();
         if ($this->useSSL) {
-            $this->ldapConnection = ldap_connect("ldaps://" . $domainController, $this->adPort);
+            $this->ldapConnection = ldap_connect("ldaps://" . $domainController . ":" . $this->adPort);
         } else {
-            $this->ldapConnection = ldap_connect($domainController, $this->adPort);
+            $this->ldapConnection = ldap_connect("ldap://" . $domainController . ":" . $this->adPort);
         }
 
         // Set some ldap options for talking to AD

--- a/plugins/Authentication/Ldap/LDAP2.php
+++ b/plugins/Authentication/Ldap/LDAP2.php
@@ -433,7 +433,7 @@ class Net_LDAP2 extends PEAR
             $this->_config['host'] = $host;
 
             // Attempt a connection.
-            $this->_link = @ldap_connect($host, $this->_config['port']);
+            $this->_link = @ldap_connect($host . ":" . $this->_config['port']);
             if (false === $this->_link) {
                 $current_error = PEAR::raiseError('Could not connect to ' .
                     $host . ':' . $this->_config['port']);


### PR DESCRIPTION
Fixes #421 

I replaced all uses of the deprecated function:

```php
ldap_connect(?string $host = null, int $port = 389)
```
with the non-deprecated equivalent function:

```php
ldap_connect(?string $uri = null)
```
