### PR TITLE
fix: unclosed div in tpl\Dashboard\announcements.tpl

### DIFF
--- a/tpl/Dashboard/announcements.tpl
+++ b/tpl/Dashboard/announcements.tpl
@@ -17,4 +17,5 @@
 				</ul>
 			</div>
 		</div>
+	</div>
 </div>


### PR DESCRIPTION
- Added missing `</div>` to properly close an unclosed div in `[tpl\Dashboard\announcements.tpl]`.
- This fixes potential rendering issues caused by the malformed HTML structure.