### PR TITLE
chore(phpstan): resolve 'arguments.count' error

### DIFF
--- a/lib/Application/Reservation/Notification/InviteeUpdatedEmailNotification.php
+++ b/lib/Application/Reservation/Notification/InviteeUpdatedEmailNotification.php
@@ -46,7 +46,7 @@ class InviteeUpdatedEmailNotification extends InviteeAddedEmailNotification
 
             $invitee = $this->userRepository->LoadById($userId);
 
-            $message = new InviteeRemovedEmail($owner, $invitee, $reservationSeries, $this->attributeRepository);
+            $message = new InviteeRemovedEmail($owner, $invitee, $reservationSeries, $this->attributeRepository, $this->userRepository);
             ServiceLocator::GetEmailService()->Send($message);
         }
     }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -265,12 +265,6 @@ parameters:
 			path: lib/Application/Reporting/ReportColumn.php
 
 		-
-			message: '#^Class InviteeRemovedEmail constructor invoked with 4 parameters, 5 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: lib/Application/Reservation/Notification/InviteeUpdatedEmailNotification.php
-
-		-
 			message: '#^Deprecated in PHP 8\.4\: Parameter \#2 \$session \(UserSession\) is implicitly nullable via default value null\.$#'
 			identifier: parameter.implicitlyNullable
 			count: 2


### PR DESCRIPTION
Add missing $userRepository parameter to InviteeRemovedEmail constructor call in InviteeUpdatedEmailNotification.php. The constructor requires 5 parameters but was being called with only 4.