### PR TITLE
chore(phpstan): scan remaining directories

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,43 +1,955 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Function mcrypt_enc_get_iv_size not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: lib/external/Slim/Http/Util.php
+			message: '#^Class LBAttribute referenced with incorrect case\: LBATtribute\.$#'
+			identifier: class.nameCase
+			count: 1
+			path: tests/Application/Attributes/AttributeListTest.php
 
 		-
-			message: '#^Function mcrypt_enc_get_key_size not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: lib/external/Slim/Http/Util.php
+			message: '#^Class ScheduleAvailabilityRule constructor invoked with 1 parameter, 2 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: tests/Application/Reservation/ScheduleAvailabilityRuleTest.php
 
 		-
-			message: '#^Function mcrypt_generic not found\.$#'
+			message: '#^Method TestReservationListing\:\:Count\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Domain/Reservation/ReservationServiceTest.php
+
+		-
+			message: '#^Method TestReservationListing\:\:ForResource\(\) should return IReservationListing but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Domain/Reservation/ReservationServiceTest.php
+
+		-
+			message: '#^Method TestReservationListing\:\:OnDate\(\) should return IDateReservationListing but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Domain/Reservation/ReservationServiceTest.php
+
+		-
+			message: '#^Method TestReservationListing\:\:OnDateForResource\(\) should return array\<ReservationListItem\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Domain/Reservation/ReservationServiceTest.php
+
+		-
+			message: '#^Method TestReservationListing\:\:Reservations\(\) should return array\<ReservationItemView\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Domain/Reservation/ReservationServiceTest.php
+
+		-
+			message: '#^Method FakeManageConfigurationPage\:\:GetConfigFileToEdit\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageConfigurationPresenterTest.php
+
+		-
+			message: '#^Method FakeManageConfigurationPage\:\:GetHomePageId\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageConfigurationPresenterTest.php
+
+		-
+			message: '#^Method FakeManageUsersPage\:\:GetImportFile\(\) should return UploadedFile but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageUsersPresenterTest.php
+
+		-
+			message: '#^Method FakeManageUsersPage\:\:GetInvitedEmails\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageUsersPresenterTest.php
+
+		-
+			message: '#^Method FakeManageUsersPage\:\:GetName\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageUsersPresenterTest.php
+
+		-
+			message: '#^Method FakeManageUsersPage\:\:GetReservationColor\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageUsersPresenterTest.php
+
+		-
+			message: '#^Method FakeManageUsersPage\:\:GetUpdateOnImport\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageUsersPresenterTest.php
+
+		-
+			message: '#^Method FakeManageUsersPage\:\:GetValue\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageUsersPresenterTest.php
+
+		-
+			message: '#^Method FakeManageUsersPage\:\:SendEmailNotification\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Admin/ManageUsersPresenterTest.php
+
+		-
+			message: '#^Method FakeCalendarSubscriptionPage\:\:GetAccessoryIds\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/CalendarSubscriptionPresenterTest.php
+
+		-
+			message: '#^Method FakeEmbeddedCalendarPage\:\:GetTitleFormat\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/EmbeddedCalendarPresenterTest.php
+
+		-
+			message: '#^Method FakeLoginPage\:\:GetCaptcha\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/LoginPresenterTest.php
+
+		-
+			message: '#^Method FakeGuestReservationPage\:\:GetEndDate\(\) should return Date but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/GuestReservationPresenterTest.php
+
+		-
+			message: '#^Method FakeGuestReservationPage\:\:GetReservationDate\(\) should return Date but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/GuestReservationPresenterTest.php
+
+		-
+			message: '#^Method FakeGuestReservationPage\:\:GetStartDate\(\) should return Date but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/GuestReservationPresenterTest.php
+
+		-
+			message: '#^Method FakeGuestReservationPage\:\:IsUnavailable\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/GuestReservationPresenterTest.php
+
+		-
+			message: '#^Method FakeReservationAttributesPage\:\:GetRequestedResourceIds\(\) should return array\<int\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/ReservationAttributesPresenterTest.php
+
+		-
+			message: '#^Method FakeReservationMovePage\:\:GetRetryParameters\(\) should return array\<ReservationRetryParameter\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/ReservationMovePresenterTest.php
+
+		-
+			message: '#^Method FakeReservationWaitlistPage\:\:GetAction\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/ReservationWaitlistPresenterTest.php
+
+		-
+			message: '#^Method FakeReservationWaitlistPage\:\:GetReferenceNumber\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/ReservationWaitlistPresenterTest.php
+
+		-
+			message: '#^Method FakeReservationWaitlistPage\:\:GetRetryParameters\(\) should return array\<ReservationRetryParameter\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Reservation/ReservationWaitlistPresenterTest.php
+
+		-
+			message: '#^Method TestResourceDisplayPage\:\:GetResourceId\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/ResourceDisplayPresenterTest.php
+
+		-
+			message: '#^Method TestResourceDisplayPage\:\:GetTermsOfServiceAcknowledgement\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/ResourceDisplayPresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:FilterCleared\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetDisplayTimezone\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetGroupId\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetLayoutDate\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetOwnerText\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetParticipantText\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetResourceId\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetScheduleId\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetScheduleStyle\(\) should return ScheduleStyle\|string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetSelectedDate\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSchedulePage\:\:GetShowFullWeek\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/SchedulePresenterTest.php
+
+		-
+			message: '#^Method FakeSearchReservationsPage\:\:GetRequestedEndDate\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Search/SearchReservationsPresenterTest.php
+
+		-
+			message: '#^Method FakeSearchReservationsPage\:\:GetRequestedStartDate\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/Presenters/Search/SearchReservationsPresenterTest.php
+
+		-
+			message: '#^Cannot instantiate class PHPUnit\\Framework\\TestSuite via private constructor PHPUnit\\Framework\\TestSuite\:\:__construct\(\)\.$#'
+			identifier: new.privateConstructor
+			count: 1
+			path: tests/TestHelper.php
+
+		-
+			message: '#^Class PHPUnit\\Framework\\TestSuite constructor invoked with 0 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: tests/TestHelper.php
+
+		-
+			message: '#^Instantiated class UnitTest not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: tests/TestHelper.php
+
+		-
+			message: '#^Access to an undefined property TestSlim\:\:\$getResponse\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/WebService/SlimWebServiceRegistryTest.php
+
+		-
+			message: '#^Method FakeAccountController\:\:GetUserAttributes\(\) should return IEntityAttributeList but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/WebServices/AccountWebServiceTest.php
+
+		-
+			message: '#^Method FakeAccountController\:\:LoadUser\(\) should return User but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/WebServices/AccountWebServiceTest.php
+
+		-
+			message: '#^Used function PHPSTORM_META\\map not found\.$#'
 			identifier: function.notFound
 			count: 1
-			path: lib/external/Slim/Http/Util.php
+			path: tests/WebServices/SchedulesWebServiceTest.php
 
 		-
-			message: '#^Function mcrypt_generic_deinit not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: lib/external/Slim/Http/Util.php
-
-		-
-			message: '#^Function mcrypt_generic_init not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: lib/external/Slim/Http/Util.php
-
-		-
-			message: '#^Function mcrypt_module_open not found\.$#'
-			identifier: function.notFound
-			count: 2
-			path: lib/external/Slim/Http/Util.php
-
-		-
-			message: '#^Function mdecrypt_generic not found\.$#'
-			identifier: function.notFound
+			message: '#^Access to an undefined property FakeDBConnection\:\:\$_LastSqlCommand\.$#'
+			identifier: property.notFound
 			count: 1
-			path: lib/external/Slim/Http/Util.php
+			path: tests/fakes/DBFakes.php
+
+		-
+			message: '#^Interface IDbConnection referenced with incorrect case\: IDBConnection\.$#'
+			identifier: interface.nameCase
+			count: 1
+			path: tests/fakes/DBFakes.php
+
+		-
+			message: '#^Method FakeDBConnection\:\:LimitQuery\(\) should return IReader but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/DBFakes.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$allowMultiDay\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$autoAssign\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$color\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$contact\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$creditCount\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$description\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$location\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$maxLength\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$maxNotice\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$maxParticipants\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$minLength\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$minNoticeAdd\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$minNoticeDelete\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$minNoticeUpdate\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$notes\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$peakCreditCount\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$requiresApproval\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$resourceName\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$scheduleId\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ReservationResourceRow\:\:\$statusId\.$#'
+			identifier: property.notFound
+			count: 2
+			path: tests/fakes/DBRows.php
+
+		-
+			message: '#^Access to an undefined property ExistingReservationSeriesBuilder\:\:\$resources\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/ExistingReservationSeriesBuilder.php
+
+		-
+			message: '#^Method FakeAccessoryRepository\:\:Add\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeAccessoryRepository.php
+
+		-
+			message: '#^Method FakeAccessoryRepository\:\:LoadById\(\) should return Accessory but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeAccessoryRepository.php
+
+		-
+			message: '#^Method FakeAnnouncementRepository\:\:GetAll\(\) should return array\<Announcement\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeAnnouncements.php
+
+		-
+			message: '#^Method FakeAnnouncementRepository\:\:LoadById\(\) should return Announcement but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeAnnouncements.php
+
+		-
+			message: '#^Method FakeAttributeList\:\:GetDefinitions\(\) should return array\<CustomAttribute\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeAttributeList.php
+
+		-
+			message: '#^Method FakeAttributeList\:\:GetLabels\(\) should return array\<string\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeAttributeList.php
+
+		-
+			message: '#^Method FakeAttributeService\:\:GetById\(\) should return CustomAttribute but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeAttributeService.php
+
+		-
+			message: '#^Method FakeBlackoutRepository\:\:Add\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeBlackoutRepository.php
+
+		-
+			message: '#^Method FakeDailyLayout\:\:GetLabels\(\) should return array\<string\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeDailyLayout.php
+
+		-
+			message: '#^Method FakeDailyLayout\:\:GetSummary\(\) should return DailyReservationSummary but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeDailyLayout.php
+
+		-
+			message: '#^Method FakeDailyLayout\:\:IsDateReservable\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeDailyLayout.php
+
+		-
+			message: '#^Method FakeExistingReservationPage\:\:IsUnavailable\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeExistingReservationPage.php
+
+		-
+			message: '#^Method FakeGroupViewRepository\:\:GetGroupsByRole\(\) should return array\<GroupItemView\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeGroupRepository.php
+
+		-
+			message: '#^Method FakeGroupViewRepository\:\:GetPermissionList\(\) should return array\<GroupResourcePermission\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeGroupRepository.php
+
+		-
+			message: '#^Method FakeGroupViewRepository\:\:GetUsersInGroup\(\) should return array\<GroupUserView\>\|PageableData but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeGroupRepository.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$email\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$end_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$end_time\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$id\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$location\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$machid\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$memberid\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$resid\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$resource_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$start_date\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$start_time\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Access to an undefined property FakeReminder\:\:\$timezone\.$#'
+			identifier: property.notFound
+			count: 1
+			path: tests/fakes/FakeReminder.php
+
+		-
+			message: '#^Method FakeReservationCheckinPage\:\:GetRetryParameters\(\) should return array\<ReservationRetryParameter\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationCheckinPage.php
+
+		-
+			message: '#^Method FakeReservationRepository\:\:AddReservationAttachment\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationRepository.php
+
+		-
+			message: '#^Method FakeReservationRepository\:\:AddReservationColorRule\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationRepository.php
+
+		-
+			message: '#^Method FakeReservationRepository\:\:GetReservationColorRule\(\) should return ReservationColorRule but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationRepository.php
+
+		-
+			message: '#^Method FakeReservationRepository\:\:GetReservationColorRules\(\) should return array\<ReservationColorRule\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationRepository.php
+
+		-
+			message: '#^Method FakeReservationRepository\:\:LoadReservationAttachment\(\) should return ReservationAttachment but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationRepository.php
+
+		-
+			message: '#^Method FakeReservationViewRepository\:\:GetReservationsMissingCheckInCheckOut\(\) should return array\<ReservationItemView\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationViewRepository.php
+
+		-
+			message: '#^Method FakeReservationViewRepository\:\:GetReservationsPendingApproval\(\) should return array\<ReservationItemView\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationViewRepository.php
+
+		-
+			message: '#^Method FakeReservationWaitlistRepository\:\:LoadById\(\) should return ReservationWaitlistRequest but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeReservationWaitlistRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:Add\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:AddResourceGroup\(\) should return ResourceGroup but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:AddResourceType\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:AddStatusReason\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetAccessoryList\(\) should return array\<AccessoryDto\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetGroupsWithPermission\(\) should return array\<GroupPermissionItemView\>\|PageableData but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetList\(\) should return array\<BookableResource\>\|PageableData but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetResourceGroups\(\) should return ResourceGroupTree but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetResourceTypes\(\) should return array\<ResourceType\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetStatusReasons\(\) should return array\<ResourceStatusReason\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetUserList\(\) should return array\<BookableResource\>\|PageableData but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetUserResourceList\(\) should return array\<BookableResource\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetUsersWithPermission\(\) should return array\<UserPermissionItemView\>\|PageableData but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:GetUsersWithPermissionsIncludingGroups\(\) should return array\<UserPermissionItemView\>\|PageableData but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:LoadResourceGroup\(\) should return ResourceGroup but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:LoadResourceGroupByPublicId\(\) should return ResourceGroup but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceRepository\:\:LoadResourceType\(\) should return ResourceType but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceRepository.php
+
+		-
+			message: '#^Method FakeResourceService\:\:GetAccessories\(\) should return array\<AccessoryDto\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceService.php
+
+		-
+			message: '#^Method FakeResourceService\:\:GetResource\(\) should return BookableResource but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceService.php
+
+		-
+			message: '#^Method FakeResourceService\:\:GetResourceAttributes\(\) should return array\<Attribute\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceService.php
+
+		-
+			message: '#^Method FakeResourceService\:\:GetResourceGroups\(\) should return ResourceGroupTree but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceService.php
+
+		-
+			message: '#^Method FakeResourceService\:\:GetResourceTypeAttributes\(\) should return array\<Attribute\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceService.php
+
+		-
+			message: '#^Method FakeResourceService\:\:GetResourceTypes\(\) should return array\<ResourceType\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeResourceService.php
+
+		-
+			message: '#^Method FakeRestServer\:\:GetFullServiceUrl\(\) should return string but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeRestServer.php
+
+		-
+			message: '#^Method FakeScheduleLayout\:\:FitsToHours\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeScheduleLayout.php
+
+		-
+			message: '#^Method FakeScheduleLayout\:\:UsesCustomLayout\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeScheduleLayout.php
+
+		-
+			message: '#^Deprecated in PHP 8\.4\: Parameter \#2 \$session \(UserSession\) is implicitly nullable via default value null\.$#'
+			identifier: parameter.implicitlyNullable
+			count: 1
+			path: tests/fakes/FakeScheduleService.php
+
+		-
+			message: '#^Method FakeScheduleRepository\:\:Add\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeSchedules.php
+
+		-
+			message: '#^Method FakeScheduleRepository\:\:GetCustomLayoutPeriodsInRange\(\) should return array\<SchedulePeriod\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeSchedules.php
+
+		-
+			message: '#^Method FakeScheduleRepository\:\:GetList\(\) should return array\<Schedule\>\|PageableData but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeSchedules.php
+
+		-
+			message: '#^Method FakeTermsOfServiceRepository\:\:Add\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeTermsOfServiceRepository.php
+
+		-
+			message: '#^Method FakeUserRepository\:\:Add\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeUserRepository.php
+
+		-
+			message: '#^Method FakeUserRepository\:\:GetApplicationAdmins\(\) should return array\<UserDto\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeUserRepository.php
+
+		-
+			message: '#^Method FakeUserRepository\:\:GetCount\(\) should return int but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeUserRepository.php
+
+		-
+			message: '#^Method FakeUserRepository\:\:GetGroupAdmins\(\) should return array\<UserDto\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeUserRepository.php
+
+		-
+			message: '#^Method FakeUserRepository\:\:GetResourceAdmins\(\) should return array\<UserDto\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeUserRepository.php
+
+		-
+			message: '#^Method FakeUserRepository\:\:LoadGroups\(\) should return array\<UserGroup\> but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeUserRepository.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:AllowEmailAddressChange\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:AllowNameChange\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:AllowOrganizationChange\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:AllowPasswordChange\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:AllowPhoneChange\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:AllowPositionChange\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:AllowUsernameChange\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:AreCredentialsKnown\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:ShowForgotPasswordPrompt\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:ShowPasswordPrompt\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:ShowPersistLoginPrompt\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php
+
+		-
+			message: '#^Method FakeAuthentication\:\:ShowUsernamePrompt\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: tests/fakes/FakeWebAuthentication.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,17 +12,22 @@ parameters:
         - Presenters
         - Web
         - WebServices
+        - config
         - lang/AvailableLanguage.php
         - lang/AvailableLanguages.php
         - lang/Language.php
         - lib
+        - phing-tasks
+        - plugins
+        - tests
     excludePaths:
         analyse:
-            - vendor/
-            - tpl_c/ (?)
-            - build/ (?)
-            - Web/scripts/
             - Web/css/
+            - Web/scripts/
+            - build/ (?)
+            - lib/external/Slim/Http/Util.php
             - plugins/
+            - tpl_c/ (?)
+            - vendor/
     bootstrapFiles:
         - vendor/autoload.php

--- a/tests/fakes/EmailFakes.php
+++ b/tests/fakes/EmailFakes.php
@@ -1,7 +1,9 @@
 <?php
 
 @define('BASE_DIR', dirname(__FILE__) . '/../..');
-require_once(BASE_DIR . '/lib/PHPMailer.class.php');
+require_once(ROOT_DIR . 'lib/Email/namespace.php');
+
+use PHPMailer\PHPMailer\PHPMailer;
 
 class FakeMailer extends PHPMailer
 {
@@ -25,7 +27,7 @@ class FakeMailer extends PHPMailer
         $this->sendWasCalled = true;
     }
 
-    public function IsHTML($bool)
+    public function IsHTML($bool = true)
     {
         $this->isHtml = $bool;
     }


### PR DESCRIPTION
Scan the remaining directories containing PHP code.

Fix issue in tests/fakes/EmailFakes.php that had to be resolved.

Add `lib/external/Slim/Http/Util.php` to the exclude list. We either need to upgrade Slim or replace it.