### PR TITLE
fix(participation): add missing ParticipationNotification import

### DIFF
--- a/Presenters/GuestParticipationPresenter.php
+++ b/Presenters/GuestParticipationPresenter.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 
 class GuestParticipationPresenter
 {


### PR DESCRIPTION
Resolves "Class 'ParticipationNotification' not found" error when guests try to accept/decline reservation invitations.

Fixes #659