### PR TITLE
fix(api): prevent duplicate custom attribute values when updating res…

### DIFF
--- a/Domain/BookableResource.php
+++ b/Domain/BookableResource.php
@@ -1452,6 +1452,14 @@ class BookableResource implements IBookableResource
     }
 
     /**
+     * @return array|AttributeValue[]
+     */
+    public function GetAttributeValues(): array
+    {
+        return [...$this->_attributeValues];
+    }
+
+    /**
      * @param $customAttributeId
      * @return mixed
      */


### PR DESCRIPTION
…ources

When updating a resource via the API, existing custom attribute values were not being removed before adding new ones, causing duplicate entries in the custom_attribute_values table.

The issue occurred because BuildResource() created a fresh BookableResource object with empty attributes, so ChangeAttributes() couldn't detect which attributes should be removed.

  * Add GetAttributeValues() method to BookableResource with copy protection
  * Copy existing attributes to new resource before calling ChangeAttributes()