### PR TITLE
fix: remove redundant script that prevented modal from opening correctly

### DIFF
--- a/Web/scripts/admin/group.js
+++ b/Web/scripts/admin/group.js
@@ -127,11 +127,6 @@ function GroupManagement(opt) {
             modal.find('.count').text(modal.find(':checked').length);
         });
 
-        //import group form
-        importGroupsDialog.click((e) => {
-            e.preventDefault();
-            elements.importGroupsDialog.modal('show');
-        });
     }
 
     var configureAutocomplete = function () {

--- a/tpl/Admin/Groups/manage_groups.tpl
+++ b/tpl/Admin/Groups/manage_groups.tpl
@@ -15,7 +15,8 @@
                 </button>
                 <ul class="dropdown-menu" role="menu" aria-labelledby="moreResourceActions">
                     <li role="presentation">
-                        <a role="menuitem" href="#" class="import-groups dropdown-item" id="import-groups">
+                        <a role="menuitem" href="#" class="import-groups dropdown-item" id="import-groups"
+                            data-bs-toggle="modal" data-bs-target="#importGroupsDialog">
                             <i class="bi bi-download me-1"></i>{translate key="Import"}
                         </a>
                     </li>


### PR DESCRIPTION
Removed a JavaScript handler in Web/scripts/admin/group.js that manually triggered the importGroupsDialog modal via jQuery.

This script conflicted with Bootstrap 5’s native modal handling through data-bs-toggle, preventing the modal from working as expected.

The modal is now triggered correctly using declarative Bootstrap markup.