### PR TITLE
Refactor Email system to builder pattern

### DIFF
--- a/lib/Email/EmailBuilder.php
+++ b/lib/Email/EmailBuilder.php
@@ -1,0 +1,146 @@
+<?php
+
+class EmailBuilder
+{
+    private array $subjectTranslationParams;
+    private string $languageCode;
+    private string $template;
+    private array $smartyValues = [];
+    private EmailAddress $from;
+    /**
+     * 
+     * @var EmailAddress[]
+     */
+    private array $to = [];
+    /**
+     * 
+     * @var EmailAddress[]
+     */
+    private array $cc = [];
+    /**
+     * 
+     * @var EmailAddress[]
+     */
+    private array $bcc = [];
+    /**
+     * 
+     * @var StringAttachment[]
+     */
+    private array $attachments = [];
+
+    /**
+     * 
+     * @param string[] $args 
+     * @return EmailBuilder 
+     */
+    public function SubjectTranslation(string $key, array $args = []): EmailBuilder
+    {
+        $this->subjectTranslationParams = 
+        [
+            'key' => $key, 
+            'args' => implode(',', $args)
+        ];
+        return $this;
+    }
+
+    public function LanguageCode(string $languageCode): EmailBuilder
+    {
+        $this->languageCode = $languageCode;
+        return $this;
+    }
+
+    public function Template(string $template): EmailBuilder
+    {
+        $this->template = $template;
+        return $this;
+    }
+
+    public function FromAddress(EmailAddress $from): EmailBuilder
+    {
+        $this->from = $from;
+        return $this;
+    }
+
+    public function From(string $email, string $name): EmailBuilder
+    {
+        return $this->FromAddress(new EmailAddress($email, $name));
+    }    
+    
+    public function AddToAddress(EmailAddress $to): EmailBuilder
+    {
+        $this->to[] = $to;
+        return $this;
+    }
+
+    public function AddTo(string $email, string $name): EmailBuilder
+    {
+        return $this->AddToAddress(new EmailAddress($email, $name));
+    }
+
+    public function AddCC(EmailAddress $cc): EmailBuilder
+    {
+        $this->cc[] = $cc;
+        return $this;
+    }
+
+    public function AddBCC(EmailAddress $bcc): EmailBuilder
+    {
+        $this->bcc[] = $bcc;
+        return $this;
+    }
+
+    public function AddStringAttachment(string $filename, string $contents): EmailBuilder
+    {
+        $this->attachments[] = new StringAttachment($filename, $contents);
+        return $this;
+    }
+
+    public function Set($var, $value): EmailBuilder
+    {
+        $this->smartyValues[] = [$var, $value];
+        return $this;
+    }
+
+    public function Build(): RenderedMessage
+    {
+        $enforceCustomTemplate = Configuration::Instance()->GetKey(ConfigKeys::ENFORCE_CUSTOM_MAIL_TEMPLATE, new BooleanConverter());
+        $email = new SmartyPage($resources);
+        $languageCode = $this->languageCode;
+        if (!empty($languageCode)) {
+            $resources->SetLanguage($languageCode);
+            $email->assign('CurrentLanguage', $languageCode);
+        }
+
+        $email->assign('ScriptUrl', Configuration::Instance()->GetScriptUrl());
+        $email->assign('Charset', $resources->Charset);
+        $email->assign('AppTitle', (empty($appTitle) ? 'LibreBooking' : $appTitle));
+
+        // ^^ copied
+
+        foreach($this->smartyValues as $pair)
+            $email->assign($pair[0], $pair[1]);
+
+        $header = $email->fetch('Email/emailheader.tpl');
+        $body = $email->FetchLocalized($this->template, $enforceCustomTemplate);
+        $footer = $email->fetch('Email/emailfooter.tpl');
+
+        $subject = $email->SmartyTranslate($this->subjectTranslationParams, $email);
+        
+        $from = $this->from ?? new EmailAddress(Configuration::Instance()->GetAdminEmail(), Configuration::Instance()->GetKey(ConfigKeys::ADMIN_EMAIL_NAME));
+        $replyTo = $from;
+
+        $charset = $resources->Charset;
+
+        return new RenderedMessage(
+            $charset,
+            $subject,
+            $from,
+            $replyTo,
+            $this->to,
+            $this->cc,
+            $this->bcc,
+            $header . $body . $footer,
+            $this->attachments
+        );
+    }
+}

--- a/lib/Email/Messages/AccountActivationEmail.php
+++ b/lib/Email/Messages/AccountActivationEmail.php
@@ -2,54 +2,22 @@
 
 require_once(ROOT_DIR . 'lib/Email/namespace.php');
 
-class AccountActivationEmail extends EmailMessage
+class AccountActivationEmail
 {
-    /**
-     * @var User
-     */
-    private $user;
-
-    /**
-     * @var string
-     */
-    private $activationCode;
-
-    public function __construct(User $user, $activationCode)
-    {
-        $this->user = $user;
-        $this->activationCode = $activationCode;
-        parent::__construct($user->Language());
-    }
-
-    /**
-     * @return array|EmailAddress[]|EmailAddress
-     */
-    public function To()
-    {
-        return new EmailAddress($this->user->EmailAddress(), $this->user->FullName());
-    }
-
-    /**
-     * @return string
-     */
-    public function Subject()
-    {
-        return $this->Translate('ActivateYourAccount');
-    }
-
-    /**
-     * @return string
-     */
-    public function Body()
+    public static function BuilderFor(User $user, $activationCode): EmailBuilder
     {
         $activationUrl = new Url(Configuration::Instance()->GetScriptUrl());
         $activationUrl
                 ->Add(Pages::ACTIVATION)
-                ->AddQueryString(QueryStringKeys::ACCOUNT_ACTIVATION_CODE, $this->activationCode);
+                ->AddQueryString(QueryStringKeys::ACCOUNT_ACTIVATION_CODE, $activationCode);
 
-        $this->Set('FirstName', $this->user->FirstName());
-        $this->Set('EmailAddress', $this->user->EmailAddress());
-        $this->Set('ActivationUrl', $activationUrl);
-        return $this->FetchTemplate('AccountActivation.tpl');
+        return (new EmailBuilder)
+            ->SubjectTranslation('ActivateYourAccount')
+            ->AddTo($user->EmailAddress(), $user->FullName())
+            ->Template('AccountActivation.tpl')
+            ->LanguageCode($user->Language())
+            ->Set('FirstName', $user->FirstName())
+            ->Set('EmailAddress', $user->EmailAddress())
+            ->Set('ActivationUrl', $activationUrl);    
     }
 }

--- a/lib/Email/Messages/AccountCreationEmail.php
+++ b/lib/Email/Messages/AccountCreationEmail.php
@@ -3,65 +3,35 @@
 require_once(ROOT_DIR . 'lib/Email/namespace.php');
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class AccountCreationEmail extends EmailMessage
+class AccountCreationEmail
 {
-    /**
-     * @var User
-     */
-    private $user;
-
-    /**
-     * @var null|UserSession
-     */
-    private $userSession;
-
-    public function __construct(User $user, $userSession = null)
+    public static function AccountCreationEmail(User $user, $userSession = null): EmailBuilder
     {
-        $this->user = $user;
-        $this->userSession = $userSession;
-        parent::__construct(Configuration::Instance()->GetKey(ConfigKeys::LANGUAGE));
-    }
-
-    /**
-     * @return array|EmailAddress[]|EmailAddress
-     */
-    public function To()
-    {
+        $builder = new EmailBuilder;
         $userRepo = new UserRepository();
         $admins = $userRepo->GetApplicationAdmins();
-        $emails = [];
         foreach ($admins as $admin) {
-            $emails[] = new EmailAddress($admin->EmailAddress, $admin->FullName);
+            $builder->AddTo($admin->EmailAddress, $admin->FullName);
         }
-        return $emails;
-    }
+        
+        $builder
+            ->SubjectTranslation('UserAdded')
+            ->Template('AccountCreation.tpl')
+            ->LanguageCode(Configuration::Instance()->GetKey(ConfigKeys::LANGUAGE))
+            ->Set('To', Configuration::Instance()->GetKey(ConfigKeys::ADMIN_EMAIL_NAME) 
+                ? Configuration::Instance()->GetKey(ConfigKeys::ADMIN_EMAIL_NAME) 
+                : 'Administrator')
+            ->Set('FullName', $user->FullName())
+            ->Set('EmailAddress', $user->EmailAddress())
+            ->Set('Phone', $user->GetAttribute(UserAttribute::Phone))
+            ->Set('Organization', $user->GetAttribute(UserAttribute::Organization))
+            ->Set('Position', $user->GetAttribute(UserAttribute::Position))
+            ->Set('CreatedBy', '');
 
-    /**
-     * @return string
-     */
-    public function Subject()
-    {
-        return $this->Translate('UserAdded');
-    }
-
-    /**
-     * @return string
-     */
-    public function Body()
-    {
-        $this->Set('To', Configuration::Instance()->GetKey(ConfigKeys::ADMIN_EMAIL_NAME) ? Configuration::Instance()
-                                                                                                        ->GetKey(ConfigKeys::ADMIN_EMAIL_NAME) : 'Administrator');
-        $this->Set('FullName', $this->user->FullName());
-        $this->Set('EmailAddress', $this->user->EmailAddress());
-        $this->Set('Phone', $this->user->GetAttribute(UserAttribute::Phone));
-        $this->Set('Organization', $this->user->GetAttribute(UserAttribute::Organization));
-        $this->Set('Position', $this->user->GetAttribute(UserAttribute::Position));
-
-        $this->Set('CreatedBy', '');
-        if ($this->userSession != null && $this->userSession->UserId != $this->user->Id()) {
-            $this->Set('CreatedBy', new FullName($this->userSession->FirstName, $this->userSession->LastName));
+        if ($userSession != null && $userSession->UserId != $user->Id()) {
+            $builder->Set('CreatedBy', new FullName($userSession->FirstName, $userSession->LastName));
         }
 
-        return $this->FetchTemplate('AccountCreation.tpl');
+        return $builder;
     }
 }

--- a/lib/Email/Messages/AccountDeletedEmail.php
+++ b/lib/Email/Messages/AccountDeletedEmail.php
@@ -2,53 +2,19 @@
 
 require_once(ROOT_DIR . 'lib/Email/namespace.php');
 
-class AccountDeletedEmail extends EmailMessage
+class AccountDeletedEmail
 {
-    /**
-     * @var User
-     */
-    private $deletedUser;
-    /**
-     * @var UserDto
-     */
-    private $to;
-    /**
-     * @var UserSession
-     */
-    private $userSession;
-
-    public function __construct(User $deletedUser, UserDto $to, UserSession $userSession)
+    public static function BuilderFor(User $deletedUser, UserDto $to, UserSession $userSession): EmailBuilder
     {
-        parent::__construct($to->LanguageCode);
-
-        $this->deletedUser = $deletedUser;
-        $this->to = $to;
-        $this->userSession = $userSession;
-    }
-
-    /**
-     * @return array|EmailAddress[]|EmailAddress
-     */
-    public function To()
-    {
-        return new EmailAddress($this->to->EmailAddress(), $this->to->FullName());
-    }
-
-    /**
-     * @return string
-     */
-    public function Subject()
-    {
-        return $this->Translate('UserDeleted', [$this->deletedUser->FullName(), new FullName($this->userSession->FirstName, $this->userSession->LastName)]);
-    }
-
-    /**
-     * @return string
-     */
-    public function Body()
-    {
-        $this->Set('UserFullName', $this->deletedUser->FullName());
-        $this->Set('AdminFullName', new FullName($this->userSession->FirstName, $this->userSession->LastName));
-        return $this->FetchTemplate('AccountDeleted.tpl');
+        return (new EmailBuilder)
+            ->SubjectTranslation('UserDeleted', [
+                $deletedUser->FullName(), 
+                new FullName($userSession->FirstName, $userSession->LastName)
+                ])
+            ->AddTo($to->EmailAddress(), $to->FullName())
+            ->Template('AccountDeleted.tpl')
+            ->LanguageCode($to->LanguageCode)
+            ->Set('UserFullName', $deletedUser->FullName())
+            ->Set('AdminFullName', new FullName($userSession->FirstName, $userSession->LastName));
     }
 }

--- a/lib/Email/Messages/AnnouncementEmail.php
+++ b/lib/Email/Messages/AnnouncementEmail.php
@@ -3,63 +3,19 @@
 require_once(ROOT_DIR . 'lib/Email/namespace.php');
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class AnnouncementEmail extends EmailMessage
+class AnnouncementEmail
 {
-    /**
-     * @var string
-     */
-    private $announcement;
-
-    /**
-     * @var UserSession
-     */
-    private $sentBy;
-
-    /**
-     * @var UserItemView
-     */
-    private $to;
-
-    /**
-     * @param string $announcement
-     * @param UserSession $sentBy
-     * @param UserItemView $to
-     */
-    public function __construct($announcement, $sentBy, $to)
+    public static function BuilderFor($announcement, $sentBy, $to): EmailBuilder
     {
-        parent::__construct($to->Language);
-        $this->announcement = $announcement;
-        $this->sentBy = $sentBy;
-        $this->to = $to;
-    }
+        $builder = new EmailBuilder;
+        $builder
+            ->SubjectTranslation('AnnouncementSubject', [new FullName($sentBy->FirstName, $sentBy->LastName)])
+            ->AddTo($to->Email, new FullName($to->First, $to->Last))
+            ->From($sentBy->Email, new FullName($sentBy->FirstName, $sentBy->LastName))
+            ->Template('AnnouncementEmail.tpl')
+            ->LanguageCode($to->Language)
+            ->Set('AnnouncementText', $announcement);
 
-    /**
-     * @return array|EmailAddress[]|EmailAddress
-     */
-    public function To()
-    {
-        return new EmailAddress($this->to->Email, new FullName($this->to->First, $this->to->Last));
-    }
-
-    /**
-     * @return string
-     */
-    public function Subject()
-    {
-        return $this->Translate('AnnouncementSubject', new FullName($this->sentBy->FirstName, $this->sentBy->LastName));
-    }
-
-    /**
-     * @return string
-     */
-    public function Body()
-    {
-        $this->Set('AnnouncementText', $this->announcement);
-        return $this->FetchTemplate('AnnouncementEmail.tpl');
-    }
-
-    public function From()
-    {
-        return new EmailAddress($this->sentBy->Email, new FullName($this->sentBy->FirstName, $this->sentBy->LastName));
-    }
+        return $builder;
+    }    
 }

--- a/lib/Email/Messages/ForgotPasswordEmail.php
+++ b/lib/Email/Messages/ForgotPasswordEmail.php
@@ -3,48 +3,15 @@
 require_once(ROOT_DIR . 'lib/Email/namespace.php');
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
-class ForgotPasswordEmail extends EmailMessage
+class ForgotPasswordEmail
 {
-    /**
-     * @var \User
-     */
-    private $user;
-
-    /**
-     * @var string
-     */
-    private $temporaryPassword;
-
-    public function __construct(User $user, $temporaryPassword)
+    public static function BuilderFor(User $user, $temporaryPassword): EmailBuilder
     {
-        parent::__construct($user->Language());
-
-        $this->user = $user;
-        $this->temporaryPassword = $temporaryPassword;
-    }
-
-    /**
-     * @return EmailAddress[]
-     */
-    public function To()
-    {
-        return new EmailAddress($this->user->EmailAddress(), $this->user->FullName());
-    }
-
-    /**
-     * @return string
-     */
-    public function Subject()
-    {
-        return $this->Translate('ResetPasswordRequest');
-    }
-
-    /**
-     * @return string
-     */
-    public function Body()
-    {
-        $this->Set('TemporaryPassword', $this->temporaryPassword);
-        return $this->FetchTemplate('ResetPassword.tpl');
+        return (new EmailBuilder)
+            ->SubjectTranslation('ResetPasswordRequest')
+            ->AddTo($user->EmailAddress(), $user->FullName())
+            ->Template('ResetPassword.tpl')
+            ->LanguageCode($user->Language())
+            ->Set('TemporaryPassword', $temporaryPassword);
     }
 }

--- a/lib/Email/Messages/GuestAccountCreationEmail.php
+++ b/lib/Email/Messages/GuestAccountCreationEmail.php
@@ -2,49 +2,16 @@
 
 require_once(ROOT_DIR . 'lib/Email/namespace.php');
 
-class GuestAccountCreationEmail extends EmailMessage
+class GuestAccountCreationEmail
 {
-    /**
-     * @var User
-     */
-    private $user;
-
-    /**
-     * @var string
-     */
-    private $password;
-
-    public function __construct(User $user, $password)
+    public static function BuilderFor(User $user, $password): EmailBuilder
     {
-        $this->user = $user;
-        $this->password = $password;
-
-        parent::__construct($user->Language());
-    }
-
-    /**
-     * @return array|EmailAddress[]|EmailAddress
-     */
-    public function To()
-    {
-        return new EmailAddress($this->user->EmailAddress(), $this->user->FullName());
-    }
-
-    /**
-     * @return string
-     */
-    public function Subject()
-    {
-        return $this->Translate('GuestAccountCreatedSubject', [Configuration::Instance()->GetKey(ConfigKeys::APP_TITLE)]);
-    }
-
-    /**
-     * @return string
-     */
-    public function Body()
-    {
-        $this->Set('EmailAddress', $this->user->EmailAddress());
-        $this->Set('Password', $this->password);
-        return $this->FetchTemplate('GuestAccountCreation.tpl');
+        return (new EmailBuilder)
+            ->SubjectTranslation('GuestAccountCreatedSubject', [Configuration::Instance()->GetKey(ConfigKeys::APP_TITLE)])
+            ->AddTo($user->EmailAddress(), $user->FullName())
+            ->Template('GuestAccountCreation.tpl')
+            ->LanguageCode($user->Language())
+            ->Set('EmailAddress', $user->EmailAddress())
+            ->Set('Password', $password);
     }
 }

--- a/lib/Email/RenderedMessage.php
+++ b/lib/Email/RenderedMessage.php
@@ -1,0 +1,26 @@
+<?php
+
+class RenderedMessage
+{
+    /**
+     * 
+     * @param EmailAddress[] $to 
+     * @param EmailAddress[] $cc 
+     * @param EmailAddress[] $bcc 
+     * @param StringAttachment[] $attachments 
+     * @return void 
+     */
+    public function __construct(
+        public readonly string $charset,
+        public readonly string $subject,
+        public readonly EmailAddress $from,
+        public readonly EmailAddress $replyTo,
+        public readonly array $to,
+        public readonly array $cc,
+        public readonly array $bcc,
+        public readonly string $body,
+        public readonly array $attachments
+    )
+    {
+    }
+}

--- a/lib/Email/StringAttachment.php
+++ b/lib/Email/StringAttachment.php
@@ -1,0 +1,12 @@
+<?php
+
+class StringAttachment
+{
+    public function __construct(
+        public readonly string $filename,
+        public readonly string $contents
+    )
+    {
+        
+    }
+}


### PR DESCRIPTION
@effgarces Please note that the original PR #426 as well as this was just an incomplete draft. Also #425 in not yet finished in this PR. I just spent a lot of work for this refactoring, so I wanted to share it. But currently I have not time to complete the work.

So here is the rest of the description of the original PR #426:

When I was working on a feature it was quite difficult to implement it because of the current architecture of the email system. This PR holds the current state of my approach, but as it was too risky to break something else I stopped working on it. Maybe it's something for Version 3.0?

The `EmailMessage` is the base class for all message types and implements an interface. Some of the derived classes have a `GetTemplateName` method, some don't.

I thought the reason for the architecture is because of a manipulation of the `EmailMessage` object after it's creation. But it seems that is not the case. All code paths I found create the message and send it to phpmailer without additional modification.

I tried to replace it with a more straighforward builder pattern.

So far I replaced the first view classes with the builder pattern approach. When I came accross `GuestAddedEmail` wich derives from `ReservationEmailMessage` things got more complicated. I think this could still be resolved when using a mixture of the builder pattern and the derived class pattern here.

Todos:
- [ ] Replace all messages with the builder pattern
- [ ] Fix #425 
- [ ] Replace `EmailMessage`