### PR TITLE
style: adjust CSS to support datepicker in theme

### DIFF
--- a/Web/css/schedule.css
+++ b/Web/css/schedule.css
@@ -545,3 +545,50 @@ a.toggle-sidebar {
 #reservationsToTop:hover {
   color: #000;
 }
+
+.ui-widget-header {
+	color: var(--text-color-btn) !important;
+	background: var(--primary) !important;
+}
+
+.ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default, .ui-button, html .ui-button.ui-state-disabled:hover, html .ui-button.ui-state-disabled:active {
+	background: var(--text-color-btn) !important;
+    border: 1px solid var(--color-lines) !important;
+}
+
+.ui-state-highlight, .ui-widget-content .ui-state-highlight, .ui-widget-header .ui-state-highlight {
+	background: var(--text-color-btn) !important;
+	border: 1px solid var(--primary) !important;
+}
+
+.ui-state-highlight, .ui-widget-content .ui-state-highlight, .ui-widget-header .ui-state-highlight {
+	border: 1px solid var(--primary) !important;
+	background: var(--primary) !important;
+	color: var(--text-color-btn) !important;
+}
+
+.ui-datepicker .ui-datepicker-buttonpane button {
+    color: var(--text-color-btn) !important;
+	background: var(--primary) !important;
+    opacity: 1;
+}
+
+.ui-datepicker-header .ui-state-hover{
+    background: none !important;
+    border: none !important;
+}
+
+.ui-datepicker .ui-datepicker-next-hover {
+	top: 2px !important;
+}
+.ui-datepicker .ui-datepicker-prev {
+	left: 2px !important;
+}
+
+.ui-datepicker .ui-datepicker-prev-hover {
+	left: 2px !important;
+}
+
+.ui-datepicker .ui-datepicker-next-hover {
+	right: 2px !important;
+}

--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -1199,7 +1199,7 @@ function ChangeGroup(node) {
 }
 
 function AddSpecificDate(dateText, inst) {
-    var formattedDate = inst.selectedYear + '-' + (inst.selectedMonth + 1).padStart(2, '0') + '-' + inst.selectedDay.padStart(2, '0');
+    var formattedDate = inst.selectedYear + '-' + (inst.selectedMonth + 1).toString().padStart(2, '0') + '-' + inst.selectedDay.toString().padStart(2, '0');
     if (scheduleSpecificDates.indexOf(formattedDate) != -1) {
         return;
     }
@@ -1218,7 +1218,7 @@ function dpDateChanged(dateText, inst) {
             ChangeDate(inst.selectedYear, (inst.selectedMonth + 1).toString().padStart(2, '0') , inst.selectedDay.toString().padStart(2, '0'));
         } else {
             var date = new Date();
-            ChangeDate(date.getFullYear(), (date.getMonth() + 1).padStart(2, '0'), date.getDate().padStart(2, '0'));
+            ChangeDate(date.getFullYear(), (date.getMonth() + 1).toString().padStart(2, '0'), date.getDate().toString().padStart(2, '0'));
         }
     }
 }


### PR DESCRIPTION
## 1. Fix for [BUG]#671

padStart TypeError on date selection when logged out
This PR resolves a bug where clicking on a calendar date while logged out causes the following JavaScript error:

Uncaught TypeError: (inst.selectedMonth + 1).padStart is not a function

This commit ensures padStart() is called on a string, not a number, by explicitly converting the number:

(inst.selectedMonth + 1).toString().padStart(2, '0')

### Describe the bug
Uncaught TypeError: (inst.selectedMonth + 1).padStart is not a function
AddSpecificDate http://lb.int.sodarock.com/Web/scripts/schedule.js?v=3.0.1:1202
dpDateChanged http://lb.int.sodarock.com/Web/scripts/schedule.js?v=3.0.1:1215
jQuery 26
http://lb.int.sodarock.com/Web/view-schedule.php:3494
jQuery 13
schedule.js:1202:76

### To Reproduce
Steps to reproduce the behavior:

go to /Web/view-schedule.php (should be logged out)
click in Show/Hide Navigation if the calendar is not displayed
Check Show Specific Dates
Image
Click on any date in the calendar, nothing happens and the console displays the error
Uncaught TypeError: (inst.selectedMonth + 1).padStart is not a function
AddSpecificDate http://lb.int.sodarock.com/Web/scripts/schedule.js?v=3.0.1:1202
dpDateChanged http://lb.int.sodarock.com/Web/scripts/schedule.js?v=3.0.1:1215
jQuery 26
http://lb.int.sodarock.com/Web/view-schedule.php:3494
jQuery 13
schedule.js:1202:76

Closes: https://github.com/LibreBooking/app/issues/671

## 2. Adjusting css to enable datepicker styling
@labmecanicatec 

Small overwrite for jquery ui to make datepicker work with the theming
not perfectly elegant but working. maybe you have a better suggestion