### PR TITLE
chore: fix deprecation warning

### DIFF
--- a/lib/Common/Validators/URI/ParamsValidator.php
+++ b/lib/Common/Validators/URI/ParamsValidator.php
@@ -13,7 +13,7 @@ class ParamsValidator
     public static function validate(array $params, string $requestURI, bool $optional): bool
     {
         // Parse query string from the URI into an array
-        $query = parse_url($requestURI, PHP_URL_QUERY);
+        $query = parse_url($requestURI, PHP_URL_QUERY) ?? '';
         parse_str($query, $queryParams);
 
         // If there are no query parameters


### PR DESCRIPTION
Deprecated: parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in lib/Common/Validators/URI/ParamsValidator.php on line 17