### PR TITLE
fix(phpstan): resolve parameter.implicitlyNullable errors

### DIFF
--- a/lib/Application/Reporting/ReportColumn.php
+++ b/lib/Application/Reporting/ReportColumn.php
@@ -94,9 +94,9 @@ abstract class ReportColumn
 
     /**
      * @param $titleKey string
-     * @param $chartColumnDefinition ChartColumnDefinition
+     * @param $chartColumnDefinition ChartColumnDefinition|null
      */
-    public function __construct($titleKey, ChartColumnDefinition $chartColumnDefinition = null)
+    public function __construct($titleKey, ?ChartColumnDefinition $chartColumnDefinition = null)
     {
         $this->titleKey = $titleKey;
         $this->chartColumnDefinition = $chartColumnDefinition;
@@ -164,7 +164,7 @@ abstract class ReportColumn
 
 class ReportStringColumn extends ReportColumn
 {
-    public function __construct($titleKey, ChartColumnDefinition $chartColumnDefinition)
+    public function __construct($titleKey, ?ChartColumnDefinition $chartColumnDefinition = null)
     {
         parent::__construct(null, $chartColumnDefinition);
         $this->titleKey = $titleKey;
@@ -173,7 +173,7 @@ class ReportStringColumn extends ReportColumn
 
 class ReportAttributeColumn extends ReportColumn
 {
-    public function __construct($title, ChartColumnDefinition $chartColumnDefinition)
+    public function __construct($title, ?ChartColumnDefinition $chartColumnDefinition = null)
     {
         parent::__construct(null, $chartColumnDefinition);
         $this->title = $title;
@@ -203,7 +203,7 @@ class ReportDateColumn extends ReportColumn
     private $timezone;
     private $format;
 
-    public function __construct($titleKey, $timezone, $format, ChartColumnDefinition $chartColumnDefinition)
+    public function __construct($titleKey, $timezone, $format, ?ChartColumnDefinition $chartColumnDefinition = null)
     {
         parent::__construct($titleKey, $chartColumnDefinition);
         $this->timezone = $timezone;
@@ -236,7 +236,7 @@ class ReportTimeColumn extends ReportColumn
 {
     private $includeTotalHours;
 
-    public function __construct($titleKey, ChartColumnDefinition $chartColumnDefinition, $includeTotalHours = true)
+    public function __construct($titleKey, ?ChartColumnDefinition $chartColumnDefinition = null, $includeTotalHours = true)
     {
         parent::__construct($titleKey, $chartColumnDefinition);
         $this->includeTotalHours = $includeTotalHours;
@@ -251,7 +251,7 @@ class ReportTimeColumn extends ReportColumn
 
 class ReportUtilizationColumn extends ReportColumn
 {
-    public function __construct($titleKey, ChartColumnDefinition $chartColumnDefinition)
+    public function __construct($titleKey, ?ChartColumnDefinition $chartColumnDefinition = null)
     {
         parent::__construct($titleKey, $chartColumnDefinition);
     }

--- a/lib/Application/Schedule/ScheduleService.php
+++ b/lib/Application/Schedule/ScheduleService.php
@@ -4,10 +4,10 @@ interface IScheduleService
 {
     /**
      * @param bool $includeInaccessible
-     * @param UserSession $session
+     * @param UserSession|null $session
      * @return Schedule[]
      */
-    public function GetAll($includeInaccessible = true, UserSession $session = null);
+    public function GetAll($includeInaccessible = true, ?UserSession $session = null);
 
     /**
      * @param int $scheduleId
@@ -49,7 +49,7 @@ class ScheduleService implements IScheduleService
         $this->dailyLayoutFactory = $dailyLayoutFactory;
     }
 
-    public function GetAll($includeInaccessible = true, UserSession $session = null)
+    public function GetAll($includeInaccessible = true, ?UserSession $session = null)
     {
         $schedules = $this->scheduleRepository->GetAll();
 

--- a/lib/Database/Commands/Commands.php
+++ b/lib/Database/Commands/Commands.php
@@ -1833,7 +1833,7 @@ class GetReservationsPendingApprovalCommand extends SqlCommand
 
 class GetReservationsMissingCheckInCheckOutCommand extends SqlCommand
 {
-    public function __construct(Date $startDate = null, Date $endDate, $userIds, $userLevelId, $scheduleIds, $resourceIds, $participantIds)
+    public function __construct(?Date $startDate, Date $endDate, $userIds, $userLevelId, $scheduleIds, $resourceIds, $participantIds)
     {
         parent::__construct(QueryBuilder::GET_RESERVATION_MISSING_CHECK_IN_OUT_LIST());
         if ($startDate !== null){

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -241,28 +241,10 @@ parameters:
 			path: lib/Application/Admin/ScheduleAdminScheduleRepository.php
 
 		-
-			message: '#^Deprecated in PHP 8\.4\: Parameter \#2 \$chartColumnDefinition \(ChartColumnDefinition\) is implicitly nullable via default value null\.$#'
-			identifier: parameter.implicitlyNullable
-			count: 1
-			path: lib/Application/Reporting/ReportColumn.php
-
-		-
-			message: '#^Deprecated in PHP 8\.4\: Parameter \#2 \$session \(UserSession\) is implicitly nullable via default value null\.$#'
-			identifier: parameter.implicitlyNullable
-			count: 2
-			path: lib/Application/Schedule/ScheduleService.php
-
-		-
 			message: '#^Call to static method GetAvailableLanguages\(\) on an unknown class AvailableLanguages\.$#'
 			identifier: class.notFound
 			count: 1
 			path: lib/Common/Resources.php
-
-		-
-			message: '#^Deprecated in PHP 8\.4\: Parameter \#1 \$startDate \(Date\) is implicitly nullable via default value null\.$#'
-			identifier: parameter.implicitlyNullable
-			count: 1
-			path: lib/Database/Commands/Commands.php
 
 		-
 			message: '#^Call to static method Contains\(\) on an unknown class AvailableLanguages\.$#'


### PR DESCRIPTION
* Make ChartColumnDefinition parameter explicitly nullable in ReportColumn constructors
* Make UserSession parameter explicitly nullable in ScheduleService::GetAll()
* Make Date startDate parameter explicitly nullable in GetReservationsMissingCheckInCheckOutCommand
* Update corresponding docblocks to reflect nullable types