### PR TITLE
chore: fix deprecated message in unit tests.

### DIFF
--- a/Domain/Values/ReservationStartTimeConstraint.php
+++ b/Domain/Values/ReservationStartTimeConstraint.php
@@ -12,9 +12,9 @@ class ReservationStartTimeConstraint
      * @param string $startTimeConstraint
      * @return bool
      */
-    public static function IsCurrent($startTimeConstraint)
+    public static function IsCurrent(string|null $startTimeConstraint)
     {
-        return strtolower($startTimeConstraint) == self::CURRENT;
+        return strtolower($startTimeConstraint ?? "") == self::CURRENT;
     }
 
     /**
@@ -22,9 +22,9 @@ class ReservationStartTimeConstraint
      * @param string $startTimeConstraint
      * @return bool
      */
-    public static function IsNone($startTimeConstraint)
+    public static function IsNone(string|null $startTimeConstraint)
     {
-        return strtolower($startTimeConstraint) == self::NONE;
+        return strtolower($startTimeConstraint ?? "") == self::NONE;
     }
 
     /**
@@ -32,8 +32,8 @@ class ReservationStartTimeConstraint
      * @param string $startTimeConstraint
      * @return bool
      */
-    public static function IsFuture($startTimeConstraint)
+    public static function IsFuture(string|null $startTimeConstraint)
     {
-        return strtolower($startTimeConstraint) == self::FUTURE;
+        return strtolower($startTimeConstraint ?? "") == self::FUTURE;
     }
 }


### PR DESCRIPTION
Saw the following error when running `phpunit`

PHP Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in librebooking/Domain/Values/ReservationStartTimeConstraint.php on line 17