### PR TITLE
docs: remove reference to hedgedoc as it is gone

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -7,8 +7,6 @@ The `master` branch is the most current stable release of LibreBooking.
 You can automatically keep your fork up to date with the [pull GitHub App](https://github.com/apps/pull). which will sync the `master` (hardreset) and `develop` (rebase) branches for you.
 Please commit bugfixes / features to a new branch prefixed `bugfix-`, `feature-` so they can be looked over, and pull requested to the `develop` branch and will eventually end up in a release on `master`.
 
-See what's currently worked on / add your own efforts to this [Active Devlopment pad](https://demo.hedgedoc.org/4MVpNd46TL2LI_IKR9K1EQ?both#).
-
 ## Design philosophy
 
 The Model-View-Presenter (MVP) pattern is used to keep a clear separation between application logic and presentation logic.  


### PR DESCRIPTION
The link to a hedgedoc instance is invalid. Remove the link.