### PR TITLE
Fix checkin/out button on Reservation page

### DIFF
--- a/tpl/Reservation/edit.tpl
+++ b/tpl/Reservation/edit.tpl
@@ -73,13 +73,13 @@
         </div>
 
 
-        {if $CheckInRequired && (!checkinAdminOnly || $CanViewAdmin)}
+        {if $CheckInRequired && (!$checkinAdminOnly || $CanViewAdmin)}
             <button type="button" class="btn btn-sm btn-warning btnCheckin"><i class="bi bi-box-arrow-in-right"></i>
                 {translate key=CheckIn}
                 <span class="autoReleaseButtonMessage" data-autorelease-minutes="{$AutoReleaseMinutes}"> -
                     {translate key=ReleasedIn} <span class="autoReleaseMinutes"></span> {translate key=minutes}</span></button>
         {/if}
-        {if $CheckOutRequired && (!checkoutAdminOnly || $CanViewAdmin)}
+        {if $CheckOutRequired && (!$checkoutAdminOnly || $CanViewAdmin)}
             <button type="button" class="btn btn-sm btn-warning btnCheckout"><i class="bi bi-box-arrow-in-right"></i>
                 {translate key=CheckOut}</button>
         {/if}

--- a/tpl/Reservation/view.tpl
+++ b/tpl/Reservation/view.tpl
@@ -281,14 +281,14 @@
                             {/block}
 
                             {block name="submitButtons"}
-                                {if $CheckInRequired && (!checkinAdminOnly || $CanViewAdmin)}
+                                {if $CheckInRequired && (!$checkinAdminOnly || $CanViewAdmin)}
                                     <button type="button" class="btn btn-warning btnCheckin"><i
                                             class="bi bi-box-arrow-in-right"></i>
                                         {translate key=CheckIn}<span class="autoReleaseButtonMessage"
                                             data-autorelease-minutes="{$AutoReleaseMinutes}"> - {translate key=ReleasedIn}
                                             <span class="autoReleaseMinutes"></span> {translate key=minutes}</span></button>
                                 {/if}
-                                {if $CheckOutRequired && (!checkoutAdminOnly || $CanViewAdmin)}
+                                {if $CheckOutRequired && (!$checkoutAdminOnly || $CanViewAdmin)}
                                     <button type="button" class="btn btn-warning btnCheckout"><i
                                             class="bi bi-box-arrow-in-left"></i>
                                         {translate key=CheckOut}</button>


### PR DESCRIPTION
Missing `$` in template was causing the buttons to only show for administrators.

The compiled template showed that checkinAdminOnly and checkoutAdminOnly were being treated as barewords.

Fixes #457