### PR TITLE
docs: remove 'beta' designation of the `develop` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,17 @@
 
 ## 🚀 About
 
-**LibreBooking** is an open-source scheduling solution, forked from Booked Scheduler. It offers a flexible, mobile-friendly, and extensible interface for organizations to manage resource reservations. The repository for the last open source version of Booked Scheduler is maintained here; the `develop` branch contains the latest working code (beta), while `master` is the stable release.
+**LibreBooking** is an open-source resource scheduling solution. It provides a
+flexible, mobile-friendly, and extensible interface for organizations to manage
+resource reservations.
+
+The repository for LibreBooking is hosted on GitHub at
+<https://github.com/LibreBooking/app>; the `develop` branch contains the latest
+code.
+
+LibreBooking is a fork of Booked Scheduler, based on Booked Scheduler's last
+open-source version released in 2020. Since then, LibreBooking has evolved
+significantly and diverged from the original project.
 
 ## ✨ Features
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,11 @@ isolated_build = True
 [testenv:cz]
 basepython = python3
 deps = -r{toxinidir}/requirements-lint.txt
+allowlist_externals = git
 commands =
-  cz check --rev-range 551582832049c6f13cd1aff692063b08f7c82a9e..HEAD
+  # Ensure that our starting commit is really an ancestor of HEAD
+  git merge-base --is-ancestor 8a420dd06cb2b07748953255420556b0ded7d769 HEAD
+  cz check --rev-range 8a420dd06cb2b07748953255420556b0ded7d769..HEAD
 
 [testenv:docs]
 description = Builds the docs site. Generated HTML files will be available in '{env:DOCS_BUILD}'.


### PR DESCRIPTION
* Remove the 'beta' designation of the `develop` branch.
* Add a link to the GitHub repo so a link will appear on the documentation website.
* No longer mention the `master` branch, as people should use the `develop` branch.
* Add blurb about Booked Scheduler last being open source in 2020. Also that LibreBooking and Booked Scheduler have diverged from each other.
* Some minor re-wording of the content.