### PR TITLE
chore(phpstan): replace deprecated regex 'e' modifier with preg_replace_callback

### DIFF
--- a/lib/GoogleVoice/GoogleVoice.php
+++ b/lib/GoogleVoice/GoogleVoice.php
@@ -278,8 +278,12 @@ class GoogleVoice
     private function _unhtmlentities($string)
     {
         // replace numeric entities
-        $string = preg_replace('~&#x([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $string);
-        $string = preg_replace('~&#([0-9]+);~e', 'chr("\\1")', $string);
+        $string = preg_replace_callback('~&#x([0-9a-f]+);~i', function($matches) {
+            return chr(hexdec($matches[1]));
+        }, $string);
+        $string = preg_replace_callback('~&#([0-9]+);~', function($matches) {
+            return chr((int)$matches[1]);
+        }, $string);
         // replace literal entities
         $string = html_entity_decode($string);
         return $string;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -301,18 +301,6 @@ parameters:
 			path: lib/FileSystem/Paths.php
 
 		-
-			message: '#^Regex pattern is invalid\: Unknown modifier ''e'' in pattern\: ~&\#\(\[0\-9\]\+\);~e$#'
-			identifier: regexp.pattern
-			count: 1
-			path: lib/GoogleVoice/GoogleVoice.php
-
-		-
-			message: '#^Regex pattern is invalid\: Unknown modifier ''e'' in pattern\: ~&\#x\(\[0\-9a\-f\]\+\);~ei$#'
-			identifier: regexp.pattern
-			count: 1
-			path: lib/GoogleVoice/GoogleVoice.php
-
-		-
 			message: '#^Function IsUserInGroup not found\.$#'
 			identifier: function.notFound
 			count: 3


### PR DESCRIPTION
Replace preg_replace() with deprecated 'e' modifier using
preg_replace_callback() in GoogleVoice._unhtmlentities() method. This
maintains the original numeric entity handling behavior while
eliminating possible security risks.

Did not change only use 'html_entity_decode()' as wasn't sure it would
be an exact replacement.
