### PR TITLE
fix: update PayPal payment logic for compatibility

### DIFF
--- a/Domain/PaymentGateway.php
+++ b/Domain/PaymentGateway.php
@@ -381,13 +381,17 @@ class PayPalGateway implements IPaymentGateway
                 }
             }
 
+            $paypalFee = isset($sale->seller_receivable_breakdown->paypal_fee->value)
+                ? $sale->seller_receivable_breakdown->paypal_fee->value
+                : 0;
+
             $logger->LogPayment(
                 $cart->UserId,
                 $response->body->status,
                 $sale->id,
                 $response->body->id,
                 $sale->amount->value,
-                $sale->seller_receivable_breakdown->paypal_fee->value,
+                $paypalFee,
                 $sale->amount->currency_code,
                 $self,
                 $refund,

--- a/Presenters/Credits/CheckoutPresenter.php
+++ b/Presenters/Credits/CheckoutPresenter.php
@@ -93,11 +93,11 @@ class CheckoutPresenter extends ActionPresenter
     {
         $gateway = $this->paymentRepository->GetPayPalGateway();
 
-        /** @var $cart CreditCartSession */
+        /** @var CreditCartSession $cart  */
         $cart = ServiceLocator::GetServer()->GetSession(SessionKeys::CREDIT_CART);
         $payment = $gateway->ExecutePayment($cart, $this->page->GetPaymentId(), $this->page->GetPayerId(), $this->paymentLogger);
 
-        if ($payment->state == "approved") {
+        if (isset($payment->status) && $payment->status == "COMPLETED") {
             $user = $this->userRepository->LoadById(ServiceLocator::GetServer()->GetUserSession()->UserId);
             $user->AddCredits($cart->Quantity, Resources::GetInstance()->GetString('NoteCreditsPurchased'));
             $this->userRepository->Update($user);
@@ -114,7 +114,7 @@ class CheckoutPresenter extends ActionPresenter
 
         $gateway = $this->paymentRepository->GetStripeGateway();
 
-        /** @var $cart CreditCartSession */
+        /** @var CreditCartSession $cart  */
         $cart = ServiceLocator::GetServer()->GetSession(SessionKeys::CREDIT_CART);
         $result = $gateway->Charge($cart, $userSession->Email, $token, $this->paymentLogger);
 


### PR DESCRIPTION
Update the PayPal payment logic for compatibility with latest API responses

Updated the PayPal payment capture and logging logic to handle missing fields such as 'seller_receivable_breakdown' and 'state' in recent API responses.

- Added checks to prevent accessing undefined properties (e.g., paypal_fee).
- Improved error resilience in ExecutePayment() and ExecutePayPalPayment().
- Ensured accurate logging and user feedback during the payment process.

These changes restore functionality for credit purchases via PayPal.