### PR TITLE
chore: fix phpstan 'variable.missing' error

### DIFF
--- a/lib/Email/EmailMessage.php
+++ b/lib/Email/EmailMessage.php
@@ -29,6 +29,7 @@ abstract class EmailMessage implements IEmailMessage
 
         $this->Set('ScriptUrl', Configuration::Instance()->GetScriptUrl());
         $this->Set('Charset', $resources->Charset);
+        $appTitle = Configuration::Instance()->GetKey(ConfigKeys::APP_TITLE);
         $this->Set('AppTitle', (empty($appTitle) ? 'LibreBooking' : $appTitle));
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -295,12 +295,6 @@ parameters:
 			path: lib/Database/Commands/Commands.php
 
 		-
-			message: '#^Undefined variable\: \$appTitle$#'
-			identifier: variable.undefined
-			count: 1
-			path: lib/Email/EmailMessage.php
-
-		-
 			message: '#^Call to static method Contains\(\) on an unknown class AvailableLanguages\.$#'
 			identifier: class.notFound
 			count: 1


### PR DESCRIPTION
The variable `$appTitle` was not defined.