### PR TITLE
fix(phpstan): resolve constructor parameter count mismatches in tests

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -145,12 +145,6 @@ parameters:
 			path: lib/external/pear/PEAR.php
 
 		-
-			message: '#^Class AuthorizationCommand constructor invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Application/Authentication/AuthenticationTest.php
-
-		-
 			message: '#^Method PHPUnit\\Framework\\TestCase\:\:once\(\) invoked with 1 parameter, 0 required\.$#'
 			identifier: arguments.count
 			count: 1
@@ -169,18 +163,6 @@ parameters:
 			path: tests/Application/Reservation/QuotaRuleTest.php
 
 		-
-			message: '#^Class ReservationConflictIdentifier constructor invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Application/Reservation/ResourceAvailabilityRuleTest.php
-
-		-
-			message: '#^Class SchedulePeriod constructor invoked with 4 parameters, 2\-3 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Application/Schedule/DailyLayoutTest.php
-
-		-
 			message: '#^Class TestReservationItemView constructor invoked with 6 parameters, 3\-5 required\.$#'
 			identifier: arguments.count
 			count: 1
@@ -193,28 +175,10 @@ parameters:
 			path: tests/Domain/Reservation/QuotaTest.php
 
 		-
-			message: '#^Class AccessoryReservation constructor invoked with 6 parameters, 5 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Domain/Reservation/ReservationViewRepositoryTest.php
-
-		-
-			message: '#^Class ResourceGroupAssignment constructor invoked with 16 parameters, 15 required\.$#'
-			identifier: arguments.count
-			count: 4
-			path: tests/Domain/Resource/ResourceGroupTest.php
-
-		-
 			message: '#^Static method Date\:\:ParseExact\(\) invoked with 2 parameters, 1 required\.$#'
 			identifier: arguments.count
 			count: 1
 			path: tests/Infrastructure/Common/DateTest.php
-
-		-
-			message: '#^Class ConfigSetting constructor invoked with 4 parameters, 3 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Presenters/Admin/ManageConfigurationPresenterTest.php
 
 		-
 			message: '#^Method ManageConfigurationPresenterTest\:\:assertSectionSettingExists\(\) invoked with 4 parameters, 3 required\.$#'

--- a/tests/Application/Authentication/AuthenticationTest.php
+++ b/tests/Application/Authentication/AuthenticationTest.php
@@ -124,7 +124,7 @@ class AuthenticationTest extends TestBase
 
         $this->auth->Validate($this->username, $this->password);
 
-        $command = new AuthorizationCommand(strtolower($this->username), $this->password);
+        $command = new AuthorizationCommand(strtolower($this->username));
 
         $this->assertEquals($command, $this->db->_LastCommand);
     }

--- a/tests/Application/Reservation/ResourceAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/ResourceAvailabilityRuleTest.php
@@ -472,7 +472,7 @@ class ResourceAvailabilityRuleTest extends TestBase
                  ->method('GetItemsBetween')
                  ->willReturn($reservations);
 
-        $rule = new ResourceAvailabilityRule(new ReservationConflictIdentifier($strategy, $this->scheduleRepository), 'UTC');
+        $rule = new ResourceAvailabilityRule(new ReservationConflictIdentifier($strategy), 'UTC');
         $result = $rule->Validate($reservation, [new ReservationRetryParameter(ReservationRetryParameter::$SKIP_CONFLICTS, true)]);
 
         $this->assertTrue($result->IsValid(), 'should have skipped conflicts');

--- a/tests/Application/Schedule/DailyLayoutTest.php
+++ b/tests/Application/Schedule/DailyLayoutTest.php
@@ -50,7 +50,7 @@ class DailyLayoutTest extends TestBase
         $displayDate = Date::Parse('2010-03-17', 'America/Chicago');
 
         $periods[] = new SchedulePeriod(Date::Parse('2010-03-16 20:30'), Date::Parse('2010-03-17 12:30'));
-        $periods[] = new SchedulePeriod(Date::Parse('2010-03-17 12:30'), Date::Parse('2010-03-17 20:30'), "start", "end");
+        $periods[] = new SchedulePeriod(Date::Parse('2010-03-17 12:30'), Date::Parse('2010-03-17 20:30'), "start");
         $periods[] = new SchedulePeriod(Date::Parse('2010-03-17 20:30'), Date::Parse('2010-03-18 12:30'));
 
         $scheduleLayout = $this->createMock('IScheduleLayout');

--- a/tests/Domain/Reservation/ReservationViewRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationViewRepositoryTest.php
@@ -453,7 +453,7 @@ class ReservationViewRepositoryTest extends TestBase
 
         $accessories = $this->repository->GetAccessoriesWithin($dateRange);
 
-        $a = new AccessoryReservation($refNum, $start->ToUtc(), $end->ToUtc(), $accessoryId, $quantity, $accessoryName);
+        $a = new AccessoryReservation($refNum, $start->ToUtc(), $end->ToUtc(), $accessoryId, $quantity);
 
         $this->assertEquals($getAccessoriesCommand, $this->db->_LastCommand);
         $this->assertEquals(2, count($accessories));

--- a/tests/Domain/Resource/ResourceGroupTest.php
+++ b/tests/Domain/Resource/ResourceGroupTest.php
@@ -18,10 +18,74 @@ class ResourceGroupTest extends TestBase
         $resourceGroupTree->AddGroup($group1a1);
         $resourceGroupTree->AddGroup($group1a);
 
-        $resourceGroupTree->AddAssignment(new ResourceGroupAssignment($group1a1->id, 'resource1', 1, null, 1, ResourceStatus::AVAILABLE, null, false, false, false, null, null, 1, null, null, null));
-        $resourceGroupTree->AddAssignment(new ResourceGroupAssignment($group1a1->id, 'resource2', 2, null, 1, ResourceStatus::AVAILABLE, null, false, false, false, null, null, 1, null, null, null));
-        $resourceGroupTree->AddAssignment(new ResourceGroupAssignment($group1a->id, 'resource3', 3, null, 1, ResourceStatus::AVAILABLE, null, false, false, false, null, null, 1, null, null, null));
-        $resourceGroupTree->AddAssignment(new ResourceGroupAssignment($group1->id, 'resource4', 4, null, 1, ResourceStatus::AVAILABLE, null, false, false, false, null, null, 1, null, null, null));
+        $resourceGroupTree->AddAssignment(new ResourceGroupAssignment(
+            group_id: $group1a1->id,
+            resource_name: 'resource1',
+            resource_id: 1,
+            resourceAdminGroupId: null,
+            scheduleId: 1,
+            statusId: ResourceStatus::AVAILABLE,
+            scheduleAdminGroupId: null,
+            requiresApproval: false,
+            isCheckInEnabled: false,
+            isAutoReleased: false,
+            autoReleaseMinutes: null,
+            minLength: null,
+            resourceTypeId: 1,
+            color: null,
+            maxConcurrentReservations: null
+        ));
+        $resourceGroupTree->AddAssignment(new ResourceGroupAssignment(
+            group_id: $group1a1->id,
+            resource_name: 'resource2',
+            resource_id: 2,
+            resourceAdminGroupId: null,
+            scheduleId: 1,
+            statusId: ResourceStatus::AVAILABLE,
+            scheduleAdminGroupId: null,
+            requiresApproval: false,
+            isCheckInEnabled: false,
+            isAutoReleased: false,
+            autoReleaseMinutes: null,
+            minLength: null,
+            resourceTypeId: 1,
+            color: null,
+            maxConcurrentReservations: null
+        ));
+        $resourceGroupTree->AddAssignment(new ResourceGroupAssignment(
+            group_id: $group1a->id,
+            resource_name: 'resource3',
+            resource_id: 3,
+            resourceAdminGroupId: null,
+            scheduleId: 1,
+            statusId: ResourceStatus::AVAILABLE,
+            scheduleAdminGroupId: null,
+            requiresApproval: false,
+            isCheckInEnabled: false,
+            isAutoReleased: false,
+            autoReleaseMinutes: null,
+            minLength: null,
+            resourceTypeId: 1,
+            color: null,
+            maxConcurrentReservations: null
+        ));
+        $resourceGroupTree->AddAssignment(new ResourceGroupAssignment(
+            group_id: $group1->id,
+            resource_name: 'resource4',
+            resource_id: 4,
+            resourceAdminGroupId: null,
+            scheduleId: 1,
+            statusId: ResourceStatus::AVAILABLE,
+            scheduleAdminGroupId: null,
+            requiresApproval: false,
+            isCheckInEnabled: false,
+            isAutoReleased: false,
+            autoReleaseMinutes: null,
+            minLength: null,
+            resourceTypeId: 1,
+            color: null,
+            maxConcurrentReservations: null
+        ));
 
         $group1a1ResourceIds = $resourceGroupTree->GetResourceIds($group1a1->id);
         $group1aResourceIds = $resourceGroupTree->GetResourceIds($group1a->id);

--- a/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
+++ b/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
@@ -136,7 +136,7 @@ class ManageConfigurationPresenterTest extends TestBase
     {
         $expectedValue = $configValues[$key];
         $this->assertTrue(
-            in_array(new ConfigSetting($key, null, $expectedValue, $type), $this->page->_Settings),
+            in_array(new ConfigSetting($key, null, $expectedValue), $this->page->_Settings),
             "Missing $key"
         );
     }


### PR DESCRIPTION
  * Remove extra parameter from AuthorizationCommand constructor call
  * Fix ReservationConflictIdentifier constructor to use single parameter
  * Remove extra parameter from SchedulePeriod constructor call
  * Remove extra parameter from AccessoryReservation constructor call
  * Fix ConfigSetting constructor to use 3 parameters instead of 4
  * Add named arguments to ResourceGroupAssignment constructor calls for clarity