### PR TITLE
test: default timezone must be 'America/Chicago' for unit tests

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Create config.php for unit tests
         run: cp config/config.dist.php config/config.php
 
+      - name: Change timezone to 'America/Chicago' in config.php
+        run: sed -i 's+Etc/UTC+America/Chicago+g' config/config.php
+
       - name: Unit Tests
         run: composer phpunit
 

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -10,3 +10,8 @@ require_once(ROOT_DIR . 'tests/TestBase.php');
 
 require_once(ROOT_DIR . 'tests/fakes/namespace.php');
 require_once(ROOT_DIR . 'lib/Common/Helpers/namespace.php');
+
+if (Configuration::Instance()->GetDefaultTimezone() != "America/Chicago") {
+  echo "\nERROR: Default timezone in 'config/config.php' must be 'America/Chicago in order to run unit tests.\n";
+  exit(1);
+}


### PR DESCRIPTION
There can be failures in the unit tests at certain times if the default timezone in `config.php` isn't "America/Chicago".

Use "America/Chicago" in the CI and fail `phpunit` early if `config.php` has a different value.

Closes: #544