### PR TITLE
chore: make the resource name field wider in the schedule view

### DIFF
--- a/Web/css/booked.css
+++ b/Web/css/booked.css
@@ -1157,7 +1157,7 @@ table.reservations td.resourcename a:hover {
   color: #3BA3D0;
 }
 table.reservations td.resdate {
-  width: 150px;
+  width: 500px;
   padding: 0 3px;
   background-color: #36648B;
   color: #F0F0F0;


### PR DESCRIPTION
In the schedule, longer resource names would get cutoff previously.