### PR TITLE
chore(stale): increase operations-per-run value

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,6 +21,7 @@ jobs:
           stale-issue-label: "stale"
           stale-pr-label: "stale"
           exempt-assignees: 'effgarces'
+          operations-per-run: 500  # API calls per run, allowed 5000 per hour.
 
           stale-issue-message: >
             This issue was marked stale because it has been open 60 days with no


### PR DESCRIPTION
With the default value of 30 it would only process about 16 issues and those were ones it had processed previously. So no actions were being taken. Increase to 500. There is an API limit of 5000 per hour.