### PR TITLE
fix(reservation): pdf generation is not working in French

### DIFF
--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -411,7 +411,7 @@ class fr_fr extends en_gb
         $strings['hours'] = 'heures';
         $strings['days'] = 'jours';
         $strings['ReminderBeforeStart'] = 'avant l\'heure de début';
-        $strings['ReminderBeforeEnd'] = 'après l\'heure de fin';
+        $strings['ReminderBeforeEnd'] = 'avant l\'heure de fin';
         $strings['Logo'] = 'Logo';
         $strings['CssFile'] = 'Fichier CSS';
         $strings['ThemeUploadSuccess'] = 'Vos modifications ont été sauvegardées. Rafraîchissez la page pour que les changements prennent effet.';
@@ -502,7 +502,7 @@ class fr_fr extends en_gb
         $strings['AutoReleaseNotification'] = 'Libéré automatiquement dans %s minutes sans confirmation';
         $strings['RequiresCheckInNotification'] = 'Nécessite un check in/out';
         $strings['NoCheckInRequiredNotification'] = 'Ne nécessite pas de check in/out';
-        $strings['RequiresApproval'] = 'Nécessite un ccord';
+        $strings['RequiresApproval'] = 'Nécessite un accord';
         $strings['CheckingIn'] = 'Check In';
         $strings['CheckingOut'] = 'Check Out';
         $strings['CheckIn'] = 'Check In';
@@ -530,10 +530,10 @@ class fr_fr extends en_gb
         $strings['SendAsEmail'] = 'Envoyer par Email';
         $strings['UsersInGroups'] = 'Utilisateurs dans le Groupe';
         $strings['UsersWithAccessToResources'] = 'Utilisateurs avec Accès à la Ressource';
-        $strings['AnnouncementSubject'] = 'Une nouvelle annonce a été posdtée par %s';
+        $strings['AnnouncementSubject'] = 'Une nouvelle annonce a été postée par %s';
         $strings['AnnouncementEmailNotice'] = 'Les utilisateurs recevront cette annonce par email';
         $strings['Day'] = 'Jour';
-        $strings['NotifyWhenAvailable'] = 'Me notifier Quand Disponible';
+        $strings['NotifyWhenAvailable'] = 'Me notifier quand disponible';
         $strings['AddingToWaitlist'] = 'Rajouté à la liste d\'attente';
         $strings['WaitlistRequestAdded'] = 'Vous serez notifié si cet horaire devient disponible';
         $strings['PrintQRCode'] = 'Imprimer le code QR';

--- a/tpl/Reservation/pdf.tpl
+++ b/tpl/Reservation/pdf.tpl
@@ -254,10 +254,12 @@ $('.btnPDF').click(function (e) {
 		body: [
 		[{ content: '{translate key="SendReminder"}', styles: { fontStyle: 'bold'}},
 		{if $ReminderTimeStart neq ''}
-		{ content: '{$ReminderTimeStart} {translate key=$ReminderIntervalStart} {translate key=ReminderBeforeStart}'},
+		{assign var="ReminderBeforeStart" value="{translate key=ReminderBeforeStart}"}
+		{ content: '{$ReminderTimeStart} {translate key=$ReminderIntervalStart} {$ReminderBeforeStart|escape:'javascript'}'},
 		{/if}
 		{if $ReminderTimeEnd neq ''}
-		{ content: '{$ReminderTimeEnd} {translate key=$ReminderIntervalEnd} {translate key=ReminderBeforeEnd}'},
+		{assign var="ReminderBeforeEnd" value="{translate key=ReminderBeforeEnd}"}
+		{ content: '{$ReminderTimeEnd} {translate key=$ReminderIntervalEnd} {$ReminderBeforeEnd|escape:'javascript'}'},
 		{/if}
 		],
 		]


### PR DESCRIPTION
When a reminder is set and the language is set to French, the reservation pdf can't be generated because the template does not escape for javascript after translation. In French the default string contains an apostrophe and this is breaking the javascript code. It also makes the update of the reservation impossible since the javascript code generate an error. Adding "|escape:'javascript'" to ReminderBeforeStart and ReminderBeforeEnd fix the problem. The code also fix the French translation.

Closes: #584