### PR TITLE
Update Server.php

### DIFF
--- a/lib/Server/Server.php
+++ b/lib/Server/Server.php
@@ -55,7 +55,7 @@ class Server
 
     public function GetSession($name)
     {
-        if (!$this->IsSessionStarted()) {
+        if (!$this->IsSessionStarted() && PHP_SAPI !== 'cli') {
             $parts = parse_url(Configuration::Instance()->GetScriptUrl());
             $path = isset($parts['path']) ? $parts['path'] : '';
             $seconds = Configuration::Instance()->GetKey(ConfigKeys::INACTIVITY_TIMEOUT, new IntConverter()) * 60;


### PR DESCRIPTION
Don't call server cookie and ini methods when running in CLI mode for cron as this creates unhelpful warnings in the cron log.

There may be a better way to do this but this seems to have fixed our issues.