### PR TITLE
fix: require PHP 8.2 or newer

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ["8.1", "8.2"]
+        php-version: ["8.1", "8.2", "8.3", "8.4"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "phpunit/phpunit": "^11.3"
     },
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "smarty/smarty": "^4.5",
         "stripe/stripe-php": "^10.2",
         "monolog/monolog": "^2.9",


### PR DESCRIPTION
LibreBooking no longer supports PHP 8.1. PHP 8.2 or newer are the supported releases of PHP for LibreBooking.