### PR TITLE
chore: stop loading unused CSS files in preparation for removal

### DIFF
--- a/tpl/Activation/activation-error.tpl
+++ b/tpl/Activation/activation-error.tpl
@@ -1,4 +1,4 @@
-{include file='globalheader.tpl' cssFiles='scripts/css/colorbox.css'}
+{include file='globalheader.tpl'}
 <div id='activation-body'>
 	<h2 class="text-center">{translate key=AccountActivationError}</h2>
 </div>

--- a/tpl/Activation/activation-sent.tpl
+++ b/tpl/Activation/activation-sent.tpl
@@ -1,4 +1,4 @@
-{include file='globalheader.tpl' cssFiles='scripts/css/colorbox.css'}
+{include file='globalheader.tpl'}
 <div id='activation-body'>
 	<h2 class="text-center">{translate key=ActivationEmailSent}</h2>
 </div>

--- a/tpl/guest-participation.tpl
+++ b/tpl/guest-participation.tpl
@@ -1,4 +1,4 @@
-{include file='globalheader.tpl' cssFiles='css/participation.css'}
+{include file='globalheader.tpl'}
 
 {if $IsMissingInformation}
 	<div class="error">This invitation is incorrect or does not exist</div>
@@ -6,14 +6,14 @@
 
 {if $InvitationAccepted ||  $InvitationDeclined}
 	<div class="success">Thanks, we've recorded your response
-		{if $IsGuest || $AllowRegistration}
-			<div><a href="{Pages::REGISTRATION}">{translate key=CreateAnAccount}</a></div>
-		{/if}
-	</div>
+	{if $IsGuest || $AllowRegistration}
+	<div><a href="{Pages::REGISTRATION}">{translate key=CreateAnAccount}</a></div>
+	{/if}
+</div>
 {/if}
 
 {if $CapacityReached}
-	<div class="error">{$CapacityErrorMessage}</div>
+<div class="error">{$CapacityErrorMessage}</div>
 {/if}
 {include file="javascript-includes.tpl"}
 {include file='globalfooter.tpl'}


### PR DESCRIPTION
Prevented the loading of CSS files that are no longer required by the application.  This change is part of a cleanup process and prepares for the complete removal of these files in a future commit.

Reducing unused CSS helps improve maintainability and performance.