### PR TITLE
fix(phpstan): resolve method and constructor parameter count mismatches

### DIFF
--- a/Pages/ViewCalendarPage.php
+++ b/Pages/ViewCalendarPage.php
@@ -41,8 +41,8 @@ class ViewCalendarPage extends CalendarPage
 
     public function DisplayPage()
     {
-        URIScriptValidator::validate($_SERVER['REQUEST_URI'], '/view-calendar.php');
-        ParamsValidator::validate(RouteParamsKeys::VIEW_CALENDAR, $_SERVER['REQUEST_URI'], '/view-calendar.php', true);
+        URIScriptValidator::validate($_SERVER['REQUEST_URI']);
+        ParamsValidator::validate(RouteParamsKeys::VIEW_CALENDAR, $_SERVER['REQUEST_URI'], true);
         
         $this->Set('pageUrl', Pages::VIEW_CALENDAR);
         $this->Set('CreateReservationPage', Pages::GUEST_RESERVATION);

--- a/Web/install/migrate.php
+++ b/Web/install/migrate.php
@@ -246,7 +246,7 @@ class MigrationPresenter
             $currentDatabase = ServiceLocator::GetDatabase();
             $runTarget = $this->page->GetRunTarget();
             if (!empty($runTarget)) {
-                $this->Migrate($runTarget, $legacyDatabase, $currentDatabase);
+                $this->Migrate($runTarget);
             } elseif ($this->page->IsLoggingIn()) {
                 if ($this->TestInstallPassword() && $this->TestLegacyConnection()) {
                     $this->page->StartMigration();

--- a/Web/view_resources.php
+++ b/Web/view_resources.php
@@ -4,5 +4,5 @@ define('ROOT_DIR', '../');
 
 require_once(ROOT_DIR . 'Pages/ResourceViewerViewResourcesPage.php');
 
-$page = new ResourceViewerViewResourcesPage(new SmartyPage());
+$page = new ResourceViewerViewResourcesPage();
 $page->PageLoad();

--- a/Web/view_schedules.php
+++ b/Web/view_schedules.php
@@ -4,5 +4,5 @@ define('ROOT_DIR', '../');
 
 require_once(ROOT_DIR . 'Pages/ScheduleViewerViewSchedulesPage.php');
 
-$page = new ScheduleViewerViewSchedulesPage(new SmartyPage());
+$page = new ScheduleViewerViewSchedulesPage();
 $page->PageLoad();

--- a/WebServices/Controllers/ReservationSaveController.php
+++ b/WebServices/Controllers/ReservationSaveController.php
@@ -119,7 +119,7 @@ class ReservationSaveController implements IReservationSaveController
      */
     public function Approve($session, $referenceNumber)
     {
-        $facade = new ReservationApprovalRequestResponseFacade($referenceNumber, $session);
+        $facade = new ReservationApprovalRequestResponseFacade($referenceNumber);
         $presenter = $this->factory->Approve($facade, $session);
         $presenter->PageLoad();
         return new ReservationControllerResult($referenceNumber, $facade->Errors());

--- a/WebServices/Responses/AccessoryResponse.php
+++ b/WebServices/Responses/AccessoryResponse.php
@@ -17,7 +17,7 @@ class AccessoryResponse extends RestResponse
 
     public static function Example()
     {
-        return new ExampleAccessoryResponse(null, new Accessory(1, 'accessoryName', 10));
+        return new ExampleAccessoryResponse();
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,18 +7,6 @@ parameters:
 			path: Domain/PaymentGateway.php
 
 		-
-			message: '#^Static method ParamsValidator\:\:validate\(\) invoked with 4 parameters, 3 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: Pages/ViewCalendarPage.php
-
-		-
-			message: '#^Static method URIScriptValidator\:\:validate\(\) invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: Pages/ViewCalendarPage.php
-
-		-
 			message: '#^Variable \$resource might not be defined\.$#'
 			identifier: variable.undefined
 			count: 24
@@ -37,40 +25,10 @@ parameters:
 			path: Presenters/ViewResourcesPresenter.php
 
 		-
-			message: '#^Method MigrationPresenter\:\:Migrate\(\) invoked with 3 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: Web/install/migrate.php
-
-		-
 			message: '#^Variable \$newScheduleId might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: Web/install/migrate.php
-
-		-
-			message: '#^Class ResourceViewerViewResourcesPage constructor invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: Web/view_resources.php
-
-		-
-			message: '#^Class ScheduleViewerViewSchedulesPage constructor invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: Web/view_schedules.php
-
-		-
-			message: '#^Class ReservationApprovalRequestResponseFacade constructor invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: WebServices/Controllers/ReservationSaveController.php
-
-		-
-			message: '#^Class ExampleAccessoryResponse constructor invoked with 2 parameters, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: WebServices/Responses/AccessoryResponse.php
 
 		-
 			message: '#^Variable \$log_folder might not be defined\.$#'


### PR DESCRIPTION
  * Remove extra parameters from ParamsValidator::validate() and URIScriptValidator::validate() calls
  * Fix MigrationPresenter::Migrate() call to use correct parameter count
  * Remove unnecessary constructor parameters from ResourceViewerViewResourcesPage and ScheduleViewerViewSchedulesPage
  * Fix ReservationApprovalRequestResponseFacade and ExampleAccessoryResponse constructor calls