### PR TITLE
fix(phpstan): array_merge return value & empty checks

### DIFF
--- a/Pages/ActionPage.php
+++ b/Pages/ActionPage.php
@@ -90,7 +90,7 @@ abstract class ActionPage extends Page implements IActionPage
 
             if ($validator->ReturnsErrorResponse()) {
                 http_response_code(400);
-                array_merge($validator->Messages(), $inlineErrors);
+                $inlineErrors = array_merge($validator->Messages(), $inlineErrors);
             }
         }
 

--- a/Pages/Admin/AdminPage.php
+++ b/Pages/Admin/AdminPage.php
@@ -105,7 +105,7 @@ abstract class AdminPage extends SecurePage implements IActionPage
 
             if ($validator->ReturnsErrorResponse()) {
                 http_response_code(400);
-                array_merge($validator->Messages(), $inlineErrors);
+                $inlineErrors = array_merge($validator->Messages(), $inlineErrors);
             }
         }
 

--- a/lib/Common/SmartyPage.php
+++ b/lib/Common/SmartyPage.php
@@ -550,9 +550,6 @@ class SmartyPage extends Smarty
             $dest = $matches[2];
             $dest = 'http://' . $dest;
 
-            if (empty($dest)) {
-                return $matches[0];
-            }
             // removed trailing [,;:] from URL
             if (in_array(substr($dest, -1), ['.', ',', ';', ':']) === true) {
                 $ret = substr($dest, -1);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,18 +7,6 @@ parameters:
 			path: Domain/PaymentGateway.php
 
 		-
-			message: '#^Variable \$inlineErrors in empty\(\) always exists and is always falsy\.$#'
-			identifier: empty.variable
-			count: 1
-			path: Pages/ActionPage.php
-
-		-
-			message: '#^Variable \$inlineErrors in empty\(\) always exists and is always falsy\.$#'
-			identifier: empty.variable
-			count: 1
-			path: Pages/Admin/AdminPage.php
-
-		-
 			message: '#^Static method ParamsValidator\:\:validate\(\) invoked with 4 parameters, 3 required\.$#'
 			identifier: arguments.count
 			count: 1
@@ -95,12 +83,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: lib/Common/Logging/Log.php
-
-		-
-			message: '#^Variable \$dest in empty\(\) always exists and is not falsy\.$#'
-			identifier: empty.variable
-			count: 1
-			path: lib/Common/SmartyPage.php
 
 		-
 			message: '#^Class Slim\\Router constructor invoked with 1 parameter, 0 required\.$#'


### PR DESCRIPTION
  * Assign array_merge result to $inlineErrors in ActionPage and AdminPage
  * Remove unnecessary empty($dest) check in SmartyPage autolink function
  * Update baseline to remove resolved issues