### PR TITLE
chore: ensure all config variables are in both config files

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -29,6 +29,8 @@ jobs:
       - run: pip install --upgrade tox
       - name: Run commitizen (https://commitizen-tools.github.io/commitizen/)
         run: tox -e cz
+      - name: Run config-check
+        run: tox -e config-check
 
   markdownlint:
     runs-on: ubuntu-latest

--- a/ci/config-check.py
+++ b/ci/config-check.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3 -ttu
+# vim: ai ts=4 sts=4 et sw=4
+
+import argparse
+import dataclasses
+import pathlib
+import pprint
+import re
+import sys
+
+
+def main() -> int:
+    args = parse_args()
+
+    dist_path = args.config_dir / "config.dist.php"
+    devel_path = args.config_dir / "config.devel.php"
+    dist_configs = read_config_values(filepath=dist_path)
+    devel_configs = read_config_values(filepath=devel_path)
+
+    exit_value = 0
+    missing_devel = dist_configs - devel_configs
+    if missing_devel:
+        print(f"Config values set in {dist_path} but not in {devel_path}")
+        pprint.pprint(sorted(missing_devel))
+        print()
+        exit_value = 1
+
+    missing_dist = devel_configs - dist_configs
+    if missing_dist:
+        print(f"Config values set in {devel_path} but not in {dist_path}")
+        pprint.pprint(sorted(missing_dist))
+        exit_value = 1
+    return exit_value
+
+
+def read_config_values(*, filepath: pathlib.Path) -> set[str]:
+    configs = set()
+    with open(filepath) as in_file:
+        for line in in_file.readlines():
+            line = line.strip()
+            if not line.startswith("$conf"):
+                continue
+            result = re.search(r"^\$conf\S+", line)
+            if not result:
+                raise ValueError(f"Invalid configuration line: {line}")
+            conf_value = result.group()[5:]
+            configs.add(conf_value)
+    return configs
+
+
+@dataclasses.dataclass(kw_only=True)
+class ProgramArgs:
+    config_dir: pathlib.Path
+
+
+def parse_args() -> ProgramArgs:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("config_dir")
+
+    args = parser.parse_args()
+    args.config_dir = pathlib.Path(args.config_dir).expanduser().resolve()
+    return ProgramArgs(**vars(args))
+
+
+if "__main__" == __name__:
+    sys.exit(main())

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -18,6 +18,7 @@ $conf['settings']['company.url'] = '';                          // URL of compan
 $conf['settings']['default.page.size'] = '50';                  // number of records per page
 $conf['settings']['enable.email'] = 'true';                     // global configuration to enable if any emails will be sent
 $conf['settings']['default.language'] = 'en_us';                // find your language in the lang directory
+$conf['settings']['enforce.custom.mail.template'] = 'false';    // Fallback to default.language for missing custom templates, but only when custom template is available for default.language
 $conf['settings']['script.url'] = '';                           // public URL to the Web directory of this instance. this is the URL that appears when you are logging in. leave http: or https: off to auto-detect
 $conf['settings']['image.upload.directory'] = 'Web/uploads/images'; // full or relative path to where images will be stored
 $conf['settings']['image.upload.url'] = 'uploads/images';       // full or relative path to show uploaded images from
@@ -30,6 +31,7 @@ $conf['settings']['registration.notify.admin'] = 'false';       // whether the r
 $conf['settings']['inactivity.timeout'] = '30';                 // minutes before the user is automatically logged out
 $conf['settings']['name.format'] = '{first} {last}';            // display format when showing user names
 $conf['settings']['css.extension.file'] = '';                   // full or relative url to an additional css file to include. this can be used to override the default style
+$conf['settings']['css.theme'] = 'default';                          //default, dimgray, dark_red, dark_green, french_blue, orange,
 $conf['settings']['disable.password.reset'] = 'false';          // if the password reset functionality should be disabled
 $conf['settings']['home.url'] = '';                             // the url to open when the logo is clicked
 $conf['settings']['logout.url'] = '';                           // the url to be directed to after logging out
@@ -187,6 +189,8 @@ $conf['settings']['google.analytics']['tracking.id'] = ''; // if set, Google Ana
 
 $conf['settings']['authentication']['allow.facebook.login'] = 'false';
 $conf['settings']['authentication']['allow.google.login'] = 'false';
+$conf['settings']['authentication']['allow.microsoft.login'] = 'false';
+$conf['settings']['authentication']['allow.oauth2.login'] = 'false';
 $conf['settings']['authentication']['required.email.domains'] = '';
 $conf['settings']['authentication']['hide.booked.login.prompt'] = 'false';
 $conf['settings']['authentication']['captcha.on.login'] = 'false';
@@ -210,6 +214,9 @@ $conf['settings']['tablet.view']['auto.suggest.emails'] = 'false';
 $conf['settings']['registration']['require.phone'] = 'false';
 $conf['settings']['registration']['require.position'] = 'false';
 $conf['settings']['registration']['require.organization'] = 'false';
+$conf['settings']['registration']['hide.phone'] = 'false';                  //Hide phone field when 'true', but show it when the phone is required
+$conf['settings']['registration']['hide.position'] = 'false';               //Hide position field when 'true', but show it when the phone is required
+$conf['settings']['registration']['hide.organization'] = 'false';           //Hide organization field when 'true', but show it when the phone is required
 /**
  * Error logging
  */
@@ -217,6 +224,54 @@ $conf['settings']['logging']['folder'] = '/var/log/librebooking/log'; //Absolute
 $conf['settings']['logging']['level'] = 'debug'; //Set to none disable logs, error to only log errors or debug to log all messages to the app.log file
 $conf['settings']['logging']['sql'] = 'false'; //Set to true no enable the creation of and sql.log file
 
+// IN THE REDIRECT URIs (OF THE AUTHENTICATION YOU ARE USING) YOU NEED TO ADD THE PATH FROM THE WEBSITE DOMAIN TO THE
+// WEB/GOOGLE-AUTH.PHP or WEB/FACEBOOK-AUTH.PHP or WEB/MICROSOFT-AUTH.PHP (depending on the services you are using)
+// EG: http://localhost/Web/facebook-auth.php
+/**
+ * Google login configuration
+ */
+$conf['settings']['authentication']['google.client.id'] = '';
+$conf['settings']['authentication']['google.client.secret'] = '';
+$conf['settings']['authentication']['google.redirect.uri'] = '/Web/google-auth.php';
+/**
+ * Microsoft login configuration
+ */
+$conf['settings']['authentication']['microsoft.client.id'] = '';
+$conf['settings']['authentication']['microsoft.tenant.id'] = 'common'; //Replace with your tenant id if the app is single tenant
+$conf['settings']['authentication']['microsoft.client.secret'] = '';
+$conf['settings']['authentication']['microsoft.redirect.uri'] = '/Web/microsoft-auth.php';
+/**
+ * Facebook login configuration
+ */
+$conf['settings']['authentication']['facebook.client.id'] = '';
+$conf['settings']['authentication']['facebook.client.secret'] = '';
+$conf['settings']['authentication']['facebook.redirect.uri'] = '/Web/facebook-auth.php';
+/**
+ * Keycloak login configuration
+ */
+$conf['settings']['authentication']['keycloak.url'] = '';
+$conf['settings']['authentication']['keycloak.realm'] = '';
+$conf['settings']['authentication']['keycloak.client.id'] = '';
+$conf['settings']['authentication']['keycloak.client.secret'] = '';
+$conf['settings']['authentication']['keycloak.client.uri'] = '/Web/keycloak-auth.php';
+/**
+ * OAuth2 login configuration
+ */
+$conf['settings']['authentication']['oauth2.name'] = 'OAuth2';
+$conf['settings']['authentication']['oauth2.url.authorize'] = '';
+$conf['settings']['authentication']['oauth2.url.token'] = '';
+$conf['settings']['authentication']['oauth2.url.userinfo'] = '';
+$conf['settings']['authentication']['oauth2.client.id'] = '';
+$conf['settings']['authentication']['oauth2.client.secret'] = '';
+$conf['settings']['authentication']['oauth2.client.uri'] = '/Web/oauth2-auth.php';
+/**
+ * Delete old data job configuration
+ * Activate the deleteolddata.php as a background job to use this feature
+ */
+$conf['settings']['delete.old.data']['years.old.data'] = '3';               //Choose how long a blackout, announcement and reservation stay in the database (in years) counting from the end date
+$conf['settings']['delete.old.data']['delete.old.announcements'] = 'false'; //Choose if this feature deletes old announcements from database
+$conf['settings']['delete.old.data']['delete.old.blackouts'] = 'false';     //Choose if this feature deletes old blackouts from database
+$conf['settings']['delete.old.data']['delete.old.reservations'] = 'false';  //Choose if this feature deletes old reservations from database
 
 /**
  * API Granularity Settings

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -18,7 +18,7 @@ $conf['settings']['company.url'] = '';                          // URL of compan
 $conf['settings']['default.page.size'] = '50';                  // number of records per page
 $conf['settings']['enable.email'] = 'true';                     // global configuration to enable if any emails will be sent
 $conf['settings']['default.language'] = 'en_us';                // find your language in the lang directory
-$conf['settings']['enforce.custom.mail.template'] = 'false';    // Fallback to default.language for missing custom templates, bu only when custom template is available for default.language
+$conf['settings']['enforce.custom.mail.template'] = 'false';    // Fallback to default.language for missing custom templates, but only when custom template is available for default.language
 $conf['settings']['script.url'] = '';                           // public URL to the Web directory of this instance. this is the URL that appears when you are logging in. leave http: or https: off to auto-detect
 $conf['settings']['image.upload.directory'] = 'Web/uploads/images'; // full or relative path to where images will be stored
 $conf['settings']['image.upload.url'] = 'uploads/images';       // full or relative path to show uploaded images from
@@ -224,7 +224,7 @@ $conf['settings']['logging']['folder'] = '/var/log/librebooking/log'; //Absolute
 $conf['settings']['logging']['level'] = 'none'; //Set to none disable logs, error to only log errors or debug to log all messages to the app.log file
 $conf['settings']['logging']['sql'] = 'false'; //Set to true no enable the creation of and sql.log file
 
-// IN THE REDIRECT URI'S (OF THE AUTHENTICATION YOU ARE USING) YOU NEED TO ADD THE PATH FROM THE WEBSITE DOMAIN TO THE
+// IN THE REDIRECT URIs (OF THE AUTHENTICATION YOU ARE USING) YOU NEED TO ADD THE PATH FROM THE WEBSITE DOMAIN TO THE
 // WEB/GOOGLE-AUTH.PHP or WEB/FACEBOOK-AUTH.PHP or WEB/MICROSOFT-AUTH.PHP (depending on the services you are using)
 // EG: http://localhost/Web/facebook-auth.php
 /**

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 minversion = 4.0
 skipsdist = True
 skip_missing_interpreters = True
-envlist = cz
+envlist = cz,config-check
 
 [testenv]
 passenv =
@@ -29,6 +29,13 @@ commands =
   # Ensure that our starting commit is really an ancestor of HEAD
   git merge-base --is-ancestor 8a420dd06cb2b07748953255420556b0ded7d769 HEAD
   cz check --rev-range 8a420dd06cb2b07748953255420556b0ded7d769..HEAD
+
+[testenv:config-check]
+basepython = python3
+deps = -r{toxinidir}/requirements-lint.txt
+allowlist_externals = {toxinidir}/ci/config-check.py
+commands =
+  {toxinidir}/ci/config-check.py {toxinidir}/config/
 
 [testenv:docs]
 description = Builds the docs site. Generated HTML files will be available in '{env:DOCS_BUILD}'.


### PR DESCRIPTION
config.devel.php was missing some config setting that were present in config.dist.php. This caused some failures.

In particular the missing 'enforce.custom.mail.template' setting caused a failure.

Also add a CI check to make sure the config files stay in sync. It does not require the values are in sync but that all settings are defined in both files.