### PR TITLE
fix(phpstan): resolve 'new.noConstructor' error in AuthenticationResp…

### DIFF
--- a/WebServices/Responses/AuthenticationResponse.php
+++ b/WebServices/Responses/AuthenticationResponse.php
@@ -18,7 +18,7 @@ class AuthenticationResponse extends RestResponse
      */
     public static function Success(IRestServer $server, $userSession, $version)
     {
-        $response = new AuthenticationResponse($server);
+        $response = new AuthenticationResponse();
         $response->sessionToken = $userSession->SessionToken;
         $response->sessionExpires = $userSession->SessionExpiration;
         $response->isAuthenticated = true;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -223,12 +223,6 @@ parameters:
 			path: WebServices/Controllers/ReservationSaveController.php
 
 		-
-			message: '#^Class AuthenticationResponse does not have a constructor and must be instantiated without any parameters\.$#'
-			identifier: new.noConstructor
-			count: 1
-			path: WebServices/Responses/AuthenticationResponse.php
-
-		-
 			message: '#^Method ScheduleWebServicePageBuilder\:\:GetGroupId\(\) should return int but return statement is missing\.$#'
 			identifier: return.missing
 			count: 1


### PR DESCRIPTION
…onse

Remove unnecessary $server parameter from AuthenticationResponse constructor call in Success() method. The class doesn't have a constructor and the parameter is only used after object creation for AddService() calls.