### PR TITLE
Resolve #558: Enable configurable mobile views and auto-scroll

### DIFF
--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -132,15 +132,22 @@ abstract class Page implements IPage
         }
         $this->smarty->assign('HomeUrl', $logoUrl);
 
-        $detect = new MobileDetect();
-        $this->IsMobile = $detect->isMobile();
-        $this->IsTablet = $detect->isTablet();
+        $loadMobileViews = Configuration::Instance()->GetSectionKey(ConfigSection::SCHEDULE, ConfigKeys::SCHEDULE_LOAD_MOBILE_VIEWS, new BooleanConverter()) ?? true;
+
+        if ($loadMobileViews) {
+            $detect = new MobileDetect();
+            $this->IsMobile = $detect->isMobile();
+            $this->IsTablet = $detect->isTablet();
+        }
+
         $this->IsDesktop = !$this->IsMobile && !$this->IsTablet;
-        $this->Set('IsMobile', $this->IsMobile);
-        $this->Set('IsTablet', $this->IsTablet);
-        $this->Set('IsDesktop', $this->IsDesktop);
+        $this->Set('IsMobile', (bool)$this->IsMobile);
+        $this->Set('IsTablet', (bool)$this->IsTablet);
+        $this->Set('IsDesktop', (bool)$this->IsDesktop);
         $this->Set('GoogleAnalyticsTrackingId', Configuration::Instance()->GetSectionKey(ConfigSection::GOOGLE_ANALYTICS, ConfigKeys::GOOGLE_ANALYTICS_TRACKING_ID));
         $this->Set('ShowNewVersion', $this->ShouldShowNewVersion());
+
+        $this->Set('AutoScrollToday', Configuration::Instance()->GetSectionKey(ConfigSection::SCHEDULE, ConfigKeys::SCHEDULE_AUTO_SCROLL_TODAY, new BooleanConverter()) ?? true);
     }
 
     protected function SetTitle($title)

--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -11,10 +11,6 @@ function Schedule(opts, resourceGroups) {
     const ScheduleWide = "1";
     const ScheduleTall = "2";
     const ScheduleCondensed = "3";
-    //Replaced by a global button
-    /* const elements = {
-         topButton: $('#reservationsToTop')
-     };*/
 
     this.init = function () {
         this.initUserDefaultSchedule();
@@ -25,11 +21,13 @@ function Schedule(opts, resourceGroups) {
         this.initNavigation();
         addNumericalIdsToRows();
 
-        var today = $(".today");
-        if (today && today.length > 0) {
-            $('html, body').animate({
-                scrollTop: today.offset().top - 50
-            }, 500);
+        if (scheduleOpts.autoScrollToday) {
+            var today = $(".today");
+            if (today && today.length > 0) {
+                $('html, body').animate({
+                    scrollTop: today.offset().top - 50
+                }, 500);
+            }
         }
 
         $(window).on('resize', _.debounce(function () {
@@ -38,20 +36,6 @@ function Schedule(opts, resourceGroups) {
                 renderEvents(true);
             }
         }, 1000));
-        //Replaced by a global button
-        /*$(window).on('scroll', function () {
-            if (document.body.scrollTop > 20 || document.documentElement.scrollTop > 20) {
-                elements.topButton[0].style.display = "block";
-            } else {
-                elements.topButton[0].style.display = "none";
-            }
-        });
-
-        elements.topButton.on('click', function () {
-            $('html, body').animate({
-                scrollTop: 0
-            }, 500);
-        });*/
 
         setInterval(function () {
             renderEvents(true);
@@ -862,12 +846,10 @@ function Schedule(opts, resourceGroups) {
             var isInteger = /^[0-9]+$/.test(scheduleDisplay);
 
             if (isInteger) {
-                
                 // If is valid cerate a normal cookie
                 createCookie(opts.cookieName, parseInt(scheduleDisplay, 10), 30, opts.scriptUrl);
                 window.location.reload();
             } else {
-                
                 // Otherwise create a cookie with value 0
                 createCookie(opts.cookieName, 0, 30, opts.scriptUrl);
                 window.location.reload();
@@ -1035,12 +1017,12 @@ function Schedule(opts, resourceGroups) {
             var ref = $(this).attr('ref');
             reservations.find('td[ref="' + ref + '"]').addClass('hilite');
         });
-
+     
          reservations.delegate('.clickres:not(.reserved)', 'mouseleave', function () {
             if (selectingTds) {
                 return;
             }
-
+     
             $(this).siblings('.resourcename').removeClass('hilite');
             var ref = $(this).attr('ref');
             reservations.find('td[ref="' + ref + '"]').removeClass('hilite');

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -42,6 +42,8 @@ $conf['settings']['schedule']['hide.blocked.periods'] = 'false';        // if bl
 $conf['settings']['schedule']['update.highlight.minutes'] = '0';    // if set, will show reservations as 'updated' for a certain amount of time
 $conf['settings']['schedule']['show.week.numbers'] = 'false';
 $conf['settings']['schedule']['fast.reservation.load'] = 'false';  // Experimental: Use new algorithm to load reservations faster in the schedule. Currently does not support concurrent reservations. With larger number of resources this can be 10x or 100x faster. Only runs with the StandardSchedule otherwise will fall back to legacy mode.
+$conf['settings']['schedule']['load.mobile.views'] = 'true';                    // if the mobile views should be loaded on mobile devices. If false, the desktop views will be loaded instead
+$conf['settings']['schedule']['auto.scroll.today'] = 'true';               // if the schedule should automatically scroll to today when the page is loaded
 /**
  * ical integration configuration
  */

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -44,6 +44,8 @@ $conf['settings']['schedule']['hide.blocked.periods'] = 'false';        // if bl
 $conf['settings']['schedule']['update.highlight.minutes'] = '0';    // if set, will show reservations as 'updated' for a certain amount of time
 $conf['settings']['schedule']['show.week.numbers'] = 'false';
 $conf['settings']['schedule']['fast.reservation.load'] = 'false';  // Experimental: Use new algorithm to load reservations faster in the schedule. Currently does not support concurrent reservations. With larger number of resources this can be 10x or 100x faster. Only runs with the StandardSchedule otherwise will fall back to legacy mode.
+$conf['settings']['schedule']['load.mobile.views'] = 'true';                    // if the mobile views should be loaded on mobile devices. If false, the desktop views will be loaded instead
+$conf['settings']['schedule']['auto.scroll.today'] = 'true';               // if the schedule should automatically scroll to today when the page is loaded
 /**
  * ical integration configuration
  */

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -36,6 +36,8 @@ class ConfigKeys
     public const SCHEDULE_UPDATE_HIGHLIGHT_MINUTES = 'update.highlight.minutes';
     public const SCHEDULE_SHOW_WEEK_NUMBERS = 'show.week.numbers';
     public const SCHEDULE_FAST_RESERVATION_LOAD = 'fast.reservation.load';
+    public const SCHEDULE_LOAD_MOBILE_VIEWS = 'load.mobile.views';
+    public const SCHEDULE_AUTO_SCROLL_TODAY = 'auto.scroll.today';
 
     public const DATABASE_TYPE = 'type';
     public const DATABASE_USER = 'user';

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -440,6 +440,7 @@
         autocompleteUrl: "{$Path}ajax/autocomplete.php?type={AutoCompleteType::User}",
         fastReservationLoad: "{$FastReservationLoad}",
         resourceMaxConcurrentReservations,
+        autoScrollToday: {$AutoScrollToday|@json_encode},
     };
 
     const resourceOrder = [];


### PR DESCRIPTION
New settings:
- load.mobile.views: Enables mobile views (default: true).
- auto.scroll.today: Auto-scroll to the current day (default: true).

Allows admins to enable mobile views and auto-scroll to today in the schedule.