### PR TITLE
chore: remove commented-out code after Bootstrap 5 upgrade

### DIFF
--- a/tpl/Admin/Attributes/attribute-list.tpl
+++ b/tpl/Admin/Attributes/attribute-list.tpl
@@ -26,8 +26,7 @@
 			</thead>
 			<tbody>
 				{foreach from=$Attributes item=attribute}
-					{*{cycle values='row0,row1' assign=rowCss}*}
-					<tr class="{$rowCss}" attributeId="{$attribute->Id()}">
+					<tr attributeId="{$attribute->Id()}">
 						<td class="d-none">{$attribute->Id()}</td>
 						<td>{$attribute->SortOrder()}</td>
 						<td>{$attribute->Label()}</td>

--- a/tpl/Admin/Blackouts/manage_blackouts.tpl
+++ b/tpl/Admin/Blackouts/manage_blackouts.tpl
@@ -189,9 +189,8 @@
 					</thead>
 					<tbody>
 						{foreach from=$blackouts item=blackout}
-							{*{cycle values='row0,row1' assign=rowCss}*}
 							{assign var=id value=$blackout->InstanceId}
-							<tr class="{$rowCss} editable" data-blackout-id="{$id}">
+							<tr class="editable" data-blackout-id="{$id}">
 								<td>{$blackout->ResourceName}</td>
 								<td class="date">{formatdate date=$blackout->StartDate timezone=$Timezone key=res_popup}
 								</td>
@@ -223,14 +222,6 @@
 							</tr>
 						{/foreach}
 					</tbody>
-					{*<tfoot>
-						<tr>
-							<td colspan="7"></td>
-							<td class="action-delete"><a href="#" id="delete-selected" class="d-none"
-									title="{translate key=Delete}">{translate key=Delete}<span
-										class="bi bi-trash3-fill text-danger icon remove"></span></a></td>
-						</tr>
-					</tfoot>*}
 				</table>
 			</div>
 		</div>

--- a/tpl/Admin/Blackouts/manage_blackouts_response.tpl
+++ b/tpl/Admin/Blackouts/manage_blackouts_response.tpl
@@ -32,8 +32,7 @@
 			</thead>
 			<tbody>
 				{foreach from=$Reservations item=reservation}
-					{*{cycle values='row0,row1' assign=rowCss}*}
-					<tr class="{$rowCss} editable" data-reservation-id="{$reservation->ReferenceNumber}">
+					<tr class="editable" data-reservation-id="{$reservation->ReferenceNumber}">
 						<td>{$reservation->FirstName} {$reservation->LastName}</td>
 						<td>{$reservation->ResourceName}</td>
 						<td>{formatdate date=$reservation->StartDate timezone=$Timezone key=res_popup}</td>

--- a/tpl/Admin/Groups/manage_groups.tpl
+++ b/tpl/Admin/Groups/manage_groups.tpl
@@ -4,10 +4,12 @@
     <div class="border-bottom mb-3 clearfix">
         <div class="dropdown admin-header-more float-end">
             <div class="btn-group btn-group-sm">
-                <a role="menuitem" href="#" class="add-group btn btn-primary" id="add-group"><i class="bi bi-plus-circle-fill me-1 icon add"></i>{translate key="AddGroup"}
+                <a role="menuitem" href="#" class="add-group btn btn-primary" id="add-group"><i
+                        class="bi bi-plus-circle-fill me-1 icon add"></i>{translate key="AddGroup"}
 
                 </a>
-                <button class="btn btn-primary dropdown-toggle" type="button" id="moreResourceActions" data-bs-toggle="dropdown">
+                <button class="btn btn-primary dropdown-toggle" type="button" id="moreResourceActions"
+                    data-bs-toggle="dropdown">
                     <span class="visually-hidden">{translate key='More'}</span>
                     <i class="bi bi-three-dots"></i>
                 </button>
@@ -18,7 +20,10 @@
                         </a>
                     </li>
                     <li role="presentation">
-                        <a role="menuitem" href="{$smarty.server.SCRIPT_NAME}?dr=export" download="{$smarty.server.SCRIPT_NAME}?dr=export" class="export-groups dropdown-item" id="export-groups" target="_blank"> <i class="bi bi-upload me-1"></i>{translate key="Export"}
+                        <a role="menuitem" href="{$smarty.server.SCRIPT_NAME}?dr=export"
+                            download="{$smarty.server.SCRIPT_NAME}?dr=export" class="export-groups dropdown-item"
+                            id="export-groups" target="_blank"> <i
+                                class="bi bi-upload me-1"></i>{translate key="Export"}
                         </a>
                     </li>
                 </ul>
@@ -55,8 +60,7 @@
                 </thead>
                 <tbody>
                     {foreach from=$groups item=group}
-                        {*{cycle values='row0,row1' assign=rowCss}*}
-                        <tr class="{$rowCss}" data-group-id="{$group->Id}" data-group-default="{$group->IsDefault}">
+                        <tr data-group-id="{$group->Id}" data-group-default="{$group->IsDefault}">
                             <td class="dataGroupName">{$group->Name}</td>
                             <td><a href="#" class="update members link-primary">{translate key='Manage'}</a></td>
                             <td><a href="#" class="update permissions link-primary">{translate key='Change'}</a></td>
@@ -65,7 +69,8 @@
                                     {if $group->IsExtendedAdmin()}
                                         <div class="btn-group btn-group-sm">
                                             <a href="#" class="update roles btn btn-outline-primary">{translate key='Change'}</a>
-                                            <button type="button" class="btn btn-sm btn-outline-primary dropdown-toggle" data-bs-toggle="dropdown">
+                                            <button type="button" class="btn btn-sm btn-outline-primary dropdown-toggle"
+                                                data-bs-toggle="dropdown">
                                                 <span class="visually-hidden">{translate key=More}</span>
                                             </button>
                                             <ul class="dropdown-menu dropdown-menu-right" role="menu">
@@ -77,17 +82,20 @@
                                                 </li>
                                                 {if $group->IsGroupAdmin()}
                                                     <li role="presentation">
-                                                        <a role="menuitem" href="#" class="update changeAdminGroups dropdown-item">{translate key="Groups"}</a>
+                                                        <a role="menuitem" href="#"
+                                                            class="update changeAdminGroups dropdown-item">{translate key="Groups"}</a>
                                                     </li>
                                                 {/if}
                                                 {if $group->IsResourceAdmin()}
                                                     <li role="presentation">
-                                                        <a role="menuitem" href="#" class="update changeAdminResources dropdown-item">{translate key="Resources"}</a>
+                                                        <a role="menuitem" href="#"
+                                                            class="update changeAdminResources dropdown-item">{translate key="Resources"}</a>
                                                     </li>
                                                 {/if}
                                                 {if $group->IsScheduleAdmin()}
                                                     <li role="presentation">
-                                                        <a role="menuitem" href="#" class="update changeAdminSchedules dropdown-item">{translate key="Schedules"}</a>
+                                                        <a role="menuitem" href="#"
+                                                            class="update changeAdminSchedules dropdown-item">{translate key="Schedules"}</a>
                                                     </li>
                                                 {/if}
                                             </ul>
@@ -97,7 +105,8 @@
                                     {/if}
                                 </td>
                             {/if}
-                            <td><a href="#" class="update groupAdmin link-primary">{$group->AdminGroupName|default:$chooseText}</a>
+                            <td><a href="#"
+                                    class="update groupAdmin link-primary">{$group->AdminGroupName|default:$chooseText}</a>
                             </td>
                             <td>{if $group->IsDefault}
                                     <i class="bi bi-check-circle text-success"></i>
@@ -107,19 +116,20 @@
                             </td>
                             <td class="action">
                                 <a href="#" class="update rename link-primary"><span class="bi bi-pencil-square icon"></a> |
-                                <a href="#" class="update delete"><span class="bi bi-trash3-fill text-danger icon remove"></span></a>
+                                <a href="#" class="update delete"><span
+                                        class="bi bi-trash3-fill text-danger icon remove"></span></a>
                             </td>
                         </tr>
                     {/foreach}
                 </tbody>
             </table>
-            {*{pagination pageInfo=$PageInfo}*}
         </div>
     </div>
 
     <input type="hidden" id="activeId" />
 
-    <div class="modal fade" id="membersDialog" tabindex="-1" role="dialog" aria-labelledby="membersDialogLabel" aria-hidden="true">
+    <div class="modal fade" id="membersDialog" tabindex="-1" role="dialog" aria-labelledby="membersDialogLabel"
+        aria-hidden="true">
         <div class="modal-dialog modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
@@ -137,13 +147,15 @@
                     <div id="groupUserList"></div>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-primary cancel" data-bs-dismiss="modal">{translate key='Done'}</button>
+                    <button type="button" class="btn btn-primary cancel"
+                        data-bs-dismiss="modal">{translate key='Done'}</button>
                 </div>
             </div>
         </div>
     </div>
 
-    <div id="allUsers" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="browseUsersDialogLabel" aria-hidden="true">
+    <div id="allUsers" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="browseUsersDialogLabel"
+        aria-hidden="true">
         <div class="modal-dialog modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
@@ -157,7 +169,8 @@
         </div>
     </div>
 
-    <div class="modal fade" id="permissionsDialog" tabindex="-1" role="dialog" aria-labelledby="permissionsDialogLabel" aria-hidden="true">
+    <div class="modal fade" id="permissionsDialog" tabindex="-1" role="dialog" aria-labelledby="permissionsDialogLabel"
+        aria-hidden="true">
         <div class="modal-dialog modal-dialog-scrollable">
 
             <div class="modal-content">
@@ -183,13 +196,14 @@
                                 </tr>
                             </thead>
                             {foreach from=$resources item=resource}
-                                {*{cycle values='row0,row1' assign=rowCss}*}
                                 {assign var=rid value=$resource->GetResourceId()}
                                 <tr>
                                     <td>
-                                        <div class="{$rowCss} permissionRow form-group clearfix">
-                                            <label for="permission_{$rid}" class="float-start">{$resource->GetName()}</label>
-                                            <select class="form-select form-select-sm w-auto resourceId float-end" {formname key=RESOURCE_ID multi=true}id="permission_{$rid}">
+                                        <div class="permissionRow form-group clearfix">
+                                            <label for="permission_{$rid}"
+                                                class="float-start">{$resource->GetName()}</label>
+                                            <select class="form-select form-select-sm w-auto resourceId float-end"
+                                                {formname key=RESOURCE_ID multi=true}id="permission_{$rid}">
                                                 <option value="{$rid}_none" class="none">{translate key=None}</option>
                                                 <option value="{$rid}_0" class="full">{translate key=FullAccess}</option>
                                                 <option value="{$rid}_1" class="view">{translate key=ViewOnly}</option>
@@ -218,7 +232,8 @@
         <input type="hidden" id="addUserId" {formname key=USER_ID} />
     </form>
 
-    <div class="modal fade" id="addGroupDialog" tabindex="-1" role="dialog" aria-labelledby="addDialogLabel" aria-hidden="true">
+    <div class="modal fade" id="addGroupDialog" tabindex="-1" role="dialog" aria-labelledby="addDialogLabel"
+        aria-hidden="true">
         <div class="modal-dialog">
             <form id="addGroupForm" method="post">
                 <div class="modal-content">
@@ -229,13 +244,17 @@
                     <div class="modal-body">
                         <div id="addGroupResults" class="error" style="display:none;"></div>
                         <div class="form-group">
-                            <label class="fw-bold" for="addGroupName">{translate key=Name}<i class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
-                            <input {formname key=GROUP_NAME} type="text" id="addGroupName" required class="form-control required has-feedback" />
+                            <label class="fw-bold" for="addGroupName">{translate key=Name}<i
+                                    class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
+                            <input {formname key=GROUP_NAME} type="text" id="addGroupName" required
+                                class="form-control required has-feedback" />
                         </div>
                         <div class="form-group mt-2">
                             <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="addGroupIsDefault" {formname key=IS_DEFAULT} />
-                                <label class="form-check-label" for="addGroupIsDefault">{translate key=AutomaticallyAddToGroup}</label>
+                                <input class="form-check-input" type="checkbox" id="addGroupIsDefault"
+                                    {formname key=IS_DEFAULT} />
+                                <label class="form-check-label"
+                                    for="addGroupIsDefault">{translate key=AutomaticallyAddToGroup}</label>
                             </div>
                         </div>
                     </div>
@@ -249,7 +268,8 @@
         </div>
     </div>
 
-    <div class="modal fade" id="deleteDialog" tabindex="-1" role="dialog" aria-labelledby="deleteDialogLabel" aria-hidden="true">
+    <div class="modal fade" id="deleteDialog" tabindex="-1" role="dialog" aria-labelledby="deleteDialogLabel"
+        aria-hidden="true">
         <div class="modal-dialog">
             <form id="deleteGroupForm" method="post">
                 <div class="modal-content">
@@ -273,7 +293,8 @@
         </div>
     </div>
 
-    <div class="modal fade" id="editDialog" tabindex="-1" role="dialog" aria-labelledby="editDialogLabel" aria-hidden="true">
+    <div class="modal fade" id="editDialog" tabindex="-1" role="dialog" aria-labelledby="editDialogLabel"
+        aria-hidden="true">
         <div class="modal-dialog">
             <form id="editGroupForm" method="post">
                 <div class="modal-content">
@@ -283,13 +304,18 @@
                     </div>
                     <div class="modal-body">
                         <div class="form-group">
-                            <label class="fw-bold" for="editGroupName">{translate key=Name}<i class="bi bi-asterisk text-danger align-top form-control-feedback" style="font-size: 0.5rem;"></i></label>
-                            <input type="text" id="editGroupName" class="form-control required has-feedback" required {formname key=GROUP_NAME} />
+                            <label class="fw-bold" for="editGroupName">{translate key=Name}<i
+                                    class="bi bi-asterisk text-danger align-top form-control-feedback"
+                                    style="font-size: 0.5rem;"></i></label>
+                            <input type="text" id="editGroupName" class="form-control required has-feedback" required
+                                {formname key=GROUP_NAME} />
                         </div>
                         <div class="form-group mt-2">
                             <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="editGroupIsDefault" {formname key=IS_DEFAULT} />
-                                <label class="form-check-label" for="editGroupIsDefault">{translate key=AutomaticallyAddToGroup}</label>
+                                <input class="form-check-input" type="checkbox" id="editGroupIsDefault"
+                                    {formname key=IS_DEFAULT} />
+                                <label class="form-check-label"
+                                    for="editGroupIsDefault">{translate key=AutomaticallyAddToGroup}</label>
                             </div>
                         </div>
                     </div>
@@ -304,7 +330,8 @@
     </div>
 
     {if $CanChangeRoles}
-        <div class="modal fade" id="rolesDialog" tabindex="-1" role="dialog" aria-labelledby="rolesDialogLabel" aria-hidden="true">
+        <div class="modal fade" id="rolesDialog" tabindex="-1" role="dialog" aria-labelledby="rolesDialogLabel"
+            aria-hidden="true">
             <div class="modal-dialog">
                 <form id="rolesForm" method="post">
                     <div class="modal-content">
@@ -315,7 +342,8 @@
                         <div class="modal-body">
                             {foreach from=$Roles item=role}
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="role{$role->Id}" {formname key=ROLE_ID multi=true} value="{$role->Id}" />
+                                    <input class="form-check-input" type="checkbox" id="role{$role->Id}"
+                                        {formname key=ROLE_ID multi=true} value="{$role->Id}" />
                                     <label class="form-check-label" for="role{$role->Id}">{$role->Name}</label>
                                 </div>
                             {/foreach}
@@ -329,7 +357,8 @@
                 </form>
             </div>
         </div>
-        <div class="modal fade adminDialog" id="resourceAdminDialog" tabindex="-1" role="dialog" aria-labelledby="resourceAdminDialogLabel" aria-hidden="true">
+        <div class="modal fade adminDialog" id="resourceAdminDialog" tabindex="-1" role="dialog"
+            aria-labelledby="resourceAdminDialogLabel" aria-hidden="true">
             <div class="modal-dialog modal-dialog-scrollable">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -343,8 +372,10 @@
 
                             {foreach from=$resources item=resource}
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="resource{$resource->GetId()}" {formname key=RESOURCE_ID multi=true} value="{$resource->GetId()}" />
-                                    <label class="form-check-label" for="resource{$resource->GetId()}">{$resource->GetName()}</label>
+                                    <input class="form-check-input" type="checkbox" id="resource{$resource->GetId()}"
+                                        {formname key=RESOURCE_ID multi=true} value="{$resource->GetId()}" />
+                                    <label class="form-check-label"
+                                        for="resource{$resource->GetId()}">{$resource->GetName()}</label>
                                 </div>
                             {/foreach}
                         </form>
@@ -357,7 +388,8 @@
                 </div>
             </div>
         </div>
-        <div class="modal fade adminDialog" id="groupAdminAllDialog" tabindex="-1" role="dialog" aria-labelledby="groupAdminAllDialogLabel" aria-hidden="true">
+        <div class="modal fade adminDialog" id="groupAdminAllDialog" tabindex="-1" role="dialog"
+            aria-labelledby="groupAdminAllDialogLabel" aria-hidden="true">
             <div class="modal-dialog">
                 <form id="groupAdminGroupsForm" method="post">
 
@@ -372,7 +404,8 @@
 
                             {foreach from=$groups item=group}
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="group{$group->Id}" {formname key=GROUP_ID multi=true}" value="{$group->Id}" />
+                                    <input class="form-check-input" type="checkbox" id="group{$group->Id}"
+                                        {formname key=GROUP_ID multi=true}" value="{$group->Id}" />
                             <label class="form-check-label" for="group{$group->Id}">{$group->Name}</label>
                         </div>
                         {/foreach}
@@ -386,7 +419,8 @@
             </form>
         </div>
     </div>
-    <div class="modal fade adminDialog" id="scheduleAdminDialog" tabindex="-1" role="dialog" aria-labelledby="scheduleAdminDialogLabel" aria-hidden="true">
+    <div class="modal fade adminDialog" id="scheduleAdminDialog" tabindex="-1" role="dialog"
+        aria-labelledby="scheduleAdminDialogLabel" aria-hidden="true">
         <div class="modal-dialog modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
@@ -400,8 +434,10 @@
 
                         {foreach from=$Schedules item=schedule}
                         <div class="form-check">
-                            <input class="form-check-input" type="checkbox" id="schedule{$schedule->GetId()}" {formname key=SCHEDULE_ID multi=true} value="{$schedule->GetId()}" />
-                            <label class="form-check-label" for="schedule{$schedule->GetId()}">{$schedule->GetName()}</label>
+                            <input class="form-check-input" type="checkbox" id="schedule{$schedule->GetId()}"
+                                {formname key=SCHEDULE_ID multi=true} value="{$schedule->GetId()}" />
+                            <label class="form-check-label"
+                                for="schedule{$schedule->GetId()}">{$schedule->GetName()}</label>
                         </div>
                         {/foreach}
                     </form>
@@ -416,7 +452,8 @@
     </div>
     {/if}
 
-    <div class="modal fade" id="groupAdminDialog" tabindex="-1" role="dialog" aria-labelledby="groupAdminDialogLabel" aria-hidden="true">
+    <div class="modal fade" id="groupAdminDialog" tabindex="-1" role="dialog" aria-labelledby="groupAdminDialogLabel"
+        aria-hidden="true">
         <div class="modal-dialog">
             <form id="groupAdminForm" method="post">
                 <div class="modal-content">
@@ -426,7 +463,8 @@
                     </div>
                     <div class="modal-body">
                         <div class="form-group has-feedback">
-                            <label for="groupAdmin" class="off-screen fw-bold">{translate key=WhoCanManageThisGroup}</label>
+                            <label for="groupAdmin"
+                                class="off-screen fw-bold">{translate key=WhoCanManageThisGroup}</label>
                             <select {formname key=GROUP_ADMIN} class="form-select" id="groupAdmin">
                                 <option value="">-- {translate key=None} --</option>
                                 {foreach from=$AdminGroups item=adminGroup}
@@ -445,8 +483,10 @@
         </div>
     </div>
 
-    <div id="importGroupsDialog" class="modal" tabindex="-1" role="dialog" aria-labelledby="importGroupsModalLabel" aria-hidden="true">
-        <form id="importGroupsForm" class="form" role="form" method="post" enctype="multipart/form-data" ajaxAction="{ManageGroupsActions::Import}">
+    <div id="importGroupsDialog" class="modal" tabindex="-1" role="dialog" aria-labelledby="importGroupsModalLabel"
+        aria-hidden="true">
+        <form id="importGroupsForm" class="form" role="form" method="post" enctype="multipart/form-data"
+            ajaxAction="{ManageGroupsActions::Import}">
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
@@ -456,7 +496,9 @@
                     <div class="modal-body">
                         <div id="importInstructions" class="alert alert-info">
                             <div class="note fst-italic">{translate key=GroupsImportInstructions}</div>
-                            <a href="{$smarty.server.SCRIPT_NAME}?dr=template" class="alert-link" download="{$smarty.server.SCRIPT_NAME}?dr=template" target="_blank">{translate key=GetTemplate} <span class="bi bi-download"></span></a>
+                            <a href="{$smarty.server.SCRIPT_NAME}?dr=template" class="alert-link"
+                                download="{$smarty.server.SCRIPT_NAME}?dr=template"
+                                target="_blank">{translate key=GetTemplate} <span class="bi bi-download"></span></a>
                         </div>
                         <div id="importGroupsResults" class="validationSummary alert alert-danger d-none">
                             <ul>
@@ -474,11 +516,14 @@
                             <a class="alert-link" href="{$smarty.server.SCRIPT_NAME}">{translate key=Done}</a>
                         </div>
                         <div class="">
-                            <input type="file" class="form-control" {formname key=GROUP_IMPORT_FILE} id="groupsImportFile" />
+                            <input type="file" class="form-control" {formname key=GROUP_IMPORT_FILE}
+                                id="groupsImportFile" />
                             <label for="groupsImportFile" class="visually-hidden">Group Import File</label>
                             <div class="form-check mt-1">
-                                <input class="form-check-input" type="checkbox" id="updateOnImport" {formname key=UPDATE_ON_IMPORT} />
-                                <label class="form-check-label" for="updateOnImport">{translate key=UpdateGroupsOnImport}</label>
+                                <input class="form-check-input" type="checkbox" id="updateOnImport"
+                                    {formname key=UPDATE_ON_IMPORT} />
+                                <label class="form-check-label"
+                                    for="updateOnImport">{translate key=UpdateGroupsOnImport}</label>
                             </div>
                         </div>
                     </div>

--- a/tpl/Admin/Reservations/manage_reservations.tpl
+++ b/tpl/Admin/Reservations/manage_reservations.tpl
@@ -221,7 +221,6 @@
 					</thead>
 					<tbody>
 						{foreach from=$reservations item=reservation}
-							{cycle values='row0,row1' assign=rowCss}
 							{if $reservation->RequiresApproval}
 								{assign var=rowCss value='table-warning pending'}
 							{/if}
@@ -236,13 +235,10 @@
 								<td class="resource">{$reservation->ResourceName}
 									{if $reservation->ResourceStatusId == ResourceStatus::AVAILABLE}
 										<i class="bi bi-check-circle-fill text-success"></i>
-										{*{translate key='Available'}*}
 									{elseif $reservation->ResourceStatusId == ResourceStatus::UNAVAILABLE}
 										<i class="bi bi-exclamation-circle-fill text-warning"></i>
-										{*{translate key='Unavailable'}*}
 									{else}
 										<i class="bi bi-x-circle-fill text-danger"></i>
-										{*{translate key='Hidden'}*}
 									{/if}
 									{*{if array_key_exists($reservation->ResourceStatusReasonId,$StatusReasons)}*}
 										{*<span class="reservationResourceStatusReason">{$StatusReasons[$reservation->ResourceStatusReasonId]->Description()}</span>*}
@@ -288,10 +284,6 @@
 										<label class="" for="delete{$reservationId}"></label>
 									</div>
 								</td>
-								{*</tr>
-						<tr class="{$rowCss}" data-seriesId="{$reservation->SeriesId}"
-							data-refnum="{$reservation->ReferenceNumber}">
-<td colspan="{$colCount}">*}
 								<td>
 									<div class="reservation-list-dates d-flex">
 										<div>
@@ -327,20 +319,8 @@
 							</tr>
 						{/foreach}
 					</tbody>
-					{*<tfoot>
-					<tr>
-						<td colspan="{$colCount-1}"></td>
-						<td class="action-delete">
-							<a href="#" id="delete-selected" class="d-none" title="{translate key=Delete}">
-								<span class="bi bi-trash3-fill text-danger icon remove"></span>
-								<span class="visually-hidden">{translate key=Delete}</span>
-							</a>
-						</td>
-					</tr>
-				</tfoot>*}
 				</table>
 
-				{*{pagination pageInfo=$PageInfo}*}
 			</div>
 		</div>
 	</div>

--- a/tpl/Admin/Resources/manage_resource_status.tpl
+++ b/tpl/Admin/Resources/manage_resource_status.tpl
@@ -136,8 +136,6 @@
 							<input type="text" class="form-control required" required id="edit-reason-description"
 								{formname key=RESOURCE_STATUS_REASON} />
 							<input type="hidden" id="add-reason-status" {formname key=RESOURCE_STATUS_ID} />
-							{*<i class="bi bi-asterisk form-control-feedback"
-								data-bv-icon-for="edit-reason-description"></i>*}
 						</div>
 					</div>
 					<div class="modal-footer">

--- a/tpl/Admin/Resources/manage_resource_types.tpl
+++ b/tpl/Admin/Resources/manage_resource_types.tpl
@@ -62,9 +62,8 @@
 				</thead>
 				<tbody>
 					{foreach from=$ResourceTypes item=type}
-						{*{cycle values='row0,row1' assign=rowCss}*}
 						{assign var=id value=$type->Id()}
-						<tr class="{$rowCss}">
+						<tr>
 							<td>{$type->Name()}</td>
 							<td>{$type->Description()|nl2br}</td>
 							<td class="action">
@@ -104,7 +103,6 @@
 									class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 							<input type="text" id="editName" class="form-control required" required="required"
 								maxlength="85" {formname key=RESOURCE_TYPE_NAME} />
-							{*<i class="bi bi-asterisk form-control-feedback" data-bv-icon-for="editName"></i>*}
 						</div>
 						<div class="form-group">
 							<label for="editDescription" class="fw-bold">{translate key='Description'}</label>

--- a/tpl/Admin/Resources/manage_resources_group_permissions.tpl
+++ b/tpl/Admin/Resources/manage_resources_group_permissions.tpl
@@ -7,10 +7,9 @@
 <table class="table table-striped">
     <tbody>
         {foreach from=$Groups item=g}
-            {*{cycle values='row0,row1' assign=rowCss}*}
             <tr>
                 <td>
-                    <div class="{$rowCss} form-group clearfix">
+                    <div class="form-group clearfix">
                         <label for="permission{$g->Id}" class="float-start">{$g->Name}</label>
                         <select class="change-permission-type float-end form-select form-select-sm inline-block"
                             style="width:auto;" id="permission{$g->Id}" data-group-id="{$g->Id}">

--- a/tpl/Admin/Resources/manage_resources_user_permissions.tpl
+++ b/tpl/Admin/Resources/manage_resources_user_permissions.tpl
@@ -7,10 +7,9 @@
 <table class="table table-striped">
     <tbody>
         {foreach from=$Users item=u}
-            {*{cycle values='row0,row1' assign=rowCss}*}
             <tr>
                 <td>
-                    <div class="{$rowCss} form-group clearfix">
+                    <div class="form-group clearfix">
                         <label for="permission{$u->Id}" class="float-start">{fullname first=$u->First last=$u->Last}</label>
                         <select class="change-permission-type float-end form-select form-select-sm" style="width:auto;"
                             id="permission{$u->Id}" data-user-id="{$u->Id}">

--- a/tpl/Admin/Schedules/manage_schedules.tpl
+++ b/tpl/Admin/Schedules/manage_schedules.tpl
@@ -70,8 +70,7 @@
 																data-value="{$schedule->GetAdminGroupId()}"
 																data-name="{FormKeys::SCHEDULE_ADMIN_GROUP_ID}">{($GroupLookup[$schedule->GetAdminGroupId()]) ? $GroupLookup[$schedule->GetAdminGroupId()]->Name : 'None'}</span>
 															{if $AdminGroups|default:array()|count > 0}
-																<a class="link-primary update changeScheduleAdmin"
-																	{*href="#" If used, clicking scrolls up the page *}><span
+																<a class="link-primary update changeScheduleAdmin"><span
 																		class="visually-hidden">{translate key='ScheduleAdministrator'}</span><span
 																		class="bi bi-pencil-square"></span>
 																</a>
@@ -287,7 +286,6 @@
 			</div>
 		</div>
 	</div>
-	{*{pagination pageInfo=$PageInfo}*}
 
 	<div id="addDialog" class="modal fade" tabindex="-1" role="dialog" aria-labelledby="addScheduleDialogLabel"
 		aria-hidden="true">

--- a/tpl/Admin/Schedules/view_schedules.tpl
+++ b/tpl/Admin/Schedules/view_schedules.tpl
@@ -6,8 +6,6 @@
 		<h1 class="float-start">{translate key=ManageSchedules}</h1>
 	</div>
 
-	{*pagination pageInfo=$PageInfo*}
-
 	<div class="card shadow" id="list-schedules-panel">
 		<div class="card-body" id="scheduleList">
 			<div class="accordion" id="scheduleAccordion">
@@ -187,7 +185,6 @@
 		</div>
 	</div>
 
-	{*pagination pageInfo=$PageInfo*}
 
 	{include file="javascript-includes.tpl" DataTable=true}
 	{datatablefilter tableId=$tableIdFilter}

--- a/tpl/Admin/Users/credit_log.tpl
+++ b/tpl/Admin/Users/credit_log.tpl
@@ -20,8 +20,7 @@
             </thead>
             <tbody>
                 {foreach from=$CreditLog item=log}
-                    {*{cycle values='row0,row1' assign=rowCss}*}
-                    <tr class="{$rowCss}">
+                    <tr>
                         <td>{formatdate date=$log->Date timezone=$Timezone key='general_datetime'}</td>
                         <td>{$log->Note}</td>
                         <td>{$log->OriginalCreditCount}</td>
@@ -31,7 +30,6 @@
             </tbody>
         </table>
 
-        {*{pagination pageInfo=$PageInfo}*}
     {/if}
 
 </div>

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -98,9 +98,8 @@
                     </thead>
                     <tbody>
                         {foreach from=$users item=user}
-                            {cycle values='row0,row1' assign=rowCss}
                             {assign var=id value=$user->Id}
-                            <tr class="{$rowCss}" data-userId="{$id}">
+                            <tr data-userId="{$id}">
                                 <td>{fullname first=$user->First last=$user->Last ignorePrivacy="true"}</td>
                                 <td>{$user->Username}</td>
                                 <td><a href="mailto:{$user->Email}" class="link-primary">{$user->Email}</a></td>
@@ -182,7 +181,7 @@
                                 </td>
 
                                 {if $attributes|default:array()|count > 0}
-                                    <td class="{$rowCss} customAttributes" userId="{$id}">
+                                    <td class="customAttributes" userId="{$id}">
                                         {assign var=changeAttributeAction value=ManageUsersActions::ChangeAttribute}
                                         {assign var=attributeUrl value="`$smarty.server.SCRIPT_NAME`?action=`$changeAttributeAction`"}
                                         {foreach from=$AttributeList item=attribute}
@@ -418,7 +417,7 @@
                                 <tr>
                                     <td>
                                         {assign var=rid value=$resource->GetResourceId()}
-                                        <div class="{$rowCss} permissionRow form-group clearfix">
+                                        <div class="permissionRow form-group clearfix">
                                             <label for="permission_{$rid}"
                                                 class="float-start">{$resource->GetName()}</label>
                                             <select class="float-end form-select form-select-sm resourceId inline-block"

--- a/tpl/Admin/Users/user-update.tpl
+++ b/tpl/Admin/Users/user-update.tpl
@@ -15,7 +15,6 @@
 						class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 				<input type="text" {formname key="USERNAME"} class="required form-control has-feedback" required
 					id="username" value="{$User->Username()|escape:html}" />
-				{*<i class="glyphicon glyphicon-asterisk form-control-feedback" data-bv-icon-for="username"></i>*}
 			</div>
 		</div>
 
@@ -25,7 +24,6 @@
 						class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 				<input type="text" {formname key="EMAIL"} class="required form-control has-feedback" required id="email"
 					value="{$User->EmailAddress()|escape:html}" />
-				{*<i class="glyphicon glyphicon-asterisk form-control-feedback" data-bv-icon-for="email"></i>*}
 			</div>
 		</div>
 
@@ -35,7 +33,6 @@
 						class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 				<input type="text" {formname key="FIRST_NAME"} class="required form-control has-feedback" required
 					id="fname" value="{$User->FirstName()|escape:html}" />
-				{*<i class="glyphicon glyphicon-asterisk form-control-feedback" data-bv-icon-for="fname"></i>*}
 			</div>
 		</div>
 
@@ -45,7 +42,6 @@
 						class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 				<input type="text" {formname key="LAST_NAME"} class="required form-control has-feedback" required
 					id="lname" value="{$User->LastName()|escape:html}" />
-				{*<i class="glyphicon glyphicon-asterisk form-control-feedback" data-bv-icon-for="lname"></i>*}
 			</div>
 		</div>
 

--- a/tpl/Admin/manage_accessories.tpl
+++ b/tpl/Admin/manage_accessories.tpl
@@ -64,8 +64,7 @@
 				</thead>
 				<tbody>
 					{foreach from=$accessories item=accessory}
-						{*{cycle values='row0,row1' assign=rowCss}*}
-						<tr class="{*{$rowCss}*}" data-accessory-id="{$accessory->Id}">
+						<tr data-accessory-id="{$accessory->Id}">
 							<td>{$accessory->Name}</td>
 							<td>{$accessory->QuantityAvailable|default:'&infin;'}</td>
 							<td>

--- a/tpl/Admin/manage_quotas.tpl
+++ b/tpl/Admin/manage_quotas.tpl
@@ -246,9 +246,8 @@
 									{translate key=NotCountingCompletedReservations}
 								{/if}
 							{/capture}
-							{*{cycle values='row0,row1' assign=rowCss}*}
 							<tr>
-								<td class="quotaItem {$rowCss} clearfix">
+								<td class="quotaItem clearfix">
 									<div class="float-start">
 										{translate key=QuotaConfiguration args="$scheduleName,$resourceName,$groupName,$amount,$unit,$duration"}
 										<span class="fw-bold">{$scope}</span>.

--- a/tpl/Credits/credit_log.tpl
+++ b/tpl/Credits/credit_log.tpl
@@ -10,8 +10,7 @@
         </thead>
         <tbody>
             {foreach from=$CreditLog item=log}
-                {cycle values='row0,row1' assign=rowCss}
-                <tr class="{$rowCss}">
+                <tr>
                     <td>{formatdate date=$log->Date timezone=$Timezone key='general_datetime'}</td>
                     <td>{$log->Note}</td>
                     <td>{$log->OriginalCreditCount}</td>

--- a/tpl/MyAccount/notification-preferences.tpl
+++ b/tpl/MyAccount/notification-preferences.tpl
@@ -26,15 +26,6 @@
 								<label class="form-check-label"
 									for="{ReservationEvent::Created}">{translate key=PreferenceSendEmail}</label>
 							</div>
-							{*<div class="btn-group form-group" data-toggle="buttons">
-								<label class="btn btn-default btn-xs {if $Created}active{/if}">
-									<input id="createdYes" type="radio" name="{ReservationEvent::Created}" value="1"
-										{if $Created}checked="checked" {/if} /> {translate key=PreferenceSendEmail}{$Created}
-								</label>
-								<label class="btn btn-default btn-xs {if !$Created}active{/if}">
-									<input id="createdNo" type="radio" name="{ReservationEvent::Created}" value="0"
-										{if !$Created}checked="checked" {/if} />{translate key=PreferenceNoEmail}</label>
-							</div>*}
 						</div>
 
 						<div class="notification-row col-12 col-sm-6">
@@ -46,15 +37,6 @@
 								<label class="form-check-label"
 									for="{ReservationEvent::Updated}">{translate key=PreferenceSendEmail}</label>
 							</div>
-							{*<div class="btn-group form-group" data-toggle="buttons">
-								<label class="btn btn-default btn-xs {if $Updated}active{/if}">
-									<input id="updatedYes" type="radio" name="{ReservationEvent::Updated}" value="1"
-										{if $Updated}checked="checked" {/if} /> {translate key=PreferenceSendEmail}
-								</label>
-								<label class="btn btn-default btn-xs {if !$Updated}active{/if}">
-									<input id="updatedNo" type="radio" name="{ReservationEvent::Updated}" value="0"
-										{if !$Updated}checked="checked" {/if} />{translate key=PreferenceNoEmail}</label>
-							</div>*}
 						</div>
 
 						<div class="notification-row col-12 col-sm-6">
@@ -68,15 +50,6 @@
 								<label class="form-check-label"
 									for="{ReservationEvent::Deleted}">{translate key=PreferenceSendEmail}</label>
 							</div>
-							{*<div class="btn-group form-group" data-toggle="buttons">
-								<label class="btn btn-default btn-xs {if $Deleted}active{/if}">
-									<input id="deletedYes" type="radio" name="{ReservationEvent::Deleted}" value="1"
-										{if $Deleted}checked="checked" {/if} /> {translate key=PreferenceSendEmail}
-								</label>
-								<label class="btn btn-default btn-xs {if !$Deleted}active{/if}">
-									<input id="deletedNo" type="radio" name="{ReservationEvent::Deleted}" value="0"
-										{if !$Deleted}checked="checked" {/if} />{translate key=PreferenceNoEmail}</label>
-							</div>*}
 
 						</div>
 
@@ -91,15 +64,6 @@
 								<label class="form-check-label"
 									for="{ReservationEvent::Approved}">{translate key=PreferenceSendEmail}</label>
 							</div>
-							{*<div class="btn-group form-group" data-toggle="buttons">
-								<label class="btn btn-default btn-xs {if $Approved}active{/if}">
-									<input id="approvedYes" type="radio" name="{ReservationEvent::Approved}" value="1"
-										{if $Approved}checked="checked" {/if} /> {translate key=PreferenceSendEmail}
-								</label>
-								<label class="btn btn-default btn-xs {if !$Approved}active{/if}">
-									<input id="approvedNo" type="radio" name="{ReservationEvent::Approved}" value="0"
-										{if !$Approved}checked="checked" {/if} />{translate key=PreferenceNoEmail}</label>
-							</div>*}
 						</div>
 
 						<div class="notification-row col-12 col-sm-6">
@@ -114,17 +78,6 @@
 								<label class="form-check-label"
 									for="{ReservationEvent::ParticipationChanged}">{translate key=PreferenceSendEmail}</label>
 							</div>
-							{*<div class="btn-group form-group" data-toggle="buttons">
-								<label class="btn btn-default btn-xs {if $ParticipantChanged}active{/if}">
-									<input id="endingYes" type="radio" name="{ReservationEvent::ParticipationChanged}" value="1"
-										{if $ParticipantChanged}checked="checked" {/if} />
-									{translate key=PreferenceSendEmail}
-								</label>
-								<label class="btn btn-default btn-xs {if !$ParticipantChanged}active{/if}">
-									<input id="endingNo" type="radio" name="{ReservationEvent::ParticipationChanged}" value="0"
-										{if !$ParticipantChanged}checked="checked"
-										{/if} />{translate key=PreferenceNoEmail}</label>
-							</div>*}
 						</div>
 
 						<div class="notification-row-alt col-12 col-sm-6">
@@ -138,15 +91,6 @@
 								<label class="form-check-label"
 									for="{ReservationEvent::SeriesEnding}">{translate key=PreferenceSendEmail}</label>
 							</div>
-							{*<div class="btn-group form-group" data-toggle="buttons">
-								<label class="btn btn-default btn-xs {if $SeriesEnding}active{/if}">
-									<input id="endingYes" type="radio" name="{ReservationEvent::SeriesEnding}" value="1"
-										{if $SeriesEnding}checked="checked" {/if} /> {translate key=PreferenceSendEmail}
-								</label>
-								<label class="btn btn-default btn-xs {if !$SeriesEnding}active{/if}">
-									<input id="endingNo" type="radio" name="{ReservationEvent::SeriesEnding}" value="0"
-										{if !$SeriesEnding}checked="checked" {/if} />{translate key=PreferenceNoEmail}</label>
-							</div>*}
 						</div>
 
 					</div>

--- a/tpl/MyAccount/participation.tpl
+++ b/tpl/MyAccount/participation.tpl
@@ -78,8 +78,6 @@
 
 	</div>
 
-	{html_image src="admin-ajax-indicator.gif" id="indicator" style="display:none;"}
-
 	{include file="javascript-includes.tpl"}
 	{jsfile src="reservationPopup.js"}
 	{jsfile src="participation.js"}

--- a/tpl/MyAccount/profile.tpl
+++ b/tpl/MyAccount/profile.tpl
@@ -5,9 +5,7 @@
     <div id="profile-box" class="default-box card shadow col-12 col-sm-8 mx-auto">
 
         <form method="post" ajaxAction="{ProfileActions::Update}" id="form-profile" class="was-validated"
-            action="{$smarty.server.SCRIPT_NAME}" role="form" {*data-bv-feedbackicons-valid="bi bi-check-lg"
-            data-bv-feedbackicons-invalid="bi bi-x-lg" data-bv-feedbackicons-validating="bi bi-arrow-repeat"
-            data-bv-feedbackicons-required="bi bi-asterisk"*} data-bv-submitbuttons='button[type="submit"]'
+            action="{$smarty.server.SCRIPT_NAME}" role="form" data-bv-submitbuttons='button[type="submit"]'
             data-bv-onerror="enableButton" data-bv-onsuccess="enableButton" data-bv-live="enabled">
 
             <div class="card-body">

--- a/tpl/Reports/results-custom.tpl
+++ b/tpl/Reports/results-custom.tpl
@@ -11,7 +11,6 @@
 					{/if}
 				</div>
 			</div>
-			{*<div id="customize-columns"></div>*}
 			<div class="table-responsive mt-3">
 				{assign var=tableId value="report-results"}
 				<table id="{$tableId}" chart-type="{$Definition->GetChartType()}"
@@ -33,8 +32,7 @@
 					</thead>
 					<tbody>
 						{foreach from=$Report->GetData()->Rows() item=row}
-							{cycle values=',alt' assign=rowCss}
-							<tr class="{$rowCss}">
+							<tr>
 								{foreach from=$Definition->GetRow($row) item=cell}
 									<td chart-value="{$cell->ChartValue()}" chart-column-type="{$cell->GetChartColumnType()}"
 										chart-group="{$cell->GetChartGroup()}">{$cell->Value()}</td>

--- a/tpl/Reports/saved-reports.tpl
+++ b/tpl/Reports/saved-reports.tpl
@@ -31,8 +31,7 @@
 								</thead>
 								<tbody>
 									{foreach from=$ReportList item=report}
-										{*{cycle values=',alt' assign=rowCss}*}
-										<tr reportId="{$report->Id()}" class="{$rowCss}">
+										<tr reportId="{$report->Id()}">
 											<td><span class="fw-bold">{$report->ReportName()|default:$untitled}</span></td>
 											<td class="right"><span
 													class="report-created-date fst-italic">{format_date date=$report->DateCreated()}</span>

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -65,7 +65,7 @@
                     <span id="warning-resources"></span> resources for <span id="warning-days"></span> days.
                     <button type="button" class="close close-forever btn btn-link alert-link"
                         aria-label="Do not show again">
-                        <span aria-hidden="true">Do not show again</span> {*Cadena para traducir*}
+                        <span aria-hidden="true">Do not show again</span>
                     </button>
                 </p>
             </div>

--- a/tpl/Search/search-reservations-results.tpl
+++ b/tpl/Search/search-reservations-results.tpl
@@ -19,7 +19,6 @@
 				</thead>
 				<tbody>
 					{foreach from=$Reservations item=reservation}
-						{*{cycle values='row0,row1' assign=rowCss}*}
 						{if $reservation->RequiresApproval}
 							{assign var=rowCss value='pending table-warning'}
 						{/if}

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -129,8 +129,6 @@
         </div>
         <nav class="navbar navbar-expand-lg bg-light shadow-sm py-2 sticky-top">
             <div class="container-fluid">
-                {*<a class="navbar-brand py-0" href="{$HomeUrl}">{html_image src="$LogoUrl?{$Version}" alt="$Title"
-                    class="logo"}</a>*}
                 <button type="button" class="navbar-toggler" data-bs-toggle="collapse"
                     data-bs-target="#librebooking-navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -248,7 +246,6 @@
                                                     href="{$Path}admin/manage_payments.php">{translate key="ManagePayments"}</a>
                                             </li>
                                         {/if}
-                                        {*<li class="dropdown-header">{translate key=Customization}</li>*}
                                         <li id="navManageAttributes"><a class="dropdown-item"
                                                 href="{$Path}admin/manage_attributes.php">{translate key="CustomAttributes"}</a>
                                         </li>

--- a/tpl/register.tpl
+++ b/tpl/register.tpl
@@ -6,9 +6,7 @@
         <div class="card shadow mb-3">
             <div class="card-body mx-3">
                 <form method="post" ajaxAction="{RegisterActions::Register}" id="form-register"
-                    action="{$smarty.server.SCRIPT_NAME}" role="form" {*data-bv-feedbackicons-valid="bi bi-check-lg"
-                    data-bv-feedbackicons-invalid="bi bi-x-lg" data-bv-feedbackicons-validating="bi bi-arrow-clockwise"
-                    data-bv-feedbackicons-required="bi bi-asterisk"*} data-bv-submitbuttons='button[type="submit"]'
+                    action="{$smarty.server.SCRIPT_NAME}" role="form" data-bv-submitbuttons='button[type="submit"]'
                     data-bv-onerror="enableButton" data-bv-onsuccess="enableButton" data-bv-live="enabled">
 
                     <h1 class="text-center border-bottom">{translate key=RegisterANewAccount}</h1>
@@ -134,45 +132,45 @@
                         </div>
 
                         {if $RequirePhone || !$HidePhone}
-                        <div class="col-12 col-sm-6" id="phone">
-                            <div class="form-group">
-                                <label class="reg fw-bold" for="phone">{translate key="Phone"}{if $RequirePhone}<i
-                                            class="bi bi-asterisk text-danger align-top"
-                                        style="font-size: 0.5rem;"></i>{/if}</label>
-                                <input type="text" id="phone" {formname key="PHONE"} class="form-control" size="20"
-                                    {if $RequirePhone}required="required" data-bv-notempty="true"
-                                    data-bv-notempty-message="{translate key=PhoneRequired}" {/if} />
+                            <div class="col-12 col-sm-6" id="phone">
+                                <div class="form-group">
+                                    <label class="reg fw-bold" for="phone">{translate key="Phone"}{if $RequirePhone}<i
+                                                class="bi bi-asterisk text-danger align-top"
+                                            style="font-size: 0.5rem;"></i>{/if}</label>
+                                    <input type="text" id="phone" {formname key="PHONE"} class="form-control" size="20"
+                                        {if $RequirePhone}required="required" data-bv-notempty="true"
+                                        data-bv-notempty-message="{translate key=PhoneRequired}" {/if} />
+                                </div>
                             </div>
-                        </div>
                         {/if}
 
                         {if $RequireOrganization || !$HideOrganization}
-                        <div class="col-12 col-sm-6" id="organization">
-                            <div class="form-group">
-                                <label class="reg fw-bold"
-                                    for="txtOrganization">{translate key="Organization"}{if $RequireOrganization}<i
-                                            class="bi bi-asterisk text-danger align-top"
-                                        style="font-size: 0.5rem;"></i>{/if}</label>
-                                <input type="text" id="txtOrganization" {formname key="ORGANIZATION"}
-                                    class="form-control" size="20" {if $RequireOrganization}required="required"
-                                        data-bv-notempty="true"
-                                    data-bv-notempty-message="{translate key=OrganizationRequired}" {/if} />
+                            <div class="col-12 col-sm-6" id="organization">
+                                <div class="form-group">
+                                    <label class="reg fw-bold"
+                                        for="txtOrganization">{translate key="Organization"}{if $RequireOrganization}<i
+                                                class="bi bi-asterisk text-danger align-top"
+                                            style="font-size: 0.5rem;"></i>{/if}</label>
+                                    <input type="text" id="txtOrganization" {formname key="ORGANIZATION"}
+                                        class="form-control" size="20" {if $RequireOrganization}required="required"
+                                            data-bv-notempty="true"
+                                        data-bv-notempty-message="{translate key=OrganizationRequired}" {/if} />
+                                </div>
                             </div>
-                        </div>
                         {/if}
 
                         {if $RequirePosition || !$HidePosition}
-                        <div class="col-12 col-sm-6 " id="position">
-                            <div class="form-group">
-                                <label class="reg fw-bold"
-                                    for="txtPosition">{translate key="Position"}{if $RequirePosition}<i
-                                            class="bi bi-asterisk text-danger align-top"
-                                        style="font-size: 0.5rem;"></i>{/if}</label>
-                                <input type="text" id="txtPosition" {formname key="POSITION"} class="form-control"
-                                    size="20" {if $RequirePosition}required="required" data-bv-notempty="true"
-                                    data-bv-notempty-message="{translate key=PositionRequired}" {/if} />
+                            <div class="col-12 col-sm-6 " id="position">
+                                <div class="form-group">
+                                    <label class="reg fw-bold"
+                                        for="txtPosition">{translate key="Position"}{if $RequirePosition}<i
+                                                class="bi bi-asterisk text-danger align-top"
+                                            style="font-size: 0.5rem;"></i>{/if}</label>
+                                    <input type="text" id="txtPosition" {formname key="POSITION"} class="form-control"
+                                        size="20" {if $RequirePosition}required="required" data-bv-notempty="true"
+                                        data-bv-notempty-message="{translate key=PositionRequired}" {/if} />
+                                </div>
                             </div>
-                        </div>
                         {/if}
 
                         <div class="col-12 col-sm-6">
@@ -184,17 +182,9 @@
                     </div>
 
                     {if $Attributes|default:array()|count > 1}
-                        {*{for $i=1 to $Attributes|default:array()|count-1}*}
-                            {*{if $i%2==1}*}
-                                {*<div class="row">*}
-                            {*{/if}*}
-                            <div class="col-12 col-sm-6">
-                                {control type="AttributeControl" attribute=$Attributes[$i]}
-                            </div>
-                            {*{if $i%2==0 || $i==$Attributes|default:array()|count-1}*}
-                                {*</div>*}
-                            {*{/if}*}
-                        {*{/for}*}
+                        <div class="col-12 col-sm-6">
+                            {control type="AttributeControl" attribute=$Attributes[$i]}
+                        </div>
                     {/if}
 
                     {if $EnableCaptcha}


### PR DESCRIPTION
Cleaned up legacy commented-out code that was left behind after migrating to Bootstrap 5.  This improves readability and helps maintain a cleaner, more maintainable codebase.