### PR TITLE
Show ical subscription link only for logged in users

### DIFF
--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -98,7 +98,7 @@
                                 <a href="#" class="schedule-style d-none d-md-block" id="schedule_week"
                                     schedule-display="{ScheduleStyle::CondensedWeek}">{html_image src="table-week.png" altKey="CondensedWeekScheduleDisplay"}</a>
                             </div>
-                            {if isset($SubscriptionUrl) && $SubscriptionUrl != null && $ShowSubscription}
+                            {if isset($SubscriptionUrl) && $SubscriptionUrl != null && $ShowSubscription && $LoggedIn}
                                 <div class="d-flex align-items-center"><i class="bi bi-rss-fill link-primary me-1"></i>
                                     <a class="link-primary me-1" target="_blank" href="{$SubscriptionUrl->GetAtomUrl()}">Atom</a>
                                     <div class="vr me-1"></div>


### PR DESCRIPTION
Currently the public schedule, when enabled shows the secret subscription link for atom and ical for each calendar with all reservation information.

The commit adds changes the logic to only show these links in the template for logged in users.

