### PR TITLE
chore: remove usage of deprecated `E_STRICT`

### DIFF
--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -1,7 +1,7 @@
 <?php
 
 mysqli_report(MYSQLI_REPORT_OFF);
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
+error_reporting(E_ALL & ~E_NOTICE);
 //ini_set('display_errors', 1);
 //ini_set('display_startup_errors', 1);
 
@@ -211,5 +211,5 @@ $conf['settings']['registration']['require.organization'] = 'false';
  * Error logging
  */
 $conf['settings']['logging']['folder'] = '/var/log/librebooking/log'; //Absolute path to folder were the log will be written, writing permissions to the folder are required
-$conf['settings']['logging']['level'] = 'debug'; //Set to none disable logs, error to only log errors or debug to log all messages to the app.log file 
+$conf['settings']['logging']['level'] = 'debug'; //Set to none disable logs, error to only log errors or debug to log all messages to the app.log file
 $conf['settings']['logging']['sql'] = 'false'; //Set to true no enable the creation of and sql.log file

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -1,7 +1,7 @@
 <?php
 
 mysqli_report(MYSQLI_REPORT_OFF);
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);
+error_reporting(E_ALL & ~E_NOTICE);
 //ini_set('display_errors', 1);
 //ini_set('display_startup_errors', 1);
 

--- a/lib/Config/Configurator.php
+++ b/lib/Config/Configurator.php
@@ -120,7 +120,7 @@ class Configurator implements IConfigurationSettings
             return;
         }
         $contents = file_get_contents($file);
-        $new = str_replace("<?php", "<?php\r\nmysqli_report(MYSQLI_REPORT_OFF);\r\nerror_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);\r\n", $contents);
+        $new = str_replace("<?php", "<?php\r\nmysqli_report(MYSQLI_REPORT_OFF);\r\nerror_reporting(E_ALL & ~E_NOTICE);\r\n", $contents);
 
         file_put_contents($file, $new);
     }

--- a/tpl/Install/configure.tpl
+++ b/tpl/Install/configure.tpl
@@ -39,7 +39,7 @@
 
                 <div class="alert alert-secondary" style="font-family: courier;">
                     &lt;?php<br />
-                    error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT);<br />
+                    error_reporting(E_ALL & ~E_NOTICE);<br />
                     {$ManualConfig|nl2br}
                     ?&gt;
                 </div>


### PR DESCRIPTION
Since PHP 8.0, all E_STRICT notices have changed to E_NOTICE.

https://php.watch/versions/8.4/E_STRICT-deprecated