### PR TITLE
fix: don't attempt to reserve view-only resource

### DIFF
--- a/tpl/Schedule/schedule-reservations-grid.tpl
+++ b/tpl/Schedule/schedule-reservations-grid.tpl
@@ -33,7 +33,7 @@
                 <tr class="slots" data-resourceid="{$resource->GetId()}">
                     <td class="resourcename"
                         {if $resource->HasColor()}style="background-color:{$resource->GetColor()} !important" {/if}>
-                        {if $resource->CanAccess && $DailyLayout->IsDateReservable($date)}
+                        {if $resource->CanBook && $DailyLayout->IsDateReservable($date)}
                             <span resourceId="{$resourceId}"
                                 class="d-sm-inline-block d-md-none resourceNameSelector bi bi-info-circle-fill"
                                 data-show-event="click"
@@ -49,7 +49,7 @@
                     </td>
                     {foreach from=$slots.$ts item=Slot}
                         {assign var=slotRef value="{$Slot->BeginDate()->Format('YmdHis')}{$resourceId}"}
-                        {displaySlot Slot=$Slot Href="$href" AccessAllowed=$resource->CanAccess SlotRef=$slotRef ResourceId=$resourceId}
+                        {displaySlot Slot=$Slot Href="$href" AccessAllowed=$resource->CanBook SlotRef=$slotRef ResourceId=$resourceId}
                     {/foreach}
                 </tr>
             {/foreach}


### PR DESCRIPTION
Previously a user could attempt to reserve a resource that they had "view-only" permission. The reservation would then fail.

Change the UI so that it doesn't offer them the option to reserve the resource.

Closes: #655