### PR TITLE
feature: Allow hiding specific fields in the registration form (#367)

### DIFF
--- a/Pages/RegistrationPage.php
+++ b/Pages/RegistrationPage.php
@@ -78,6 +78,9 @@ class RegistrationPage extends ActionPage implements IRegistrationPage
         $this->Set('RequirePhone', Configuration::Instance()->GetSectionKey(ConfigSection::REGISTRATION, ConfigKeys::REGISTRATION_REQUIRE_PHONE, new BooleanConverter()));
         $this->Set('RequirePosition', Configuration::Instance()->GetSectionKey(ConfigSection::REGISTRATION, ConfigKeys::REGISTRATION_REQUIRE_POSITION, new BooleanConverter()));
         $this->Set('RequireOrganization', Configuration::Instance()->GetSectionKey(ConfigSection::REGISTRATION, ConfigKeys::REGISTRATION_REQUIRE_ORGANIZATION, new BooleanConverter()));
+        $this->Set('HidePhone', Configuration::Instance()->GetSectionKey(ConfigSection::REGISTRATION, ConfigKeys::REGISTRATION_HIDE_PHONE, new BooleanConverter()));
+        $this->Set('HidePosition', Configuration::Instance()->GetSectionKey(ConfigSection::REGISTRATION, ConfigKeys::REGISTRATION_HIDE_POSITION, new BooleanConverter()));
+        $this->Set('HideOrganization', Configuration::Instance()->GetSectionKey(ConfigSection::REGISTRATION, ConfigKeys::REGISTRATION_HIDE_ORGANIZATION, new BooleanConverter()));
 
         $this->_presenter->PageLoad();
 

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -209,6 +209,9 @@ $conf['settings']['tablet.view']['auto.suggest.emails'] = 'false';
 $conf['settings']['registration']['require.phone'] = 'false';
 $conf['settings']['registration']['require.position'] = 'false';
 $conf['settings']['registration']['require.organization'] = 'false';
+$conf['settings']['registration']['hide.phone'] = 'false';                  //Hide phone field when 'true', but show it when the phone is required
+$conf['settings']['registration']['hide.position'] = 'false';               //Hide position field when 'true', but show it when the phone is required
+$conf['settings']['registration']['hide.organization'] = 'false';           //Hide organization field when 'true', but show it when the phone is required
 /**
  * Error logging
  */

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -159,6 +159,9 @@ class ConfigKeys
     public const REGISTRATION_REQUIRE_PHONE = 'require.phone';
     public const REGISTRATION_REQUIRE_ORGANIZATION = 'require.organization';
     public const REGISTRATION_REQUIRE_POSITION = 'require.position';
+    public const REGISTRATION_HIDE_PHONE = 'hide.phone';
+    public const REGISTRATION_HIDE_ORGANIZATION = 'hide.organization';
+    public const REGISTRATION_HIDE_POSITION = 'hide.position';
 
     public const LOGGING_FOLDER = 'folder';
     public const LOGGING_LEVEL = 'level';

--- a/tpl/register.tpl
+++ b/tpl/register.tpl
@@ -133,6 +133,7 @@
                             </div>
                         </div>
 
+                        {if $RequirePhone || !$HidePhone}
                         <div class="col-12 col-sm-6" id="phone">
                             <div class="form-group">
                                 <label class="reg fw-bold" for="phone">{translate key="Phone"}{if $RequirePhone}<i
@@ -143,7 +144,9 @@
                                     data-bv-notempty-message="{translate key=PhoneRequired}" {/if} />
                             </div>
                         </div>
+                        {/if}
 
+                        {if $RequireOrganization || !$HideOrganization}
                         <div class="col-12 col-sm-6" id="organization">
                             <div class="form-group">
                                 <label class="reg fw-bold"
@@ -156,7 +159,9 @@
                                     data-bv-notempty-message="{translate key=OrganizationRequired}" {/if} />
                             </div>
                         </div>
+                        {/if}
 
+                        {if $RequirePosition || !$HidePosition}
                         <div class="col-12 col-sm-6 " id="position">
                             <div class="form-group">
                                 <label class="reg fw-bold"
@@ -168,6 +173,7 @@
                                     data-bv-notempty-message="{translate key=PositionRequired}" {/if} />
                             </div>
                         </div>
+                        {/if}
 
                         <div class="col-12 col-sm-6">
                             {if $Attributes|default:array()|count > 0}


### PR DESCRIPTION
### Add option to hide fields in the registration form
#### Fields that can be hidden:

- Phone
- Position
- Organization

#### Behavior for required fields:

- These fields can now be toggled on or off in the project settings under the "Registration" section.
- If any of these fields are marked as required, the hide setting will be ignored, and the field will still be displayed in the form.
- Closes #367