### PR TITLE
style: in schedule view, make resource name wider

### DIFF
--- a/Web/css/schedule.css
+++ b/Web/css/schedule.css
@@ -105,7 +105,7 @@ table.reservations td.resourcename a:hover {
 }
 
 table.reservations td.resdate {
-  width: 150px;
+  width: 400px;
   padding: 0 3px;
   background-color: #36648B;
   color: #F0F0F0;


### PR DESCRIPTION
This increases the size of the column that the resource name is displayed in on the `Web/schedule.php` page. To get to that page chose `Schedule -> Bookings`.

Now resource names of 60 characters are no longer truncated.