### PR TITLE
fix(phpstan): remove unused ReminderRepository::Add method

### DIFF
--- a/Domain/Access/ReminderRepository.php
+++ b/Domain/Access/ReminderRepository.php
@@ -20,19 +20,6 @@ class ReminderRepository implements IReminderRepository
         return $reminders;
     }
 
-    /**
-     * @param Reminder $reminder
-     */
-    public function Add(Reminder $reminder)
-    {
-        ServiceLocator::GetDatabase()->ExecuteInsert(new AddReminderCommand(
-            $reminder->UserID(),
-            $reminder->Address(),
-            $reminder->Message(),
-            $reminder->SendTime(),
-            $reminder->RefNumber()
-        ));
-    }
 
     /**
      * @param string $user_id
@@ -119,11 +106,6 @@ interface IReminderRepository
      */
     public function GetAll();
 
-    /**
-     * @abstract
-     * @param Reminder $reminder
-     */
-    public function Add(Reminder $reminder);
 
     /**
      * @abstract

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Instantiated class AddReminderCommand not found\.$#'
-			identifier: class.notFound
-			count: 1
-			path: Domain/Access/ReminderRepository.php
-
-		-
 			message: '#^Parameter \$item of method DashboardPage\:\:AddItem\(\) has invalid type DashboardItem\.$#'
 			identifier: class.notFound
 			count: 1


### PR DESCRIPTION
Remove the unused Add() method from both ReminderRepository class and IReminderRepository interface. This method was not used in the codebase.

Fixes PHPStan error for missing AddReminderCommand class by eliminating the dead code that referenced it.