### PR TITLE
chore: enable error reporting for `config.devel.php`

### DIFF
--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -2,8 +2,8 @@
 
 mysqli_report(MYSQLI_REPORT_OFF);
 error_reporting(E_ALL & ~E_NOTICE);
-//ini_set('display_errors', 1);
-//ini_set('display_startup_errors', 1);
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
 
 /**
  * Application configuration


### PR DESCRIPTION
When doing development it is useful to see all the error messages. The `config.dist.php` file still leaves it disabled.