### PR TITLE
Revert "test: default timezone must be 'America/Chicago' for unit tests"

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -61,9 +61,6 @@ jobs:
       - name: Create config.php for unit tests
         run: cp config/config.dist.php config/config.php
 
-      - name: Change timezone to 'America/Chicago' in config.php
-        run: sed -i 's+Etc/UTC+America/Chicago+g' config/config.php
-
       - name: Unit Tests
         run: composer phpunit
 

--- a/tests/autoload.php
+++ b/tests/autoload.php
@@ -10,8 +10,3 @@ require_once(ROOT_DIR . 'tests/TestBase.php');
 
 require_once(ROOT_DIR . 'tests/fakes/namespace.php');
 require_once(ROOT_DIR . 'lib/Common/Helpers/namespace.php');
-
-if (Configuration::Instance()->GetDefaultTimezone() != "America/Chicago") {
-  echo "\nERROR: Default timezone in 'config/config.php' must be 'America/Chicago in order to run unit tests.\n";
-  exit(1);
-}


### PR DESCRIPTION
This reverts commit 0deefef584e2ab6d1ff5867a1ba56f4616df4ec3.

Unfortunately this was not a complete fix for the issue.