### PR TITLE
Added keycloak as external auth provider

### DIFF
--- a/Pages/LoginPage.php
+++ b/Pages/LoginPage.php
@@ -94,19 +94,24 @@ interface ILoginPage extends IPage, ILoginBasePage
     public function SetAnnouncements($announcements);
 
     /**
-     *  
+     *
      */
     public function SetGoogleUrl($URL);
 
     /**
-     *  
+     *
      */
     public function SetMicrosoftUrl($URL);
 
     /**
-     *  
+     *
      */
     public function SetFacebookUrl($URL);
+
+    /**
+     *
+     */
+    public function SetKeycloakUrl($URL);
 }
 
 class LoginPage extends Page implements ILoginPage
@@ -119,7 +124,7 @@ class LoginPage extends Page implements ILoginPage
 
         $this->presenter = new LoginPresenter($this); // $this pseudo variable of class object is Page object
         $resumeUrl = $this->server->GetQuerystring(QueryStringKeys::REDIRECT);
-        if($resumeUrl !== NULL) $resumeUrl = str_replace('&amp;&amp;', '&amp;', $resumeUrl);
+        if ($resumeUrl !== NULL) $resumeUrl = str_replace('&amp;&amp;', '&amp;', $resumeUrl);
         $this->Set('ResumeUrl', $resumeUrl);
         $this->Set('ShowLoginError', false);
         $this->Set('Languages', Resources::GetInstance()->AvailableLanguages);
@@ -128,11 +133,12 @@ class LoginPage extends Page implements ILoginPage
         $this->Set('AllowFacebookLogin', Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK, new BooleanConverter()));
         $this->Set('AllowGoogleLogin', Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE, new BooleanConverter()));
         $this->Set('AllowMicrosoftLogin', Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT, new BooleanConverter()));
+        $this->Set('AllowKeycloakLogin', Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_KEYCLOAK, new BooleanConverter()));
         $scriptUrl = Configuration::Instance()->GetScriptUrl();
         $parts = explode('://', $scriptUrl);
         $this->Set('Protocol', $parts[0]);
         if (isset($parts[1])) {
-          $this->Set('ScriptUrlNoProtocol', $parts[1]);
+            $this->Set('ScriptUrlNoProtocol', $parts[1]);
         }
         $this->Set('GoogleState', strtr(base64_encode("resume=$scriptUrl/external-auth.php%3Ftype%3Dgoogle%26redirect%3D$resumeUrl"), '+/=', '-_,'));
         $this->Set('EnableCaptcha', Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_CAPTCHA_ON_LOGIN, new BooleanConverter()));
@@ -299,41 +305,52 @@ class LoginPage extends Page implements ILoginPage
     }
 
     /**
-     * Sends the created google url in the presenter to the smarty page 
+     * Sends the created google url in the presenter to the smarty page
      */
-    public function SetGoogleUrl($googleUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE, new BooleanConverter())){
-            $this->Set('GoogleUrl',$googleUrl);
+    public function SetGoogleUrl($googleUrl)
+    {
+        if (Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_GOOGLE, new BooleanConverter())) {
+            $this->Set('GoogleUrl', $googleUrl);
         }
     }
 
     /**
-     * Sends the created microsoft url in the presenter to the smarty page 
+     * Sends the created microsoft url in the presenter to the smarty page
      */
-    public function SetMicrosoftUrl($microsoftUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT, new BooleanConverter())){
-            $this->Set('MicrosoftUrl',$microsoftUrl);
+    public function SetMicrosoftUrl($microsoftUrl)
+    {
+        if (Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_MICROSOFT, new BooleanConverter())) {
+            $this->Set('MicrosoftUrl', $microsoftUrl);
         }
     }
 
     /**
-     * Sends the created facebook url in the presenter to the smarty page 
+     * Sends the created facebook url in the presenter to the smarty page
      */
-    public function SetFacebookUrl($FacebookUrl){
-        if(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK, new BooleanConverter())){
-            $this->Set('FacebookUrl',$FacebookUrl);
+    public function SetFacebookUrl($FacebookUrl)
+    {
+        if (Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_FACEBOOK, new BooleanConverter())) {
+            $this->Set('FacebookUrl', $FacebookUrl);
         }
     }
 
     /**
-     * Temporary solution for facebook auth SDK error 
+     * Temporary solution for facebook auth SDK error
      * After facebook failed authentication user is redirected to login page (this one) and is shown a message to try again
      * Error occurs rarely (FacebookSDKException)
      */
-    private function SetFacebookErrorMessage(){
+    private function SetFacebookErrorMessage()
+    {
         if (isset($_SESSION['facebook_error']) && $_SESSION['facebook_error'] == true) {
-            $this->Set('facebookError',$_SESSION['facebook_error']);
+            $this->Set('facebookError', $_SESSION['facebook_error']);
             unset($_SESSION['facebook_error']);
+        }
+    }
+
+    public function SetKeycloakUrl($KeycloakUrl)
+    {
+        if (Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::AUTHENTICATION_ALLOW_KEYCLOAK, new BooleanConverter())) {
+            $this->Set('KeycloakUrl', $KeycloakUrl);
         }
     }
 }

--- a/Presenters/Authentication/ExternalAuthLoginPresenter.php
+++ b/Presenters/Authentication/ExternalAuthLoginPresenter.php
@@ -35,6 +35,9 @@ class ExternalAuthLoginPresenter
         if ($this->page->GetType() == 'microsoft') {
             $this->ProcessMicrosoftSingleSignOn();
         }
+        if ($this->page->GetType() == 'keycloak') {
+            $this->ProcessKeycloakSingleSignOn();
+        }
     }
 
     /**
@@ -54,18 +57,18 @@ class ExternalAuthLoginPresenter
             $token = $client->fetchAccessTokenWithAuthCode($_GET['code']);
             //set the access token that it received
             $client->setAccessToken($token['access_token']);
-        
-            //Using the Google API to get the user information 
+
+            //Using the Google API to get the user information
             $google_oauth = new Google\Service\Oauth2($client);
             $google_account_info = $google_oauth->userinfo->get();
-            
+
             //Save the informations needed to authenticate the login
             $email     =  $google_account_info->email;
             $firstName = $google_account_info->given_name;
             $lastName  = $google_account_info->family_name;
-        
+
             //Process $userData as needed (e.g., create a user, log in, etc.)
-            $this->processUserData($email,$email,$firstName,$lastName);
+            $this->processUserData($email, $email, $firstName, $lastName);
         }
     }
 
@@ -73,13 +76,13 @@ class ExternalAuthLoginPresenter
      * Exchanges the code given by microsoft in _GET for a token and with said token retrieves client data
      */
     private function ProcessMicrosoftSingleSignOn()
-    {        
+    {
         if (isset($_GET['code'])) {
             $code = filter_input(INPUT_GET, 'code');
 
             $tokenEndpoint = 'https://login.microsoftonline.com/'
-                            .urlencode(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::MICROSOFT_TENANT_ID))
-                            .'/oauth2/v2.0/token';
+                . urlencode(Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::MICROSOFT_TENANT_ID))
+                . '/oauth2/v2.0/token';
 
             $postData = [
                 'client_id' => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::MICROSOFT_CLIENT_ID),
@@ -95,13 +98,13 @@ class ExternalAuthLoginPresenter
             $response = $client->post($tokenEndpoint, [
                 'form_params' => $postData,
             ]);
-            
+
             // Decode the JSON response
             $tokenData = json_decode($response->getBody(), true);
 
             // Extract the access token from the response
             $accessToken = $tokenData['access_token'];
-            
+
             //Get user information
             $graphApiEndpoint = 'https://graph.microsoft.com/v1.0/me';
 
@@ -111,78 +114,152 @@ class ExternalAuthLoginPresenter
                     'Authorization' => 'Bearer ' . $accessToken,
                 ],
             ]);
-        
+
             // Decode the JSON response
             $userData = json_decode($response->getBody(), true);
-        
+
             // Handle the user data as needed
             $email     = $userData['mail'];
             $firstName = $userData['givenName'];;
             $lastName  = $userData['surname'];
-            
+
             //Process $userData as needed (e.g., create a user, log in, etc.)
-            $this->processUserData($email,$email,$firstName,$lastName);
+            $this->processUserData($email, $email, $firstName, $lastName);
         }
-        
     }
 
     /**
      * Gets token created in facebook-auth.php and exchanges it for the client data
      * Unlike the other two (microsoft and google) the token must be obtained directly in the redirect uri, therefore can't be sent here for exchange(?)
      */
-    private function ProcessFacebookSingleSignOn(){
-        
+    private function ProcessFacebookSingleSignOn()
+    {
+
         $facebook_Client = new Facebook\Facebook([
             'app_id'                => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_ID),
             'app_secret'            => Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_CLIENT_SECRET),
             'default_graph_version' => 'v2.5'
         ]);
-        
+
         if (isset($_SESSION['facebook_access_token'])) {
             $facebook_Client->setDefaultAccessToken(unserialize($_SESSION['facebook_access_token']));
         }
         unset($_SESSION['facebook_access_token']);
 
-        $profile_request = $facebook_Client ->get('/me?fields=name,first_name,last_name,email');
-        $profile = $profile_request ->getGraphUser();
+        $profile_request = $facebook_Client->get('/me?fields=name,first_name,last_name,email');
+        $profile = $profile_request->getGraphUser();
 
         $email     = $profile->getField('email');
         $firstName = $profile->getField('first_name');
         $lastName  = $profile->getField('last_name');
 
         //Process $userData as needed (e.g., create a user, log in, etc.)
-        $this->processUserData($email,$email,$firstName,$lastName);
-        
+        $this->processUserData($email, $email, $firstName, $lastName);
     }
+
+    private function ProcessKeycloakSingleSignOn()
+    {
+        $code = $_GET['code'];
+
+        $keycloakUrl  = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_URL);
+        $realm        = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_REALM);
+        $clientId     = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_CLIENT_ID);
+        $clientSecret = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_CLIENT_SECRET);
+        $redirectUri = rtrim(Configuration::Instance()->GetScriptUrl(), 'Web/') . Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::KEYCLOAK_REDIRECT_URI);
+
+        $tokenEndpoint = rtrim($keycloakUrl, '/') . '/realms/' . urlencode($realm) . '/protocol/openid-connect/token';
+
+        // Prepare the POST data for the token request.
+        $postData = [
+            'grant_type'    => 'authorization_code',
+            'code'          => $code,
+            'redirect_uri'  => $redirectUri,
+            'client_id'     => $clientId,
+            'client_secret' => $clientSecret,
+        ];
+
+        $client = new \GuzzleHttp\Client();
+
+        try {
+            $response = $client->post($tokenEndpoint, [
+                'form_params' => $postData,
+            ]);
+        } catch (\Exception $e) {
+            $this->page->ShowError(['Error retrieving Keycloak token: ' . $e->getMessage()]);
+            return;
+        }
+
+        $tokenData = json_decode($response->getBody(), true);
+        if (!isset($tokenData['access_token'])) {
+            $this->page->ShowError(['Access token not found in Keycloak response']);
+            return;
+        }
+        $accessToken = $tokenData['access_token'];
+
+        // Build the userinfo endpoint URL (again, without '/auth').
+        $userInfoEndpoint = rtrim($keycloakUrl, '/') . '/realms/' . urlencode($realm) . '/protocol/openid-connect/userinfo';
+
+        try {
+            $userResponse = $client->get($userInfoEndpoint, [
+                'headers' => [
+                    'Authorization' => 'Bearer ' . $accessToken,
+                ],
+            ]);
+        } catch (\Exception $e) {
+            $this->page->ShowError(['Error retrieving Keycloak user info: ' . $e->getMessage()]);
+            return;
+        }
+
+        $userData = json_decode($userResponse->getBody(), true);
+
+        $email     = isset($userData['email']) ? $userData['email'] : '';
+        $firstName = isset($userData['given_name']) ? $userData['given_name'] : 'not set';
+        $lastName  = isset($userData['family_name']) ? $userData['family_name'] : 'not set';
+        $username  = isset($userData['preferred_username']) ? $userData['preferred_username'] : $email;
+        $phone  = isset($userData['phone_number']) ? $userData['phone_number'] : '';
+        $organization  = isset($userData['organization']) ? $userData['organization'] : '';
+        $title  = isset($userData['title']) ? $userData['title'] : '';
+
+        if (empty($email)) {
+            $this->page->ShowError(["Email is not set in your Keycloak profile. Please update your profile and try again."]);
+            return;
+        }
+
+        $this->processUserData($username, $email, $firstName, $lastName, $phone, $organization, $title);
+    }
+
 
     /**
      * Processes user given data, creates a user in database if it doesn't exist and logs it in
      */
-    private function processUserData($username,$email,$firstName,$lastName){
+    private function processUserData($username, $email, $firstName, $lastName, $phone = null, $organization = null, $title = null)
+    {
         $requiredDomainValidator = new RequiredEmailDomainValidator($email);
         $requiredDomainValidator->Validate();
         if (!$requiredDomainValidator->IsValid()) {
             $this->page->ShowError(array(Resources::GetInstance()->GetString('InvalidEmailDomain')));
             return;
         }
-        if($this->registration->UserExists($username,$email)){
+        if ($this->registration->UserExists($username, $email)) {
             $this->authentication->Login($email, new WebLoginContext(new LoginData()));
             LoginRedirector::Redirect($this->page);
-        }
-        else{
-            $this->registration->Synchronize(new AuthenticatedUser(
-                $username,
-                $email,
-                $firstName, 
-                $lastName,
-                Password::GenerateRandom(),
-                Resources::GetInstance()->CurrentLanguage,
-                Configuration::Instance()->GetDefaultTimezone(),
-                null,
-                null,
-                null),
+        } else {
+            $this->registration->Synchronize(
+                new AuthenticatedUser(
+                    $username,
+                    $email,
+                    $firstName,
+                    $lastName,
+                    Password::GenerateRandom(),
+                    Resources::GetInstance()->CurrentLanguage,
+                    Configuration::Instance()->GetDefaultTimezone(),
+                    $phone,
+                    $organization,
+                    $title
+                ),
                 false,
-                false);
+                false
+            );
             $this->authentication->Login($email, new WebLoginContext(new LoginData()));
             LoginRedirector::Redirect($this->page);
         }

--- a/Web/keycloak-auth.php
+++ b/Web/keycloak-auth.php
@@ -1,0 +1,14 @@
+<?php
+define('ROOT_DIR', '../');
+
+require_once(ROOT_DIR . 'lib/Common/namespace.php');
+
+//Checks if the user was authenticated by keycloak and redirects to external authentication page
+if (isset($_GET['code'])) {
+    $code = filter_input(INPUT_GET, 'code');
+    header("Location: " . ROOT_DIR . "Web/external-auth.php?type=keycloak&code=" . $code);
+    exit;
+} else {
+    header("Location:" . ROOT_DIR . "Web");
+    exit();
+}

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -243,6 +243,14 @@ $conf['settings']['authentication']['facebook.client.id'] = '';
 $conf['settings']['authentication']['facebook.client.secret'] = '';
 $conf['settings']['authentication']['facebook.redirect.uri'] = '/Web/facebook-auth.php';
 /**
+ * Keycloak login configuration
+ */
+$conf['settings']['authentication']['keycloak.url'] = '';
+$conf['settings']['authentication']['keycloak.realm'] = '';
+$conf['settings']['authentication']['keycloak.client.id'] = '';
+$conf['settings']['authentication']['keycloak.client.secret'] = '';
+$conf['settings']['authentication']['keycloak.client.uri'] = '/Web/keycloak-auth.php';
+/**
  * Delete old data job configuration
  * Activate the deleteolddata.php as a background job to use this feature
  */

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ if ! [ -f config/config.php ]; then \
   echo '$conf["settings"]["database"]["hostspec"] = ' "'$DB_HOST';" >>config/config.php; \
   echo '$conf["settings"]["database"]["name"] = ' "'$DB_DATABASE';" >>config/config.php; \
   echo '$conf["settings"]["install.password"] = ' "'$INSTALL_PASSWORD';" >>config/config.php; \
-  echo '$conf["settings"]["sript.url"] = ' "'$SCRIPT_URL';" >>config/config.php; \
+  echo '$conf["settings"]["script.url"] = ' "'$SCRIPT_URL';" >>config/config.php; \
   echo '$conf["settings"]["admin.email"] = ' "'$ADMIN_EMAIL';" >>config/config.php; \
 fi
 

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -146,6 +146,7 @@ class ConfigKeys
     public const AUTHENTICATION_ALLOW_FACEBOOK = 'allow.facebook.login';
     public const AUTHENTICATION_ALLOW_GOOGLE = 'allow.google.login';
     public const AUTHENTICATION_ALLOW_MICROSOFT = 'allow.microsoft.login';
+    public const AUTHENTICATION_ALLOW_KEYCLOAK = 'allow.keycloak.login';
     public const AUTHENTICATION_REQUIRED_EMAIL_DOMAINS = 'required.email.domains';
     public const AUTHENTICATION_HIDE_BOOKED_LOGIN_PROMPT = 'hide.booked.login.prompt';
     public const AUTHENTICATION_CAPTCHA_ON_LOGIN = 'captcha.on.login';
@@ -181,6 +182,11 @@ class ConfigKeys
     public const FACEBOOK_CLIENT_SECRET = 'facebook.client.secret';
     public const FACEBOOK_REDIRECT_URI = 'facebook.redirect.uri';
 
+    public const KEYCLOAK_URL = 'keycloak.url';
+    public const KEYCLOAK_REALM = 'keycloak.realm';
+    public const KEYCLOAK_CLIENT_ID = 'keycloak.client.id';
+    public const KEYCLOAK_CLIENT_SECRET = 'keycloak.client.secret';
+    public const KEYCLOAK_REDIRECT_URI = 'keycloak.client.uri';
     public const YEARS_OLD_DATA = 'years.old.data';
     public const DELETE_OLD_ANNOUNCEMENTS = 'delete.old.announcements';
     public const DELETE_OLD_BLACKOUTS = 'delete.old.blackouts';

--- a/tests/Presenters/LoginPresenterTest.php
+++ b/tests/Presenters/LoginPresenterTest.php
@@ -223,11 +223,13 @@ class FakeLoginPage extends FakePageBase implements ILoginPage
     public $_ShowScheduleLink = false;
     public $_Announcements;
 
-    public function SetGoogleUrl($URL) { }
+    public function SetGoogleUrl($URL) {}
 
-    public function SetMicrosoftUrl($URL) { }
+    public function SetMicrosoftUrl($URL) {}
 
-    public function SetFacebookUrl($URL) { }
+    public function SetFacebookUrl($URL) {}
+
+    public function SetKeycloakUrl($URL) {}
 
     public function PageLoad()
     {

--- a/tpl/login.tpl
+++ b/tpl/login.tpl
@@ -2,139 +2,130 @@
 
 <div id="page-login">
 
-	{if $EnableCaptcha}
-		{validation_group class="alert alert-danger"}
-		{validator id="captcha" key="CaptchaMustMatch"}
-		{/validation_group}
-	{/if}
+    {if $EnableCaptcha}
+        {validation_group class="alert alert-danger"}
+        {validator id="captcha" key="CaptchaMustMatch"}
+        {/validation_group}
+    {/if}
 
-	{if $Announcements|default:array()|count > 0}
-		<div id="announcements" class="col-sm-8 col-12 mx-auto shadow mb-2 mt-5">
-			<div class="list-group">
-				{foreach from=$Announcements item=each}
-					<div class="announcement list-group-item">{$each->Text()|html_entity_decode|url2link|nl2br}</div>
-				{/foreach}
-			</div>
-		</div>
-	{/if}
+    {if $Announcements|default:array()|count > 0}
+        <div id="announcements" class="col-sm-8 col-12 mx-auto shadow mb-2 mt-5">
+            <div class="list-group">
+                {foreach from=$Announcements item=each}
+                    <div class="announcement list-group-item">{$each->Text()|html_entity_decode|url2link|nl2br}</div>
+                {/foreach}
+            </div>
+        </div>
+    {/if}
 
-	<div class="col-md-6 col-12 mx-auto mt-5">
-		<form role="form" name="login" id="login" class="form-horizontal" method="post"
-			action="{$smarty.server.SCRIPT_NAME}">
-			<div class="card shadow mb-2">
-				<div class="card-body mx-3">
-					<div id="login-box" class="default-box">
-						<div class="login-icon my-2">
-							{html_image src="$LogoUrl?{$Version}" alt="$Title" class="mx-auto d-block w-50"}
-						</div>
+    <div class="col-md-6 col-12 mx-auto mt-5">
+        <form role="form" name="login" id="login" class="form-horizontal" method="post" action="{$smarty.server.SCRIPT_NAME}">
+            <div class="card shadow mb-2">
+                <div class="card-body mx-3">
+                    <div id="login-box" class="default-box">
+                        <div class="login-icon my-2">
+                            {html_image src="$LogoUrl?{$Version}" alt="$Title" class="mx-auto d-block w-50"}
+                        </div>
 
-						{if $ShowLoginError}
-							<div id="loginError" class="alert alert-danger">
-								{translate key='LoginError'}
-							</div>
-						{/if}
+                        {if $ShowLoginError}
+                            <div id="loginError" class="alert alert-danger">
+                                {translate key='LoginError'}
+                            </div>
+                        {/if}
 
-						{if $ShowUsernamePrompt}
-							<div class="input-group mb-2">
-								<span class="input-group-text"><i class="bi bi-person-fill"></i></span>
-								<input type="text" required="" class="form-control" id="email" {formname key=EMAIL}
-									placeholder="{translate key=UsernameOrEmail}" />
-							</div>
-						{/if}
+                        {if $ShowUsernamePrompt}
+                            <div class="input-group mb-2">
+                                <span class="input-group-text"><i class="bi bi-person-fill"></i></span>
+                                <input type="text" required="" class="form-control" id="email" {formname key=EMAIL} placeholder="{translate key=UsernameOrEmail}" />
+                            </div>
+                        {/if}
 
-						{if $ShowPasswordPrompt}
-							<div class="input-group mb-2">
-								<span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
-								<input type="password" required="" id="password" {formname key=PASSWORD}
-									class="form-control" value="" placeholder="{translate key=Password}" />
-							</div>
-						{/if}
+                        {if $ShowPasswordPrompt}
+                            <div class="input-group mb-2">
+                                <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
+                                <input type="password" required="" id="password" {formname key=PASSWORD} class="form-control" value="" placeholder="{translate key=Password}" />
+                            </div>
+                        {/if}
 
-						{if $EnableCaptcha}
-							<div class="text-center mb-2">
-								{control type="CaptchaControl"}
-							</div>
-						{else}
-							<input type="hidden" {formname key=CAPTCHA} value="" />
-						{/if}
+                        {if $EnableCaptcha}
+                            <div class="text-center mb-2">
+                                {control type="CaptchaControl"}
+                            </div>
+                        {else}
+                            <input type="hidden" {formname key=CAPTCHA} value="" />
+                        {/if}
 
-						{if $ShowUsernamePrompt &&  $ShowPasswordPrompt}
-							<div class="d-grid mb-2 mt-3">
-								<button type="submit" class="btn btn-primary btn-block" name="{Actions::LOGIN}"
-									value="submit">{translate key='LogIn'}</button>
-								<input type="hidden" {formname key=RESUME} value="{$ResumeUrl}" />
-							</div>
-						{/if}
+                        {if $ShowUsernamePrompt &&  $ShowPasswordPrompt}
+                            <div class="d-grid mb-2 mt-3">
+                                <button type="submit" class="btn btn-primary btn-block" name="{Actions::LOGIN}" value="submit">{translate key='LogIn'}</button>
+                                <input type="hidden" {formname key=RESUME} value="{$ResumeUrl}" />
+                            </div>
+                        {/if}
 
-						<div class="clearfix">
-							{if $ShowUsernamePrompt &&  $ShowPasswordPrompt}
-								<div class="float-start">
-									<div class="form-check">
-										<input class="form-check-input" id="rememberMe" type="checkbox"
-											{formname key=PERSIST_LOGIN}>
-										<label class="form-check-label" for="rememberMe">{translate key=RememberMe}</label>
-									</div>
-								</div>
-							{/if}
+                        <div class="clearfix">
+                            {if $ShowUsernamePrompt &&  $ShowPasswordPrompt}
+                                <div class="float-start">
+                                    <div class="form-check">
+                                        <input class="form-check-input" id="rememberMe" type="checkbox" {formname key=PERSIST_LOGIN}>
+                                        <label class="form-check-label" for="rememberMe">{translate key=RememberMe}</label>
+                                    </div>
+                                </div>
+                            {/if}
 
-							{if $ShowRegisterLink}
-								<div class="float-end register">
-									<span class="fw-bold">{translate key="FirstTimeUser?"}
-										<a class="link-primary" href="{$RegisterUrl}"
-											{if isset($RegisterUrlNew)}{$RegisterUrlNew}{/if}
-											title="{translate key=Register}">{translate key=Register}</a>
-									</span>
-								</div>
-							{/if}
-						</div>
+                            {if $ShowRegisterLink}
+                                <div class="float-end register">
+                                    <span class="fw-bold">{translate key="FirstTimeUser?"}
+                                        <a class="link-primary" href="{$RegisterUrl}" {if isset($RegisterUrlNew)}{$RegisterUrlNew}{/if} title="{translate key=Register}">{translate key=Register}</a>
+                                    </span>
+                                </div>
+                            {/if}
+                        </div>
 
-						<section class="d-flex justify-content-center flex-wrap gap-2 my-3 social-login">
-							{if $AllowGoogleLogin}
-								<a type="button" href="{$GoogleUrl}" class="btn btn-outline-primary"><i
-										class="bi bi-google me-1"></i>{translate key='SignInWith'}<span class="fw-medium">
-										Google</span></a>
-							{/if}
-							{if $AllowMicrosoftLogin}
-								<a type="button" href="{$MicrosoftUrl}" class="btn btn-outline-primary"><i
-										class="bi bi-microsoft me-1"></i>{translate key='SignInWith'}<span
-										class="fw-medium"> Microsoft</span></a>
-							{/if}
-							{if $AllowFacebookLogin}
-								<a type="button" href="{$FacebookUrl}" class="btn btn-outline-primary"><i
-										class="bi bi-facebook me-1"></i>{translate key='SignInWith'}<span class="fw-medium">
-										Facebook</span></a>
-							{/if}
-						</section>
-						{if $facebookError}
-							<p class="text-center my-3">
-								{translate key="FacebookLoginErrorMessage"} </p>
-						{/if}
-					</div>
-				</div>
-				<div id="login-footer" class="card-footer d-flex align-items-start justify-content-between">
-					{if $ShowForgotPasswordPrompt}
-						<div id="forgot-password">
-							<a href="{$ForgotPasswordUrl}" {if isset($ForgotPasswordUrlNew)}{$ForgotPasswordUrlNew}{/if}
-								class="link-primary"><span><i class="bi bi-question-circle-fill"></i></span>
-								{translate key='ForgotMyPassword'}</a>
-						</div>
-					{/if}
-					<div id="change-language" class="text-end">
-						<a type="button" class="link-primary" data-bs-toggle="collapse"
-							data-bs-target="#change-language-options"><span><i class="bi bi-globe-americas"></i></span>
-							{translate key=ChangeLanguage}
-						</a>
-						<div id="change-language-options" class="collapse">
-							<select {formname key=LANGUAGE} class="form-select form-select-sm" id="languageDropDown">
-								{object_html_options options=$Languages key='GetLanguageCode' label='GetDisplayName' selected=$SelectedLanguage}
-							</select>
-						</div>
-					</div>
-				</div>
-			</div>
+                        <section class="d-flex justify-content-center flex-wrap gap-2 my-3 social-login">
+                            {if $AllowGoogleLogin}
+                                <a type="button" href="{$GoogleUrl}" class="btn btn-outline-primary"><i class="bi bi-google me-1"></i>{translate key='SignInWith'}<span class="fw-medium">
+                                        Google</span></a>
+                            {/if}
+                            {if $AllowMicrosoftLogin}
+                                <a type="button" href="{$MicrosoftUrl}" class="btn btn-outline-primary"><i class="bi bi-microsoft me-1"></i>{translate key='SignInWith'}<span class="fw-medium"> Microsoft</span></a>
+                            {/if}
+                            {if $AllowFacebookLogin}
+                                <a type="button" href="{$FacebookUrl}" class="btn btn-outline-primary"><i class="bi bi-facebook me-1"></i>{translate key='SignInWith'}<span class="fw-medium">
+                                        Facebook</span></a>
+                            {/if}
+                            {if $AllowKeycloakLogin}
+                                <a type="button" href="{$KeycloakUrl}" class="btn btn-outline-primary">{translate key='SignInWith'}<span class="fw-medium">
+                                        Keycloak</span></a>
+                            {/if}
+                        </section>
+                        {if $facebookError}
+                            <p class="text-center my-3">
+                                {translate key="FacebookLoginErrorMessage"} </p>
+                        {/if}
+                    </div>
+                </div>
+                <div id="login-footer" class="card-footer d-flex align-items-start justify-content-between">
+                    {if $ShowForgotPasswordPrompt}
+                        <div id="forgot-password">
+                            <a href="{$ForgotPasswordUrl}" {if isset($ForgotPasswordUrlNew)}{$ForgotPasswordUrlNew}{/if} class="link-primary"><span><i class="bi bi-question-circle-fill"></i></span>
+                                {translate key='ForgotMyPassword'}</a>
+                        </div>
+                    {/if}
+                    <div id="change-language" class="text-end">
+                        <a type="button" class="link-primary" data-bs-toggle="collapse" data-bs-target="#change-language-options"><span><i class="bi bi-globe-americas"></i></span>
+                            {translate key=ChangeLanguage}
+                        </a>
+                        <div id="change-language-options" class="collapse">
+                            <select {formname key=LANGUAGE} class="form-select form-select-sm" id="languageDropDown">
+                                {object_html_options options=$Languages key='GetLanguageCode' label='GetDisplayName' selected=$SelectedLanguage}
+                            </select>
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-		</form>
-	</div>
+        </form>
+    </div>
 </div>
 
 {setfocus key='EMAIL'}
@@ -142,24 +133,24 @@
 {include file="javascript-includes.tpl"}
 
 <script type="text/javascript">
-	var url = 'index.php?{QueryStringKeys::LANGUAGE}=';
-	$(document).ready(function() {
-		$('#languageDropDown').change(function() {
-			window.location.href = url + $(this).val();
-		});
+    var url = 'index.php?{QueryStringKeys::LANGUAGE}=';
+    $(document).ready(function() {
+        $('#languageDropDown').change(function() {
+            window.location.href = url + $(this).val();
+        });
 
-		var langCode = readCookie('{CookieKeys::LANGUAGE}');
+        var langCode = readCookie('{CookieKeys::LANGUAGE}');
 
-		if (!langCode) {
-			langCode = (navigator.language + "").replace("-", "_").toLowerCase();
+        if (!langCode) {
+            langCode = (navigator.language + "").replace("-", "_").toLowerCase();
 
-			var availableLanguages = [{foreach from=$Languages item=lang}"{$lang->GetLanguageCode()}",{/foreach}];
-			if (langCode !== "" && langCode != '{$SelectedLanguage|lower}') {
-			if (availableLanguages.indexOf(langCode) !== -1) {
-				window.location.href = url + langCode;
-			}
-		}
-	}
-	});
+            var availableLanguages = [{foreach from=$Languages item=lang}"{$lang->GetLanguageCode()}",{/foreach}];
+            if (langCode !== "" && langCode != '{$SelectedLanguage|lower}') {
+            if (availableLanguages.indexOf(langCode) !== -1) {
+                window.location.href = url + langCode;
+            }
+        }
+    }
+    });
 </script>
 {include file='globalfooter.tpl'}


### PR DESCRIPTION
based on the scheme used for Google and Microsoft external auth, I added a keycloak provider that enables oauth through a keycloak instance.

Config for keycloak requires the following values

$conf['settings']['authentication']['keycloak.url'] = '';
$conf['settings']['authentication']['keycloak.realm'] = '';
$conf['settings']['authentication']['keycloak.client.id'] = '';
$conf['settings']['authentication']['keycloak.client.secret'] = '';
$conf['settings']['authentication']['keycloak.client.uri'] = '/Web/keycloak-auth.php';

Keycloak Configuration:

- Create (or use an existing) realm (e.g., “LibreBooking”) dedicated to your application.
- Client ID: Set to (for example) librebooking.
- Access Type: Set to confidential (this enables client authentication using a client secret).
- Standard Flow Enabled: Must be enabled (authorization code flow).
- Direct Access Grants/Implicit Flow: Disable these for enhanced security.
- to get title, phone number and organization mapping to user profile, the client scope should be set