### PR TITLE
fix(phpstan): resolve test parameter count mismatches

### DIFF
--- a/Domain/PaymentGateway.php
+++ b/Domain/PaymentGateway.php
@@ -318,6 +318,7 @@ class PayPalGateway implements IPaymentGateway
         $resources = Resources::GetInstance();
         $baseUrl = $this->GetBaseUrl();
         $token = $this->GetAuthToken($baseUrl);
+        $body = "";
 
         try {
             Log::Debug('PayPal Checkout/Orders CartId/invoice number: %s, Total: %s', $cart->Id(), $cart->Total());

--- a/Presenters/ViewResourcesPresenter.php
+++ b/Presenters/ViewResourcesPresenter.php
@@ -68,6 +68,7 @@ class ViewResourcesPresenter
 
         $filterValues = $this->page->GetFilterValues();
 
+        $resourceIds = [];
         foreach ($resources as $resource) {
             $resourceIds[] = $resource->GetId();
         }

--- a/Web/install/migrate.php
+++ b/Web/install/migrate.php
@@ -446,6 +446,7 @@ class MigrationPresenter
 
             $newScheduleReader = $currentDatabase->Query(new AdHocCommand("select schedule_id from schedules where legacyId = \"{$row['scheduleid']}\""));
 
+            $newScheduleId = null;
             if ($srow = $newScheduleReader->GetRow()) {
                 $newScheduleId = $srow['schedule_id'];
             }

--- a/lib/Common/Logging/Log.php
+++ b/lib/Common/Logging/Log.php
@@ -33,6 +33,9 @@ class Log
 
         $log_level = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_LEVEL);
 
+        $log_folder = null;
+        $log_sql = false;
+
         if ($log_level != 'none') {
             $log_folder = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_FOLDER);
             $log_sql = Configuration::Instance()->GetSectionKey(ConfigSection::LOGGING, ConfigKeys::LOGGING_SQL, new BooleanConverter());

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Variable \$body might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: Domain/PaymentGateway.php
-
-		-
 			message: '#^Variable \$resource might not be defined\.$#'
 			identifier: variable.undefined
 			count: 24
@@ -17,30 +11,6 @@ parameters:
 			identifier: variable.undefined
 			count: 5
 			path: Presenters/Admin/ManageUsersPresenter.php
-
-		-
-			message: '#^Variable \$resourceIds might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: Presenters/ViewResourcesPresenter.php
-
-		-
-			message: '#^Variable \$newScheduleId might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: Web/install/migrate.php
-
-		-
-			message: '#^Variable \$log_folder might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: lib/Common/Logging/Log.php
-
-		-
-			message: '#^Variable \$log_sql might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: lib/Common/Logging/Log.php
 
 		-
 			message: '#^Class Slim\\Router constructor invoked with 1 parameter, 0 required\.$#'
@@ -101,45 +71,3 @@ parameters:
 			identifier: staticMethod.notFound
 			count: 2
 			path: lib/external/pear/PEAR.php
-
-		-
-			message: '#^Method PHPUnit\\Framework\\TestCase\:\:once\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Application/Reservation/AccessoryAvailabilityRuleTest.php
-
-		-
-			message: '#^Method PHPUnit\\Framework\\Assert\:\:isInstanceOf\(\) invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 10
-			path: tests/Application/Reservation/AdminEmailNotificationTest.php
-
-		-
-			message: '#^Method QuotaRuleTest\:\:mockQuota\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 5
-			path: tests/Application/Reservation/QuotaRuleTest.php
-
-		-
-			message: '#^Class TestReservationItemView constructor invoked with 6 parameters, 3\-5 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Application/Schedule/ScheduleReservationListTest.php
-
-		-
-			message: '#^Static method Date\:\:_SetNow\(\) invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 2
-			path: tests/Domain/Reservation/QuotaTest.php
-
-		-
-			message: '#^Static method Date\:\:ParseExact\(\) invoked with 2 parameters, 1 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Infrastructure/Common/DateTest.php
-
-		-
-			message: '#^Method ManageConfigurationPresenterTest\:\:assertSectionSettingExists\(\) invoked with 4 parameters, 3 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/Presenters/Admin/ManageConfigurationPresenterTest.php

--- a/tests/Application/Reservation/AccessoryAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/AccessoryAvailabilityRuleTest.php
@@ -127,7 +127,7 @@ class AccessoryAvailabilityRuleTest extends TestBase
             ->with($accessory1->AccessoryId)
             ->willReturn(new Accessory($accessory1->AccessoryId, 'name1', $quantityAvailable));
 
-        $this->reservationRepository->expects($this->once(0))
+        $this->reservationRepository->expects($this->once())
             ->method('GetAccessoriesWithin')
             ->with($this->anything())
             ->willReturn([]);

--- a/tests/Application/Reservation/AdminEmailNotificationTest.php
+++ b/tests/Application/Reservation/AdminEmailNotificationTest.php
@@ -75,8 +75,8 @@ class AdminEmailNotificationTest extends TestBase
 
         $this->assertEquals(6, count($this->fakeEmailService->_Messages));
 
-        $this->isInstanceOf('ReservationCreatedEmailAdmin', $this->fakeEmailService->_Messages[0]);
-        $this->isInstanceOf('ReservationCreatedEmailAdmin', $this->fakeEmailService->_Messages[1]);
+        $this->assertInstanceOf('ReservationCreatedEmailAdmin', $this->fakeEmailService->_Messages[0]);
+        $this->assertInstanceOf('ReservationCreatedEmailAdmin', $this->fakeEmailService->_Messages[1]);
     }
 
     public function testSendsReservationUpdatedEmailIfAdminWantsIt()
@@ -135,8 +135,8 @@ class AdminEmailNotificationTest extends TestBase
 
         $this->assertEquals(6, count($this->fakeEmailService->_Messages), "send one per person, no duplicates");
 
-        $this->isInstanceOf('ReservationUpdatedEmailAdmin', $this->fakeEmailService->_Messages[0]);
-        $this->isInstanceOf('ReservationUpdatedEmailAdmin', $this->fakeEmailService->_Messages[1]);
+        $this->assertInstanceOf('ReservationUpdatedEmailAdmin', $this->fakeEmailService->_Messages[0]);
+        $this->assertInstanceOf('ReservationUpdatedEmailAdmin', $this->fakeEmailService->_Messages[1]);
     }
 
     public function testSendsReservationCreatedRequiresApprovalEmailIfAdminWantsIt()
@@ -196,8 +196,8 @@ class AdminEmailNotificationTest extends TestBase
 
         $this->assertEquals(6, count($this->fakeEmailService->_Messages));
 
-        $this->isInstanceOf('ReservationRequiresApprovalEmailAdmin', $this->fakeEmailService->_Messages[0]);
-        $this->isInstanceOf('ReservationRequiresApprovalEmailAdmin', $this->fakeEmailService->_Messages[1]);
+        $this->assertInstanceOf('ReservationRequiresApprovalEmailAdmin', $this->fakeEmailService->_Messages[0]);
+        $this->assertInstanceOf('ReservationRequiresApprovalEmailAdmin', $this->fakeEmailService->_Messages[1]);
     }
 
     public function testDoesNotSendReservationCreatedRequiresApprovalEmailIfAdminWantsItButNotRequiresApproval()
@@ -282,8 +282,8 @@ class AdminEmailNotificationTest extends TestBase
 
         $this->assertEquals(6, count($this->fakeEmailService->_Messages), "send one per person, no duplicates");
 
-        $this->isInstanceOf('ReservationRequiresApprovalEmailAdmin', $this->fakeEmailService->_Messages[0]);
-        $this->isInstanceOf('ReservationRequiresApprovalEmailAdmin', $this->fakeEmailService->_Messages[1]);
+        $this->assertInstanceOf('ReservationRequiresApprovalEmailAdmin', $this->fakeEmailService->_Messages[0]);
+        $this->assertInstanceOf('ReservationRequiresApprovalEmailAdmin', $this->fakeEmailService->_Messages[1]);
     }
 
     public function testSendsReservationDeletedEmailIfAdminWantsIt()
@@ -341,8 +341,8 @@ class AdminEmailNotificationTest extends TestBase
 
         $this->assertEquals(6, count($this->fakeEmailService->_Messages), "send one per person, no duplicates");
 
-        $this->isInstanceOf('ReservationDeletedEmailAdmin', $this->fakeEmailService->_Messages[0]);
-        $this->isInstanceOf('ReservationDeletedEmailAdmin', $this->fakeEmailService->_Messages[1]);
+        $this->assertInstanceOf('ReservationDeletedEmailAdmin', $this->fakeEmailService->_Messages[0]);
+        $this->assertInstanceOf('ReservationDeletedEmailAdmin', $this->fakeEmailService->_Messages[1]);
     }
 
     public function testNothingSentIfConfiguredOff()

--- a/tests/Application/Reservation/QuotaRuleTest.php
+++ b/tests/Application/Reservation/QuotaRuleTest.php
@@ -72,9 +72,9 @@ class QuotaRuleTest extends TestBase
         );
         $series->AddResource(new FakeBookableResource(22));
 
-        $quota1 = $this->mockQuota('IQuota');
-        $quota2 = $this->mockQuota('IQuota');
-        $quota3 = $this->mockQuota('IQuota');
+        $quota1 = $this->mockQuota();
+        $quota2 = $this->mockQuota();
+        $quota3 = $this->mockQuota();
 
         $quotas = [$quota1, $quota2, $quota3];
 
@@ -134,8 +134,8 @@ class QuotaRuleTest extends TestBase
         );
         $series->AddResource(new FakeBookableResource(22));
 
-        $quota1 = $this->mockQuota('IQuota');
-        $quota2 = $this->mockQuota('IQuota');
+        $quota1 = $this->mockQuota();
+        $quota2 = $this->mockQuota();
 
         $quotas = [$quota1, $quota2];
 

--- a/tests/Application/Schedule/ScheduleReservationListTest.php
+++ b/tests/Application/Schedule/ScheduleReservationListTest.php
@@ -662,12 +662,11 @@ class ScheduleReservationListTest extends TestBase
         $layout->AppendPeriod(Time::Parse('6:00', $tz), Time::Parse('0:00', $tz));
 
         $item = new TestReservationItemView(
-            1,
-            Date::Parse('2011-02-08 2:00', $tz)->ToUtc(),
-            Date::Parse('2011-02-08 6:00', $tz)->ToUtc(),
-            1,
-            30,
-            60
+            id: 1,
+            startDate: Date::Parse('2011-02-08 2:00', $tz)->ToUtc(),
+            endDate: Date::Parse('2011-02-08 6:00', $tz)->ToUtc(),
+            resourceId: 1,
+            referenceNumber: 30
         );
         $item->WithBufferTime(60*60);
         $r1 = new ReservationListItem($item);

--- a/tests/Domain/Reservation/QuotaTest.php
+++ b/tests/Domain/Reservation/QuotaTest.php
@@ -305,7 +305,7 @@ class QuotaTest extends TestBase
     public function testWhenTotalLimitIsExceededForWeekAndWeekStartOnToday()
     {
         $tz = 'UTC';
-        Date::_SetNow(Date::Parse('2017-02-21'), $tz);    // tuesday
+        Date::_SetNow(Date::Parse('2017-02-21', $tz));    // tuesday
         $this->schedule->SetTimezone($tz);
         $this->schedule->SetWeekdayStart(Schedule::Today);
 
@@ -343,7 +343,7 @@ class QuotaTest extends TestBase
     public function testWhenTotalLimitIsNotExceededForWeekAndWeekStartOnToday()
     {
         $tz = 'UTC';
-        Date::_SetNow(Date::Parse('2017-02-21'), $tz);    // tuesday
+        Date::_SetNow(Date::Parse('2017-02-21', $tz));    // tuesday
         $this->schedule->SetTimezone($tz);
         $this->schedule->SetWeekdayStart(Schedule::Today);
 

--- a/tests/Infrastructure/Common/DateTest.php
+++ b/tests/Infrastructure/Common/DateTest.php
@@ -511,7 +511,7 @@ class DateTest extends TestBase
         $d = Date::Parse('2012-04-06 12:02:03', 'America/New_York');
         $iso = $d->ToIso();
 
-        $d2 = Date::ParseExact($iso, 'America/New_York');
+        $d2 = Date::ParseExact($iso);
 
         $this->assertTrue($d->Equals($d2), $d->ToUtc()->ToString() . ' ' . $d2->ToString());
     }

--- a/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
+++ b/tests/Presenters/Admin/ManageConfigurationPresenterTest.php
@@ -76,10 +76,9 @@ class ManageConfigurationPresenterTest extends TestBase
 
         $this->assertSettingExists($configValues, ConfigKeys::ADMIN_EMAIL, ConfigSettingType::String);
         $this->assertSectionSettingExists(
-            $configValues,
-            ConfigKeys::PRIVACY_HIDE_RESERVATION_DETAILS,
-            ConfigSection::PRIVACY,
-            ConfigSettingType::Boolean
+            configValues: $configValues,
+            key: ConfigKeys::PRIVACY_HIDE_RESERVATION_DETAILS,
+            section: ConfigSection::PRIVACY
         );
 
         $this->assertSettingMissing(ConfigKeys::INSTALLATION_PASSWORD);


### PR DESCRIPTION
  * Fix TestReservationItemView constructor call with 6 parameters (only 3-5 required)
  * Fix Date::_SetNow() calls with 2 parameters (only 1 required)
  * Fix Date::ParseExact() call with 2 parameters (only 1 required)
  * Fix assertSectionSettingExists() call with 4 parameters (only 3 required)
  * Use named arguments for improved clarity in some test constructors