### PR TITLE
Fix for #671 / Adjusting css to enable datepicker styling

### DIFF
--- a/Web/css/schedule.css
+++ b/Web/css/schedule.css
@@ -545,3 +545,50 @@ a.toggle-sidebar {
 #reservationsToTop:hover {
   color: #000;
 }
+
+.ui-widget-header {
+	color: var(--text-color-btn) !important;
+	background: var(--primary) !important;
+}
+
+.ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default, .ui-button, html .ui-button.ui-state-disabled:hover, html .ui-button.ui-state-disabled:active {
+	background: var(--text-color-btn) !important;
+    border: 1px solid var(--color-lines) !important;
+}
+
+.ui-state-highlight, .ui-widget-content .ui-state-highlight, .ui-widget-header .ui-state-highlight {
+	background: var(--text-color-btn) !important;
+	border: 1px solid var(--primary) !important;
+}
+
+.ui-state-highlight, .ui-widget-content .ui-state-highlight, .ui-widget-header .ui-state-highlight {
+	border: 1px solid var(--primary) !important;
+	background: var(--primary) !important;
+	color: var(--text-color-btn) !important;
+}
+
+.ui-datepicker .ui-datepicker-buttonpane button {
+    color: var(--text-color-btn) !important;
+	background: var(--primary) !important;
+    opacity: 1;
+}
+
+.ui-datepicker-header .ui-state-hover{
+    background: none !important;
+    border: none !important;
+}
+
+.ui-datepicker .ui-datepicker-next-hover {
+	top: 2px !important;
+}
+.ui-datepicker .ui-datepicker-prev {
+	left: 2px !important;
+}
+
+.ui-datepicker .ui-datepicker-prev-hover {
+	left: 2px !important;
+}
+
+.ui-datepicker .ui-datepicker-next-hover {
+	right: 2px !important;
+}

--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -1199,7 +1199,7 @@ function ChangeGroup(node) {
 }
 
 function AddSpecificDate(dateText, inst) {
-    var formattedDate = inst.selectedYear + '-' + (inst.selectedMonth + 1).padStart(2, '0') + '-' + inst.selectedDay.padStart(2, '0');
+    var formattedDate = inst.selectedYear + '-' + (inst.selectedMonth + 1).toString().padStart(2, '0') + '-' + inst.selectedDay.toString().padStart(2, '0');
     if (scheduleSpecificDates.indexOf(formattedDate) != -1) {
         return;
     }
@@ -1218,7 +1218,7 @@ function dpDateChanged(dateText, inst) {
             ChangeDate(inst.selectedYear, (inst.selectedMonth + 1).toString().padStart(2, '0') , inst.selectedDay.toString().padStart(2, '0'));
         } else {
             var date = new Date();
-            ChangeDate(date.getFullYear(), (date.getMonth() + 1).padStart(2, '0'), date.getDate().padStart(2, '0'));
+            ChangeDate(date.getFullYear(), (date.getMonth() + 1).toString().padStart(2, '0'), date.getDate().toString().padStart(2, '0'));
         }
     }
 }


### PR DESCRIPTION
1. Fix for #671 padStart TypeError on date selection when logged out

This PR resolves a bug where clicking on a calendar date while logged out causes the following JavaScript error:

Uncaught TypeError: (inst.selectedMonth + 1).padStart is not a function

This commit ensures padStart() is called on a string, not a number, by explicitly converting the number:

(inst.selectedMonth + 1).toString().padStart(2, '0')

2. Adjusting css to enable datepicker styling

Small overwrite for jquery ui to make datepicker work with the theming