### PR TITLE
ci: add a 'stale' automatic workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+# https://github.com/actions/stale
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9.1.0
+        with:
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          exempt-assignees: 'effgarces'
+
+          any-of-labels: 'need info,stale'
+          stale-issue-message: >
+            This issue was marked stale because it has been open 60 days with no
+            activity. Please remove the stale label or comment on this issue. Otherwise,
+            it will be closed in 15 days.
+          days-before-issue-stale: 60
+          days-before-issue-close: 15
+          close-issue-message: >
+            This issue was closed because it has been marked stale for 15 days with no
+            activity. If this issue is still valid, please re-open.
+
+          stale-pr-message: >
+            This Pull Request (PR) was marked stale because it has been open 90 days
+            with no activity.  Please remove the stale label or comment on this PR.
+            Otherwise, it will be closed in 15 days.
+          days-before-pr-stale: 90
+          days-before-pr-close: 15
+          close-pr-message: >
+            This PR was closed because it has been marked stale for 15 days with no
+            activity. If this PR is still valid, please re-open.
+


### PR DESCRIPTION
This will mark issues and PRs as stale if no activity occurs on them.

Rules are:
  * Mark Issue stale if no activity for 60 days or more
  * Mark PRs stale if no activity for 90 days or more
  * If Issue or PR has been marked stale for 15 days or more it will be closed.

If someone makes a comment on an issue/PR then the stale label will be removed and the clock will reset.