### PR TITLE
BugFix: Wrong input date on reservation edit

### DIFF
--- a/tpl/Controls/DateSetup.tpl
+++ b/tpl/Controls/DateSetup.tpl
@@ -16,10 +16,11 @@
             $controlId.attr('max', maxDate);
         {/if}
 
-        {if $DefaultDate}
-            var defaultDate = {dateFormat date=$DefaultDate};
-            $controlId.val(defaultDate);
-
+        {if $smarty.server.SCRIPT_NAME|basename != 'reservation.php'}
+            {if $DefaultDate}
+                var defaultDate = {dateFormat date=$DefaultDate};
+                $controlId.val(defaultDate);
+            {/if}
         {/if}
 
         {if $AltId neq ''}


### PR DESCRIPTION
Fix Applied

The issue occurred because the default date was being set unconditionally, even on the reservation.php page, causing a one-day offset.

To resolve this, the following condition was added:

```
{if $smarty.server.SCRIPT_NAME|basename != 'reservation.php'}
    {if $DefaultDate}
        var defaultDate = {dateFormat date=$DefaultDate};
        $controlId.val(defaultDate);
    {/if}
{/if}
```

This ensures that the default date is only applied on pages other than reservation.php, preventing it from interfering with the existing reservation values.

As a result, the start and end dates now correctly match the selected event when editing a reservation.