### PR TITLE
fix(schedule): datepicker string conversion issue

### DIFF
--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -1199,7 +1199,7 @@ function ChangeGroup(node) {
 }
 
 function AddSpecificDate(dateText, inst) {
-    var formattedDate = inst.selectedYear + '-' + (inst.selectedMonth + 1).padStart(2, '0') + '-' + inst.selectedDay.padStart(2, '0');
+    var formattedDate = inst.selectedYear + '-' + (inst.selectedMonth + 1).toString().padStart(2, '0') + '-' + inst.selectedDay.toString().padStart(2, '0');
     if (scheduleSpecificDates.indexOf(formattedDate) != -1) {
         return;
     }
@@ -1218,7 +1218,7 @@ function dpDateChanged(dateText, inst) {
             ChangeDate(inst.selectedYear, (inst.selectedMonth + 1).toString().padStart(2, '0') , inst.selectedDay.toString().padStart(2, '0'));
         } else {
             var date = new Date();
-            ChangeDate(date.getFullYear(), (date.getMonth() + 1).padStart(2, '0'), date.getDate().padStart(2, '0'));
+            ChangeDate(date.getFullYear(), (date.getMonth() + 1).toString().padStart(2, '0'), date.getDate().toString().padStart(2, '0'));
         }
     }
 }


### PR DESCRIPTION
Fix for [BUG] #671: padStart TypeError on date selection when logged out
This PR resolves a bug where clicking on a calendar date while logged out causes the following JavaScript error:

Uncaught TypeError: (inst.selectedMonth + 1).padStart is not a function

This commit ensures padStart() is called on a string, not a number, by explicitly converting the number:

`(inst.selectedMonth + 1).toString().padStart(2, '0')`

Describe the bug**
Uncaught TypeError: (inst.selectedMonth + 1).padStart is not a function
AddSpecificDate http://lb.int.sodarock.com/Web/scripts/schedule.js?v=3.0.1:1202
dpDateChanged http://lb.int.sodarock.com/Web/scripts/schedule.js?v=3.0.1:1215
jQuery 26
http://lb.int.sodarock.com/Web/view-schedule.php:3494
jQuery 13
schedule.js:1202:76

To Reproduce**
Steps to reproduce the behavior:

go to /Web/view-schedule.php (should be logged out)
click in Show/Hide Navigation if the calendar is not displayed
Check Show Specific Dates
Image
Click on any date in the calendar, nothing happens and the console displays the error
Uncaught TypeError: (inst.selectedMonth + 1).padStart is not a function
AddSpecificDate http://lb.int.sodarock.com/Web/scripts/schedule.js?v=3.0.1:1202
dpDateChanged http://lb.int.sodarock.com/Web/scripts/schedule.js?v=3.0.1:1215
jQuery 26
http://lb.int.sodarock.com/Web/view-schedule.php:3494
jQuery 13
schedule.js:1202:76

Closes: #671