### PR TITLE
chore: update composer.json and validate it in CI

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["8.2", "8.3"]
+        php-version: ["8.2", "8.3", "8.4"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["8.1"]
+        php-version: ["8.1", "8.2"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -78,17 +78,19 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
-      # TODO: Enable this after resolving issues
-      # - name: Validate composer.json and composer.lock
-      #   run: composer validate --strict
-
       - name: Install Composer dependencies
-        # Allow the previous check to fail but not abort
-        if: always()
         uses: ramsey/composer-install@v2
         with:
           # Ignore zip for php-webdriver/webdriver
           composer-options: "--ignore-platform-reqs"
+
+      - name: Update the composer.lock file
+        if: matrix.php-version > '8.1'
+        run: composer update
+
+      - name: Validate composer.json and composer.lock
+        if: matrix.php-version > '8.1'
+        run: composer validate --strict
 
       # TODO: Enable this after resolving issues
       # - name: Cache coding-standard
@@ -100,8 +102,6 @@ jobs:
       #     key: phpcs-cache
 
       - name: Lint PHP files
-        # Allow the previous check to fail but not abort
-        if: always()
         run: ./ci/ci-phplint
 
       # TODO: Enable this after resolving issues

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,7 @@
 {
+    "name": "librebooking/librebooking",
     "description": "LibreBooking",
+    "license": "GPL-3.0-only",
     "autoload": {},
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7.1",
@@ -12,7 +14,7 @@
         "smarty/smarty": "^4.5",
         "stripe/stripe-php": "^10.2",
         "monolog/monolog": "^2.9",
-        "google/recaptcha": "1.2.4",
+        "google/recaptcha": "1.2.*",
         "gregwar/captcha": "1.*",
         "google/apiclient": "^2.0",
         "microsoft/microsoft-graph": "^2.0",
@@ -45,7 +47,8 @@
     },
     "config": {
         "allow-plugins": {
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "tbachert/spi": true
         }
     }
 }


### PR DESCRIPTION
When running with PHP 8.2 or newer, validate `composer.json`.

phpunit >= 11.3 requires PHP 8.2 or newer. This will cause the
`composer validate --strict` to fail with PHP 8.1

Also start running phpunit tests with PHP 8.4