### PR TITLE
chore(resource creation): don't grant access by default

### DIFF
--- a/tpl/Admin/Resources/manage_resources.tpl
+++ b/tpl/Admin/Resources/manage_resources.tpl
@@ -646,8 +646,8 @@
 						<div class="form-group mb-2">
 							<label class="fw-bold" for="permissions">{translate key='ResourcePermissions'}</label>
 							<select class="form-select" {formname key=AUTO_ASSIGN} id="permissions">
-								<option value="1">{translate key="ResourcePermissionAutoGranted"}</option>
 								<option value="0">{translate key="ResourcePermissionNotAutoGranted"}</option>
+								<option value="1">{translate key="ResourcePermissionAutoGranted"}</option>
 							</select>
 						</div>
 						<div class="form-group mb-2">


### PR DESCRIPTION
Now when adding a resource, the default in the dropdown menu will be to not grant access to a resource. The admin can select in the dropdown menu to grant access.

This helps to prevent inadvertently creating resources that will then be available to users.