### PR TITLE
Make deployment in openshift possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ lang/*/*-custom.tpl
 !/Web/uploads/images/index.html
 /Web/uploads/tos/*
 !/Web/uploads/tos/index.html
+/Web/uploads/theme/*
+!/Web/uploads/theme/index.html
 
 /Web/test-embed.html
 

--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -5,11 +5,14 @@ if (file_exists(ROOT_DIR . 'vendor/autoload.php')) {
     require ROOT_DIR . 'vendor/autoload.php';
 }
 
+
 require_once(ROOT_DIR . 'Pages/IPage.php');
 require_once(ROOT_DIR . 'Pages/Pages.php');
+require_once(ROOT_DIR . 'lib/FileSystem/namespace.php');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
 require_once(ROOT_DIR . 'lib/Server/namespace.php');
 require_once(ROOT_DIR . 'lib/Config/namespace.php');
+
 require_once(ROOT_DIR . 'lib/external/MobileDetect/Mobile_Detect.php');
 
 abstract class Page implements IPage
@@ -91,19 +94,26 @@ abstract class Page implements IPage
         $this->smarty->assign('cssTheme', (Configuration::Instance()->GetKey(ConfigKeys::CSS_THEME) ?? 'default'));
 
         $this->smarty->assign('LogoUrl', 'librebooking.png');
-        if (file_exists($this->path . 'img/custom-logo.png')) {
-            $this->smarty->assign('LogoUrl', 'custom-logo.png');
-        }
-        if (file_exists($this->path . 'img/custom-logo.gif')) {
-            $this->smarty->assign('LogoUrl', 'custom-logo.gif');
-        }
-        if (file_exists($this->path . 'img/custom-logo.jpg')) {
-            $this->smarty->assign('LogoUrl', 'custom-logo.jpg');
+        $this->smarty->assign('LogoPath', $this->path .  "img");
+
+        // custom logo
+        foreach ( ['.png', '.gif', '.jpg'] as $extension){
+            if (file_exists($this->path . 'img/custom-logo' . $extension)) {
+                $this->smarty->assign('LogoUrl', 'custom-logo' . $extension);
+                break;
+            }
+            if (file_exists(Paths::Theme() . 'custom-logo' . $extension)) {
+                $this->smarty->assign('LogoPath', Paths::Theme());
+                $this->smarty->assign('LogoUrl', 'custom-logo.png');
+
+                break;
+            }
         }
 
         $this->smarty->assign('CssUrl', 'null-style.css');
-        if (file_exists($this->path . 'css/custom-style.css')) {
-            $this->smarty->assign('CssUrl', 'custom-style.css');
+        if (file_exists(Paths::Theme() . 'custom-style.css')) {
+            $this->smarty->assign('CssUrl',  'custom-style.css');
+            $this->smarty->assign('CssPath', Paths::Theme());
         }
 
         $stylingFactory = PluginManager::Instance()->LoadStyling();
@@ -112,17 +122,19 @@ abstract class Page implements IPage
         }
 
         $this->smarty->assign('FaviconUrl', 'favicon.ico');
-        if (file_exists($this->path . 'custom-favicon.png')) {
-            $this->smarty->assign('FaviconUrl', 'custom-favicon.png');
-        }
-        if (file_exists($this->path . 'custom-favicon.gif')) {
-            $this->smarty->assign('FaviconUrl', 'custom-favicon.gif');
-        }
-        if (file_exists($this->path . 'custom-favicon.jpg')) {
-            $this->smarty->assign('FaviconUrl', 'custom-favicon.jpg');
-        }
-        if (file_exists($this->path . 'custom-favicon.ico')) {
-            $this->smarty->assign('FaviconUrl', 'custom-favicon.ico');
+        $this->smarty->assign('FaviconPath', $this->path);
+
+        // custom favicon
+        foreach ( ['.png', '.gif', '.jpg','.ico'] as $extension){
+            if (file_exists($this->path . 'img/custom-favicon' . $extension)) {
+                $this->smarty->assign('FaviconUrl', 'custom-favicon' . $extension);
+                break;
+            }
+            if (file_exists(Paths::Theme() . 'custom-favicon' . $extension)) {
+                $this->smarty->assign('FaviconUrl', 'custom-favicon' . $extension);
+                $this->smarty->assign('FaviconPath', Paths::Theme());
+                break;
+            }
         }
 
         $logoUrl = Configuration::Instance()->GetKey(ConfigKeys::HOME_URL);

--- a/Presenters/Admin/ManageConfigurationPresenter.php
+++ b/Presenters/Admin/ManageConfigurationPresenter.php
@@ -51,7 +51,7 @@ class ManageConfigurationPresenter extends ActionPresenter
         parent::__construct($page);
         $this->page = $page;
         $this->configSettings = $settings;
-        $this->configFilePath = ROOT_DIR . 'config/config.php';
+        $this->configFilePath = Configuration::Instance()->GetConfigFilePath();
         $this->configFilePathDist = ROOT_DIR . 'config/config.dist.php';
 
         $this->AddAction(ConfigActions::Update, 'Update');

--- a/Presenters/Admin/ManageThemePresenter.php
+++ b/Presenters/Admin/ManageThemePresenter.php
@@ -30,7 +30,7 @@ class ManageThemePresenter extends ActionPresenter
 
             $this->RemoveLogo();
 
-            $target = ROOT_DIR . 'Web/img/custom-logo.' . $logoFile->Extension();
+            $target = Paths::Theme() . 'custom-logo.' . $logoFile->Extension();
             $copied = copy($logoFile->TemporaryName(), $target);
             if (!$copied) {
                 Log::Error(
@@ -42,7 +42,7 @@ class ManageThemePresenter extends ActionPresenter
         }
         if ($cssFile != null) {
             Log::Debug('Replacing css file with ' . $cssFile->OriginalName());
-            $target = ROOT_DIR . 'Web/css/custom-style.css';
+            $target = Paths::Theme() . 'custom-style.css';
             $copied = copy($cssFile->TemporaryName(), $target);
             if (!$copied) {
                 Log::Error(
@@ -57,7 +57,7 @@ class ManageThemePresenter extends ActionPresenter
 
             $this->RemoveFavicon();
 
-            $target = ROOT_DIR . 'Web/custom-favicon.' . $favicon->Extension();
+            $target = Paths::Theme() . 'custom-favicon.' . $favicon->Extension();
             $copied = copy($favicon->TemporaryName(), $target);
             if (!$copied) {
                 Log::Error(
@@ -72,7 +72,7 @@ class ManageThemePresenter extends ActionPresenter
     public function RemoveLogo()
     {
         try {
-            $targets = glob(ROOT_DIR . 'Web/img/custom-logo.*');
+            $targets = array_merge(glob(ROOT_DIR . 'Web/img/custom-logo.*'), glob(PATHS::Theme() . 'custom-logo.*'));
             foreach ($targets as $target) {
                 $removed = unlink($target);
                 if (!$removed) {
@@ -87,7 +87,7 @@ class ManageThemePresenter extends ActionPresenter
     public function RemoveFavicon()
     {
         try {
-            $targets = glob(ROOT_DIR . 'Web/custom-favicon.*');
+            $targets = array_merge(glob(ROOT_DIR . 'Web/custom-favicon.*'), glob(PATHS::Theme() . 'custom-favicon.*'));
             foreach ($targets as $target) {
                 $removed = unlink($target);
                 if (!$removed) {
@@ -102,7 +102,7 @@ class ManageThemePresenter extends ActionPresenter
     public function RemoveCss()
     {
         try {
-            $targets = glob(ROOT_DIR . 'Web/css/custom-style.css');
+            $targets = array_merge(glob(ROOT_DIR . 'Web/css/custom-style.css'), glob(PATHS::Theme() . 'custom-style.css'));
             foreach ($targets as $target) {
                 $removed = unlink($target);
                 if (!$removed) {

--- a/Web/index.php
+++ b/Web/index.php
@@ -2,9 +2,9 @@
 
 define('ROOT_DIR', '../');
 
-if (!file_exists(ROOT_DIR . 'config/config.php')) {
-    die('Missing config/config.php. Please refer to the installation instructions.');
-}
+require_once(ROOT_DIR . 'lib/Config/Configuration.php');
+
+Configuration::Instance()->Validate();
 
 require_once(ROOT_DIR . 'Pages/LoginPage.php');
 require_once(ROOT_DIR . 'Presenters/LoginPresenter.php');

--- a/build.xml
+++ b/build.xml
@@ -93,6 +93,7 @@
                 <!-- user files -->
                 <exclude name="**/uploads/images/*" />
                 <exclude name="**/uploads/reservation/*" />
+                <exclude name="**/uploads/theme/*" />
                 <!-- asset resources -->
                 <exclude name="**.psd" />
                 <exclude name="**.bak" />

--- a/lib/Common/SmartyPage.php
+++ b/lib/Common/SmartyPage.php
@@ -127,6 +127,7 @@ class SmartyPage extends Smarty
         $this->registerPlugin('function', 'format_date', [$this, 'FormatDate']);
         $this->registerPlugin('function', 'html_link', [$this, 'PrintLink']);
         $this->registerPlugin('function', 'html_image', [$this, 'PrintImage']);
+        $this->registerPlugin('function', 'html_favicon', [$this, 'PrintFavicon']);
         $this->registerPlugin('function', 'control', [$this, 'DisplayControl']);
         $this->registerPlugin('function', 'validator', [$this, 'Validator']);
         $this->registerPlugin('function', 'textbox', [$this, 'Textbox']);
@@ -221,7 +222,13 @@ class SmartyPage extends Smarty
 
     public function PrintLink($params, $smarty)
     {
+        $icon = isset($params['icon']) ? $params['icon'] : 'bi-people-fill';
+
         $string = $this->Resources->GetString($params['key']);
+        if (isset($params['text'])){
+            $string = $params['text'];
+        }
+
         if (!isset($params['title'])) {
             $title = $string;
         } else {
@@ -237,7 +244,7 @@ class SmartyPage extends Smarty
         $knownAttributes = ['key', 'title', 'href'];
         $attributes = $this->AppendAttributes($params, $knownAttributes);
 
-        return "<a href=\"$href\" class=\"link-primary\" title=\"$title\" $attributes><i class=\"bi bi-people-fill me-1\"></i>$string</a>";
+        return "<a href=\"$href\" class=\"link-primary\" title=\"$title\" $attributes><i class=\"bi $icon me-1\"></i>$string</a>";
     }
 
     public function SmartyTranslate($params, $smarty)
@@ -280,13 +287,32 @@ class SmartyPage extends Smarty
         return $formatted;
     }
 
+    public function PrintFavicon($params, $smarty){
+
+        $favicon = isset($params['favicon']) ? $params['favicon'] : '';
+        $path = isset($params['path']) ? $params['path'] : '';
+
+        return "<link rel=\"shortcut icon\" href=\"$path$favicon\" />" . PHP_EOL
+        . "<link rel=\"icon\" href=\"$path$favicon\" />";
+    }
+
     public function PrintImage($params, $smarty)
     {
         $alt = isset($params['alt']) ? $params['alt'] : '';
         $altKey = isset($params['altKey']) ? $params['altKey'] : '';
         $width = isset($params['width']) ? $params['width'] : '';
         $height = isset($params['height']) ? $params['height'] : '';
-        $imgPath = sprintf('%simg/%s', $this->RootPath, $params['src']);
+        
+        $file = isset($params['file']) ? $params['file'] : '';
+        $path = isset($params['path']) ? $params['path'] : '';
+        
+        if (isset($file) && isset($path)){
+            $imgPath = $path.'/'.$file;
+            unset($params['file']);
+            unset($params['path']);
+        } else {
+            $imgPath = sprintf('%simg/%s', $this->RootPath, $params['src']);
+        }
 
         $knownAttributes = ['alt', 'width', 'height', 'src', 'title', 'altKey'];
         $attributes = $this->AppendAttributes($params, $knownAttributes);

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -63,6 +63,16 @@ interface IConfigurationFile
     public function GetAdminEmail();
 
     public function EnableSubscription();
+
+    /**
+     * @return string
+     */
+    public function GetConfigFilePath();
+
+    /**
+     * do nothing or die
+     */
+    public function Validate();
 }
 
 class Configuration implements IConfiguration
@@ -83,9 +93,7 @@ class Configuration implements IConfiguration
 
     public const VERSION = '2.8.6.2';
 
-    protected function __construct()
-    {
-    }
+    protected function __construct() {}
 
     /**
      * @return IConfigurationFile
@@ -95,12 +103,32 @@ class Configuration implements IConfiguration
         if (self::$_instance == null) {
             self::$_instance = new Configuration();
             self::$_instance->Register(
-                dirname(__FILE__) . '/../../' . self::DEFAULT_CONFIG_FILE_PATH,
+                self::$_instance->getConfigFilePath(),
                 self::DEFAULT_CONFIG_ID
             );
         }
 
         return self::$_instance;
+    }
+
+    public function GetConfigFilePath()
+    {
+
+        $env = getenv(strtoupper(self::DEFAULT_CONFIG_ID) . '_CONFIG_FILE');
+
+        if (!empty($env)) {
+            return dirname(__FILE__) . '/../../' . $env;
+        }
+
+        return dirname(__FILE__) . '/../../' . self::DEFAULT_CONFIG_FILE_PATH;
+    }
+
+    public function Validate()
+    {
+        if (empty($this->_configs[self::DEFAULT_CONFIG_ID])) {
+
+            die('Missing configuration file. Please refer to the installation instructions.');
+        }
     }
 
     public static function SetInstance($value)
@@ -199,6 +227,14 @@ class ConfigurationFile implements IConfigurationFile
         if (array_key_exists($keyName, $this->_values)) {
             return $this->Convert($this->_values[$keyName], $converter);
         }
+        return null;
+    }
+
+    public function Validate(){
+        //  do nothing
+    }
+
+    public function GetConfigFilePath(){
         return null;
     }
 

--- a/lib/FileSystem/Paths.php
+++ b/lib/FileSystem/Paths.php
@@ -55,6 +55,16 @@ class Paths
      */
     public static function Theme()
     {
+        $themeDir = dirname(__FILE__) . '/' . ROOT_DIR . 'Web/uploads/theme';
+        if (!is_dir($themeDir)) {
+            Log::Debug('Could not find directory %s. Attempting to create it', $themeDir);
+            $created = mkdir($themeDir);
+            if ($created) {
+                Log::Debug('Created %s', $themeDir);
+            } else {
+                Log::Debug('Could not create %s', $themeDir);
+            }
+        }
         return ROOT_DIR . 'Web/uploads/theme/';
     }
 

--- a/lib/FileSystem/Paths.php
+++ b/lib/FileSystem/Paths.php
@@ -47,6 +47,17 @@ class Paths
         return ROOT_DIR . 'Web/uploads/tos/';
     }
 
+     /**
+     * Filesystem directory for storing theme files (logo, favicon, css)
+     *
+     * @static
+     * @return string
+     */
+    public static function Theme()
+    {
+        return ROOT_DIR . 'Web/uploads/theme/';
+    }
+
     /**
      * Filesystem directory for storing terms of email templates for given language. Always contains trailing slash
      *

--- a/tpl/Admin/Configuration/change_theme.tpl
+++ b/tpl/Admin/Configuration/change_theme.tpl
@@ -26,10 +26,9 @@
 
                     <li class="list-group-item">
                         <h4>{translate key="Logo"} (*.png, *.gif, *.jpg - Recommended height 75px)</h4>
-                        <img src="{$ScriptUrl}/img/{$LogoUrl}" class="d-block mx-auto mw-100" />
+                         {html_image file="$LogoUrl?{$Version}" path="{$ScriptUrl}{$LogoPath}" alt="$Title" class="d-block mx-auto mw-100" }
                         <div class="d-flex align-items-center justify-content-center my-2">
-                            <a href="{$ScriptUrl}/img/{$LogoUrl}" download="{$ScriptUrl}/img/{$LogoUrl}"
-                                class="link-primary"><i class="bi bi-download me-1"></i>{$LogoUrl}</a>
+                            {html_link text="{$LogoUrl}" href="{$ScriptUrl}{$LogoPath}{$LogoUrl}?{$Version}" download="{$ScriptUrl}{$LogoPath}{$LogoUrl}?{$Version}" class="link-primary" icon="bi-download" }
                             <div class="vr mx-1"></div>
                             <a href="#" id="removeLogo" class="link-danger text-decoration-none"><i
                                     class="bi bi-trash3-fill me-1"></i>{translate key=Remove}</a>
@@ -45,10 +44,9 @@
 
                     <li class="list-group-item">
                         <h4>Favicon (*.ico, *.png, *.gif, *.jpg - Recommended size 48px x 48px)</h4>
-                        <img src="{$ScriptUrl}/{$FaviconUrl}" class="d-block mx-auto" />
+                        {html_image file="$FaviconUrl" path="{$ScriptUrl}{$FaviconPath}" alt="$Title" class="d-block mx-auto"}
                         <div class="d-flex align-items-center justify-content-center my-2">
-                            <a href="{$ScriptUrl}/{$FaviconUrl}" download="{$ScriptUrl}/img/{$FaviconUrl}"
-                                class="link-primary"><i class="bi bi-download me-1"></i>{$FaviconUrl}</a>
+                            {html_link text="{$FaviconUrl}" href="{$ScriptUrl}{$FaviconPath}{$FaviconUrl}" download="{$ScriptUrl}{$FaviconPath}{$FaviconUrl}" class="link-primary" icon="bi-download" }
                             <div class="vr mx-1"></div>
                             <a href="#" id="removeFavicon" class="link-danger text-decoration-none"><i
                                     class="bi bi-trash3-fill me-1"></i>{translate key=Remove}</a>
@@ -65,13 +63,14 @@
                     <li class="list-group-item">
                         <div>
                             <h4>{translate key="CssFile"} (*.css)</h4>
+                            {if isset($CssUrl) && $CssUrl neq 'null-style.css'}
                             <div class="d-flex align-items-center justify-content-center my-2">
-                                <a href="{$ScriptUrl}/css/{$CssUrl}" download="{$ScriptUrl}/css/{$CssUrl}"
-                                    class="link-primary"><i class="bi bi-download me-1"></i>{$CssUrl}</a>
+                                {html_link text="{$CssUrl}" href="{$ScriptUrl}{$CssPath}{$CssUrl}" download="{$ScriptUrl}{$CssPath}{$CssUrl}" class="link-primary" icon="bi-download" }
                                 <div class="vr mx-1"></div>
                                 <a href="#" id="removeCss" class="link-danger text-decoration-none"><i
                                         class="bi bi-trash3-fill me-1"></i>{translate key=Remove}</a>
                             </div>
+                            {/if}
                         </div>
                         <div class="input-group input-group-sm">
                             <input type="file" {formname key=CSS_FILE} class="form-control" id="cssFile"

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -10,8 +10,7 @@
         <meta http-equiv="REFRESH"
             content="{$SessionTimeoutSeconds};URL={$Path}logout.php?{QueryStringKeys::REDIRECT}={$smarty.server.REQUEST_URI|urlencode}" />
     {/if}
-    <link rel="shortcut icon" href="{$Path}{$FaviconUrl}" />
-    <link rel="icon" href="{$Path}{$FaviconUrl}" />
+    {html_favicon path="$FaviconPath" favicon="$FaviconUrl"}
     <!-- JavaScript -->
     {if isset($UseLocalJquery) && $UseLocalJquery}
         {jsfile src="js/jquery-3.3.1.min.js"}
@@ -88,8 +87,9 @@
             {cssfile src=$cssFile}
         {/foreach}
     {/if}
-    {if isset($CssUrl) && $CssUrl neq ''}
-        {cssfile src=$CssUrl}
+    {if isset($CssUrl) && $CssUrl neq '' && $CssUrl neq 'null-style.css' }
+        {assign var='CssFullUrl' value= $CssPath|cat:$CssUrl}
+        {cssfile src=$CssFullUrl}
     {/if}
     {if isset($CssStylingFile) && $CssStylingFile neq ''}
         {cssfile src='styling-plugin.php'}
@@ -119,7 +119,7 @@
     {if !isset($HideNavBar) || $HideNavBar == false}
         <div class="d-flex align-items-center gap-2 m-2">
             <a class="navbar-brand" href="{$HomeUrl}">
-                {html_image src="$LogoUrl?{$Version}" alt="$Title" class="logo"}
+                {html_image file="$LogoUrl?{$Version}" path="$LogoPath" alt="$Title" class="logo"}
             </a>
             <div class="border-start ps-2 d-flex flex-column">
                 {if $CompanyName neq ''}
@@ -130,7 +130,7 @@
         </div>
         <nav class="navbar navbar-expand-lg bg-light shadow-sm py-2 sticky-top">
             <div class="container-fluid">
-                {*<a class="navbar-brand py-0" href="{$HomeUrl}">{html_image src="$LogoUrl?{$Version}" alt="$Title"
+                {*<a class="navbar-brand py-0" href="{$HomeUrl}">{html_image path="$logoPath" file="$LogoUrl"?{$Version}" alt="$Title"
                     class="logo"}</a>*}
                 <button type="button" class="navbar-toggler" data-bs-toggle="collapse"
                     data-bs-target="#librebooking-navigation">

--- a/tpl/login.tpl
+++ b/tpl/login.tpl
@@ -24,7 +24,7 @@
                 <div class="card-body mx-3">
                     <div id="login-box" class="default-box">
                         <div class="login-icon my-2">
-                            {html_image src="$LogoUrl?{$Version}" alt="$Title" class="mx-auto d-block w-50"}
+                            {html_image file="$LogoUrl?{$Version}" path="$LogoPath" alt="$Title" class="mx-auto d-block w-50"}
                         </div>
 
                         {if $ShowLoginError}


### PR DESCRIPTION
When deploying application to OpenShift, you have to keep in mind that files saved on container instance (pod) are not persisted by design. So that if you deploy a new version of the application, then modification are lost.

To avoid this problem, you can use a remote distributed filesystem (nfs, s3...) or use a persistent volume. 

The difficulty with Librebooking is that  files like (logo, favicon or css are stored in different path and near static files. Persistent volume are directories and not file. So, it's important to save this file in dedicated directories.  Commit 67e43cf use uploads/theme directory to save these three files. 

Because persistent volume are directories, config.php have to be placed in a dedicated directories, so that others configuration file in config/ directory are not hidden by the persistent volume. The commit f148916 allow to define an environment variable LIBREBOOKING_CONFIG_FILE to define the path of the config.php file.