### PR TITLE
Update emailheader.tpl

### DIFF
--- a/tpl/Email/emailheader.tpl
+++ b/tpl/Email/emailheader.tpl
@@ -5,12 +5,10 @@
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset={$Charset}" />
 		<style type="text/css">
-			* { margin:0; padding:0; }
 
 			body {
 			    font: 13px Helvetica, "Lucida Grande", Verdana, Arial, sans-serif;
 			    background-color: #fefefe;
-			    margin: 0px;
 			    color: #333333;
 			    height: 100%;
 			}


### PR DESCRIPTION
Use default padding and margin on HTML elements in emails to avoid ugly bunched up emails with no spacing around the outside or between elements.

(in my opionion) this makes the emails look nicer for a very small tweak. Although it's removing something someone previously added so there may be logic I don't know for why all the padding and margins were removed from emails.