### PR TITLE
Update smarty5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require": {
         "php": ">=8.2",
-        "smarty/smarty": "^4.5",
+        "smarty/smarty": "^5.5",
         "stripe/stripe-php": "^10.2",
         "monolog/monolog": "^2.9",
         "google/recaptcha": "1.2.*",

--- a/lib/Common/SmartyPage.php
+++ b/lib/Common/SmartyPage.php
@@ -10,6 +10,8 @@ require_once(ROOT_DIR . 'lib/Common/Converters/namespace.php');
 require_once(ROOT_DIR . 'lib/Common/Helpers/namespace.php');
 require_once(ROOT_DIR . 'lib/Common/SmartyControls/namespace.php');
 
+use Smarty\Smarty;
+
 class SmartyPage extends Smarty
 {
     /**
@@ -32,8 +34,13 @@ class SmartyPage extends Smarty
      * @param Resources $resources
      * @param string $RootPath
      */
-    public function __construct(Resources &$resources = null, protected $RootPath = null)
-    {
+
+    public $plugins_dir;
+
+    public function __construct(
+        protected ?Resources $resources = null,
+        protected $RootPath = null
+    ) {
         parent::__construct();
 
         $base = __DIR__ . '/../../';
@@ -79,7 +86,7 @@ class SmartyPage extends Smarty
      * if custom template of the target language is not available.
      * @return string
      */
-    public function FetchLocalized($templateName, bool $enforceCustomTemplate, string $languageCode = null)
+    public function FetchLocalized($templateName, bool $enforceCustomTemplate, ?string $languageCode = null)
     {
         if ($languageCode == null) {
             $languageCode = $this->getTemplateVars('CurrentLanguage');
@@ -193,7 +200,6 @@ class SmartyPage extends Smarty
         $this->registerPlugin('function', 'formatdate', $this->FormatDate(...));
         $this->registerPlugin('function', 'format_date', $this->FormatDate(...));
         $this->registerPlugin('function', 'html_link', $this->PrintLink(...));
-        $this->registerPlugin('function', 'html_image', $this->PrintImage(...));
         $this->registerPlugin('function', 'control', $this->DisplayControl(...));
         $this->registerPlugin('function', 'validator', $this->Validator(...));
         $this->registerPlugin('function', 'textbox', $this->Textbox(...));
@@ -226,10 +232,7 @@ class SmartyPage extends Smarty
         $this->registerPlugin('function', 'formatcurrency', $this->FormatCurrency(...));
         $this->registerPlugin('function', 'linebreak', $this->LineBreak(...));
         $this->registerPlugin('modifier', 'urlencode', $this->UrlEncode(...));
-        $this->registerPlugin('modifier', 'explode', $this->Explode(...));
         $this->registerPlugin('modifier', 'html_entity_decode', $this->HtmlEntityDecode(...));
-        $this->registerPlugin('modifier', 'implode', $this->Implode(...));
-        $this->registerPlugin('modifier', 'join', $this->Join(...));
         $this->registerPlugin('modifier', 'intval', $this->Intval(...));
         $this->registerPlugin('modifier', 'strtolower', $this->Strtolower(...));
         $this->registerPlugin('function', 'datatable', $this->CreateDataTable(...));
@@ -346,24 +349,6 @@ class SmartyPage extends Smarty
             $formatted = str_replace($english_days[$date->Weekday()], $days[$date->Weekday()], $formatted);
         }
         return $formatted;
-    }
-
-    public function PrintImage($params, $smarty)
-    {
-        $alt = $params['alt'] ?? '';
-        $altKey = $params['altKey'] ?? '';
-        $width = $params['width'] ?? '';
-        $height = $params['height'] ?? '';
-        $imgPath = sprintf('%simg/%s', $this->RootPath, $params['src']);
-
-        $knownAttributes = ['alt', 'width', 'height', 'src', 'title', 'altKey'];
-        $attributes = $this->AppendAttributes($params, $knownAttributes);
-
-        if (!empty($altKey)) {
-            $alt = $this->Resources->GetString($altKey);
-        }
-
-        return "<img src=\"$imgPath\" title=\"$alt\" alt=\"$alt\"  $attributes />";
     }
 
     public function DisplayControl($params, $smarty)
@@ -1012,24 +997,9 @@ class SmartyPage extends Smarty
         return count($value, $mode);
     }
 
-    public function Explode($separator, $string)
-    {
-        return explode($separator, (string) $string);
-    }
-
-    public function Implode($separator, $array)
-    {
-        return implode($separator, $array);
-    }
-
     public function HtmlEntityDecode($string)
     {
         return html_entity_decode((string) $string);
-    }
-
-    public function Join($sep, $array)
-    {
-        return join($sep, $array);
     }
 
     public function Intval($string)

--- a/lib/Email/SmartyEmail.php
+++ b/lib/Email/SmartyEmail.php
@@ -1,10 +1,12 @@
 <?php
 
 if (file_exists(ROOT_DIR . 'vendor/autoload.php')) {
-  require_once ROOT_DIR . 'vendor/autoload.php';
+    require_once ROOT_DIR . 'vendor/autoload.php';
 }
 require_once(ROOT_DIR . 'lib/Server/namespace.php');
 require_once(ROOT_DIR . 'lib/Common/namespace.php');
+
+use Smarty\Smarty;
 
 class SmartyEmail extends Smarty
 {
@@ -29,8 +31,8 @@ class SmartyEmail extends Smarty
         $this->cache_dir = ROOT_DIR . 'cache';
 
         $cacheTemplates = Configuration::Instance()->GetKey(ConfigKeys::CACHE_TEMPLATES, new BooleanConverter());
-        $this->compile_check = !$cacheTemplates;	// should be set to false in production
-        $this->force_compile = !$cacheTemplates;	// should be set to false in production
+        $this->compile_check = !$cacheTemplates;    // should be set to false in production
+        $this->force_compile = !$cacheTemplates;    // should be set to false in production
 
         $this->RegisterFunctions();
     }

--- a/tests/fakes/FakeSmarty.php
+++ b/tests/fakes/FakeSmarty.php
@@ -4,12 +4,15 @@ if (file_exists(ROOT_DIR . 'vendor/autoload.php')) {
   require_once ROOT_DIR . 'vendor/autoload.php';
 }
 
+use Smarty\Smarty;
+
+
 class FakeSmarty extends Smarty
 {
     public $_LastVar;
     public $_Value;
 
-    public function getTemplateVars($varname = null, Smarty_Internal_Data $_ptr = null, $search_parents = true)
+    public function getTemplateVars($varname = null, $_ptr = null, $search_parents = true)
     {
         $this->_LastVar = $varname;
 

--- a/tpl/Admin/Attributes/attribute-list.tpl
+++ b/tpl/Admin/Attributes/attribute-list.tpl
@@ -38,7 +38,7 @@
 							{/if}</td>
 						{if $Category != CustomAttributeCategory::RESERVATION}
 							<td>{if $attribute->UniquePerEntity()}
-									{', '|implode:$attribute->EntityDescriptions()}
+									{$attribute->EntityDescriptions()|join:', '}
 								{else}
 									{translate key=All}
 								{/if}
@@ -46,7 +46,7 @@
 						{/if}
 						<td>
 							{if $attribute->HasSecondaryEntities()}
-								{', '|implode:$attribute->SecondaryEntityDescriptions()}
+								{$attribute->SecondaryEntityDescriptions()|join:', '}
 							{else}
 								{translate key=All}
 							{/if}
@@ -93,15 +93,15 @@
 		type: "{$attribute->Type()}",
 		sortOrder: "{$attribute->SortOrder()}",
 		{if $attribute->EntityIds()|count > 0}
-			entityIds: ["{'","'|implode:$attribute->EntityIds()}"],
+			entityIds: ["{$attribute->EntityIds()|join:'","'}"],
 		{else}
 			entityIds: [],
 			{/if}
-			entityDescriptions: ["{'","'|implode:$attribute->EntityDescriptions()}"],
+			entityDescriptions: ["{$attribute->EntityDescriptions()|join:'","'}"],
 			adminOnly: {$attribute->AdminOnly()},
 			{if $attribute->HasSecondaryEntities()}
-				secondaryEntityIds: ["{'","'|implode:$attribute->SecondaryEntityIds()}"],
-				secondaryEntityDescriptions: ["{'","'|implode:$attribute->SecondaryEntityDescriptions()}"],
+				secondaryEntityIds: ["{$attribute->SecondaryEntityIds()|join:'","'}"],
+				secondaryEntityDescriptions: ["{$attribute->SecondaryEntityDescriptions()|join:'","'}"],
 			{else}
 				secondaryEntityIds: [],
 				secondaryEntityDescriptions: [],

--- a/tpl/Admin/Resources/manage_resources.tpl
+++ b/tpl/Admin/Resources/manage_resources.tpl
@@ -2389,7 +2389,7 @@
 				resource.images.push('{resource_image image=$image}');
 			{/foreach}
 
-			resource.resourceGroupIds = [{','|join:$resource->GetResourceGroupIds()}];
+			resource.resourceGroupIds = [{$resource->GetResourceGroupIds()|join:','}];
 
 			resourceManagement.add(resource);
 		{/foreach}

--- a/tpl/Admin/Schedules/manage_peak_times.tpl
+++ b/tpl/Admin/Schedules/manage_peak_times.tpl
@@ -11,7 +11,7 @@
 		{/if}
 	</div>
 
-	<div class="peakDays" data-everyday="{$p->IsEveryDay()}" data-weekdays="{','|implode:$p->GetWeekdays()}">
+	<div class="peakDays" data-everyday="{$p->IsEveryDay()}" data-weekdays="{$p->GetWeekdays()|join:','}">
 		{if $p->IsEveryDay()}
 			{translate key=Everyday}
 		{else}

--- a/tpl/Dashboard/dashboard_reservation.tpl
+++ b/tpl/Dashboard/dashboard_reservation.tpl
@@ -12,7 +12,7 @@
     <div class="col-sm-3 col-6">{formatdate date=$reservation->StartDate->ToTimezone($Timezone) key=dashboard} -
         {formatdate date=$reservation->EndDate->ToTimezone($Timezone) key=dashboard}</div>
     {*<div class="col-sm-2 col-6">{formatdate date=$reservation->EndDate->ToTimezone($Timezone) key=dashboard}</div>*}
-    <div class="col-sm-{if $checkin || $checkout}2{else}3{/if} col-12">{', '|join:$reservation->ResourceNames}</div>
+    <div class="col-sm-{if $checkin || $checkout}2{else}3{/if} col-12">{$reservation->ResourceNames|join:', '}</div>
     {if $allowCheckin}
         {if $checkin}
             <div class="col-sm-1 col-12">

--- a/tpl/Reservation/create.tpl
+++ b/tpl/Reservation/create.tpl
@@ -460,7 +460,7 @@
                                 <input type="hidden" class="name" value="{$accessory->GetName()}" />
                                 <input type="hidden" class="id" value="{$accessory->GetId()}" />
                                 <input type="hidden" class="resource-ids"
-                                    value="{','|implode:$accessory->ResourceIds()}" />
+                                    value="{$accessory->ResourceIds()|join:','}" />
                                 <label for="accessory{$accessory->GetId()}"
                                     class="visually-hidden">{$accessory->GetName()}</label>
                                 {if $accessory->GetQuantityAvailable() == 1}

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -90,13 +90,20 @@
                                 <a href="#" id="make_default" class="link-primary me-2" style="display:none;"><i
                                         class="bi bi-star-fill"></i></a>
                                 <a href="#" class="schedule-style me-1" id="schedule_standard"
-                                    schedule-display="{ScheduleStyle::Standard}">{html_image src="table.png" altKey="StandardScheduleDisplay"}</a>
-                                <a href="#" class="schedule-style me-1" id="schedule_tall"
-                                    schedule-display="{ScheduleStyle::Tall}">{html_image src="table-tall.png" altKey="TallScheduleDisplay"}</a>
+                                    schedule-display="{ScheduleStyle::Standard}">
+                                    <img src="img/table.png" alt="{translate key='StandardScheduleDisplay'}" />
+                                </a>
+                                <a href="#" class="schedule-style me-1" id="schedule_tall" schedule-display="{ScheduleStyle::Tall}">
+                                    <img src="img/table-tall.png" alt="{translate key='TallScheduleDisplay'}" />
+                                </a>
                                 <a href="#" class="schedule-style d-none d-md-block me-1" id="schedule_wide"
-                                    schedule-display="{ScheduleStyle::Wide}">{html_image src="table-wide.png" altKey="WideScheduleDisplay"}</a>
+                                    schedule-display="{ScheduleStyle::Wide}">
+                                    <img src="img/table-wide.png" alt="{translate key='WideScheduleDisplay'}" />
+                                </a>
                                 <a href="#" class="schedule-style d-none d-md-block" id="schedule_week"
-                                    schedule-display="{ScheduleStyle::CondensedWeek}">{html_image src="table-week.png" altKey="CondensedWeekScheduleDisplay"}</a>
+                                    schedule-display="{ScheduleStyle::CondensedWeek}">
+                                    <img src="img/table-week.png" alt="{translate key='CondensedWeekScheduleDisplay'}" />
+                                </a>
                             </div>
                             {if isset($SubscriptionUrl) && $SubscriptionUrl != null && $ShowSubscription && $LoggedIn}
                                 <div class="d-flex align-items-center"><i class="bi bi-rss-fill link-primary me-1"></i>
@@ -425,7 +432,7 @@
         cookieName: "{$CookieName}",
         scheduleId: "{$ScheduleId|escape:'javascript'}",
         scriptUrl: '{$ScriptUrl}',
-        selectedResources: [{','|implode:$ResourceIds}],
+        selectedResources: [{$ResourceIds|join:','}],
         specificDates: [{foreach from=$SpecificDates item=d}'{$d->Format('Y-m-d')}',{/foreach}],
         updateReservationUrl: "{$Path}ajax/reservation_move.php",
         lockTableHead: "{if isset($LockTableHead)}{$LockTableHead}{/if}",

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -82,7 +82,7 @@
     {cssfile src="scripts/css/jquery-ui-timepicker-addon.css"}
     {cssfile src="librebooking.css"}
     {if isset($cssFiles) && $cssFiles neq ''}
-        {assign var='CssFileList' value=','|explode:$cssFiles}
+        {assign var='CssFileList' value=$cssFiles|split:','}
         {foreach from=$CssFileList item=cssFile}
             {cssfile src=$cssFile}
         {/foreach}
@@ -98,7 +98,7 @@
     {/if}
 
     {if isset($printCssFiles) && $printCssFiles neq ''}
-        {assign var='PrintCssFileList' value=','|explode:$printCssFiles}
+        {assign var='PrintCssFileList' value=$printCssFiles|split:','}
         {foreach from=$PrintCssFileList item=cssFile}
             <link rel='stylesheet' type='text/css' href='{$Path}{$cssFile}' media='print' />
         {/foreach}
@@ -118,7 +118,7 @@
     {if !isset($HideNavBar) || $HideNavBar == false}
         <div class="d-flex align-items-center gap-2 m-2">
             <a class="navbar-brand" href="{$HomeUrl}">
-                {html_image src="$LogoUrl?{$Version}" alt="$Title" class="logo"}
+                <img src="{$Path}img/{$LogoUrl}?{$Version}" alt="{$Title}" class="logo">
             </a>
             <div class="border-start ps-2 d-flex flex-column">
                 {if $CompanyName neq ''}

--- a/tpl/login.tpl
+++ b/tpl/login.tpl
@@ -27,7 +27,7 @@
                 <div class="card-body mx-3">
                     <div id="login-box" class="default-box">
                         <div class="login-icon my-2">
-                            {html_image src="$LogoUrl?{$Version}" alt="$Title" class="mx-auto d-block w-50"}
+                            <img src="{$Path}img/{$LogoUrl}?{$Version}" alt="{$Title}" class="mx-auto d-block w-50">
                         </div>
 
                         {if $ShowLoginError}

--- a/tpl/maintenance.tpl
+++ b/tpl/maintenance.tpl
@@ -6,7 +6,7 @@
             <div class="card-body mx-3">
                 <div id="maintenance-box" class="default-box">
                     <div class="maintenance-icon my-2">
-                        {html_image src="$LogoUrl?{$Version}" alt="$Title" class="mx-auto d-block w-50"}
+                        <img src="{$Path}img/{$LogoUrl}?{$Version}" alt="{$Title}" class="mx-auto d-block w-50">
                     </div>
                     <div class="text-center mb-2">
                         <i class="bi bi-tools fs-1"></i>


### PR DESCRIPTION
This PR updates the smarty/smarty dependency to version ^5.5 and applies a set of related code improvements to ensure compatibility with the new version and modern PHP standards.

Changes included:

- Updated smarty/smarty to ^5.5.
- Added missing use statement for the Smarty namespace.
- Replaced {html_image} tags with standard HTML <img> elements for displaying the logo and schedule images.
- Updated deprecated implode and join modifier syntax in .tpl templates to avoid PHP 8.2+ warnings.
- Removed unused custom Smarty plugins and methods no longer needed after cleanup.

Notes:

These changes are internal and do not affect the external behavior or features of the application. However, some testing around template rendering and plugin functionality is recommended to confirm full compatibility.