### PR TITLE
fix(API): stop storing multiple custom attributes of same type for Reources

### DIFF
--- a/Domain/BookableResource.php
+++ b/Domain/BookableResource.php
@@ -1393,27 +1393,12 @@ class BookableResource implements IBookableResource
     private $_removedAttributeValues = [];
 
     /**
-     * @param $attributes AttributeValue[]|array
+     * @param AttributeValue[]|array $attributes
      */
     public function ChangeAttributes($attributes)
     {
-        $diff = new ArrayDiff($this->_attributeValues, $attributes);
-
-        $added = $diff->GetAddedToArray1();
-        $removed = $diff->GetRemovedFromArray1();
-
-        /** @var AttributeValue $attribute */
-        foreach ($added as $attribute) {
-            $this->_addedAttributeValues[] = $attribute;
-        }
-
-        /** @var AttributeValue $attribute */
-        foreach ($removed as $attribute) {
-            $this->_removedAttributeValues[] = $attribute;
-        }
-
         foreach ($attributes as $attribute) {
-            $this->AddAttributeValue($attribute);
+            $this->ChangeAttribute($attribute);
         }
     }
 


### PR DESCRIPTION
When using the API to update a resource it would cause multiple custom attributes with the same ID to be stored in the
`custom_attribute_values` table in the database.

For example if currently have the custom attribute "Test Number" set to 1 for the resource. And then use the API to change it to a value of 2. In the `custom_attribute_values` table there will now be both entries stored. When using the web interface to edit the custom attribute it will delete the old value from the database table and then add new value.

Change it so that the old value will be deleted and the new value added.

Closes: #680 