### PR TITLE
fix(phpstan): resolve undefined variable issues in presenters

### DIFF
--- a/Presenters/Admin/ManageResourcesPresenter.php
+++ b/Presenters/Admin/ManageResourcesPresenter.php
@@ -1018,6 +1018,7 @@ class ManageResourcesPresenter extends ActionPresenter
                 )) ? ResourceStatus::AVAILABLE : $resourceStatusesIndexed[$row->status];
                 $autoAssign = $row->autoAssign == 'true' || $row->autoAssign == '1';
 
+                $resource = null;
                 if ($shouldUpdate) {
                     $resource = $this->resourceRepository->LoadByName($row->name);
                     if ($resource->GetId() == null) {
@@ -1034,45 +1035,47 @@ class ManageResourcesPresenter extends ActionPresenter
                     $this->resourceRepository->Add($resource);
                 }
 
-                $resource->ChangeStatus($statusId);
-                $resource->SetResourceTypeId($resourceTypeId);
-                $resource->SetLocation($row->location);
-                $resource->SetContact($row->contact);
-                $resource->SetDescription($row->description);
-                $resource->SetNotes($row->notes);
-                $resource->SetAdminGroupId($adminGroupId);
-                $resource->SetColor($row->color);
-                $resource->SetRequiresApproval($row->approvalRequired == 'true' || $row->approvalRequired == '1');
-                $resource->SetMaxParticipants($row->capacity);
-                $resource->SetMinLength($row->minLength);
-                $resource->SetMaxLength($row->maxLength);
-                $resource->SetBufferTime($row->buffer);
-                $resource->SetAllowMultiday($row->crossDay);
-                $resource->SetMinNoticeAdd($row->addNotice);
-                $resource->SetMinNoticeUpdate($row->updateNotice);
-                $resource->SetMinNoticeDelete($row->deleteNotice);
-                $resource->SetCheckin($row->checkIn, $row->autoreleaseMinutes);
-                $resource->SetCreditsPerSlot($row->credits);
-                $resource->SetPeakCreditsPerSlot($row->creditsPeak);
-                $resource->SetMaxConcurrentReservations($row->maximumConcurrent);
+                if ($resource !== null) {
+                    $resource->ChangeStatus($statusId);
+                    $resource->SetResourceTypeId($resourceTypeId);
+                    $resource->SetLocation($row->location);
+                    $resource->SetContact($row->contact);
+                    $resource->SetDescription($row->description);
+                    $resource->SetNotes($row->notes);
+                    $resource->SetAdminGroupId($adminGroupId);
+                    $resource->SetColor($row->color);
+                    $resource->SetRequiresApproval($row->approvalRequired == 'true' || $row->approvalRequired == '1');
+                    $resource->SetMaxParticipants($row->capacity);
+                    $resource->SetMinLength($row->minLength);
+                    $resource->SetMaxLength($row->maxLength);
+                    $resource->SetBufferTime($row->buffer);
+                    $resource->SetAllowMultiday($row->crossDay);
+                    $resource->SetMinNoticeAdd($row->addNotice);
+                    $resource->SetMinNoticeUpdate($row->updateNotice);
+                    $resource->SetMinNoticeDelete($row->deleteNotice);
+                    $resource->SetCheckin($row->checkIn, $row->autoreleaseMinutes);
+                    $resource->SetCreditsPerSlot($row->credits);
+                    $resource->SetPeakCreditsPerSlot($row->creditsPeak);
+                    $resource->SetMaxConcurrentReservations($row->maximumConcurrent);
 
-                foreach ($row->attributes as $label => $value) {
-                    if (empty($value)) {
-                        continue;
+                    foreach ($row->attributes as $label => $value) {
+                        if (empty($value)) {
+                            continue;
+                        }
+                        if (array_key_exists($label, $attributesIndexed)) {
+                            $attribute = $attributesIndexed[$label];
+                            $resource->ChangeAttribute(new AttributeValue($attribute->Id(), $value));
+                        }
                     }
-                    if (array_key_exists($label, $attributesIndexed)) {
-                        $attribute = $attributesIndexed[$label];
-                        $resource->ChangeAttribute(new AttributeValue($attribute->Id(), $value));
-                    }
-                }
 
-                $this->resourceRepository->Update($resource);
+                    $this->resourceRepository->Update($resource);
 
-                foreach ($row->resourceGroups as $groupName) {
-                    $groupName = strtolower($groupName);
-                    if (array_key_exists($groupName, $resourceGroupsIndexed)) {
-                        Log::Debug('Assigning resource %s to group %s', $row->name, $groupName);
-                        $this->resourceRepository->AddResourceToGroup($resource->GetId(), $resourceGroupsIndexed[$groupName]);
+                    foreach ($row->resourceGroups as $groupName) {
+                        $groupName = strtolower($groupName);
+                        if (array_key_exists($groupName, $resourceGroupsIndexed)) {
+                            Log::Debug('Assigning resource %s to group %s', $row->name, $groupName);
+                            $this->resourceRepository->AddResourceToGroup($resource->GetId(), $resourceGroupsIndexed[$groupName]);
+                        }
                     }
                 }
 

--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -610,6 +610,7 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
                 $language = empty($row->language) ? 'en_us' : $row->language;
                 $status = empty($row->status) ? AccountStatus::ACTIVE : $this->DetermineStatus($row->status);
 
+                $user = null;
                 if ($shouldUpdate) {
                     $user = $this->manageUsersService->LoadUser($row->email);
                     if ($user->Id() == null) {
@@ -652,30 +653,32 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
                     }
                 }
 
-                if (count($userGroups) > 0) {
-                    $user->ChangeGroups($userGroups);
-                }
-
-                if ($row->credits != null) {
-                    $user->ChangeCurrentCredits($row->credits);
-                }
-
-                if ($row->color != null) {
-                    $user->ChangePreference(UserPreferences::RESERVATION_COLOR, $row->color);
-                }
-
-                foreach ($row->attributes as $label => $value) {
-                    if (empty($value)) {
-                        continue;
+                if ($user !== null) {
+                    if (count($userGroups) > 0) {
+                        $user->ChangeGroups($userGroups);
                     }
-                    if (array_key_exists($label, $attributesIndexed)) {
-                        $attribute = $attributesIndexed[$label];
-                        $user->ChangeCustomAttribute(new AttributeValue($attribute->Id(), $value));
-                    }
-                }
 
-                if (count($userGroups) > 0 || count($row->attributes) > 0 || $shouldUpdate) {
-                    $this->userRepository->Update($user);
+                    if ($row->credits != null) {
+                        $user->ChangeCurrentCredits($row->credits);
+                    }
+
+                    if ($row->color != null) {
+                        $user->ChangePreference(UserPreferences::RESERVATION_COLOR, $row->color);
+                    }
+
+                    foreach ($row->attributes as $label => $value) {
+                        if (empty($value)) {
+                            continue;
+                        }
+                        if (array_key_exists($label, $attributesIndexed)) {
+                            $attribute = $attributesIndexed[$label];
+                            $user->ChangeCustomAttribute(new AttributeValue($attribute->Id(), $value));
+                        }
+                    }
+
+                    if (count($userGroups) > 0 || count($row->attributes) > 0 || $shouldUpdate) {
+                        $this->userRepository->Update($user);
+                    }
                 }
 
                 $importCount++;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,18 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Variable \$resource might not be defined\.$#'
-			identifier: variable.undefined
-			count: 24
-			path: Presenters/Admin/ManageResourcesPresenter.php
-
-		-
-			message: '#^Variable \$user might not be defined\.$#'
-			identifier: variable.undefined
-			count: 5
-			path: Presenters/Admin/ManageUsersPresenter.php
-
-		-
 			message: '#^Class Slim\\Router constructor invoked with 1 parameter, 0 required\.$#'
 			identifier: arguments.count
 			count: 1


### PR DESCRIPTION
Initialize $resource and $user variables and add null checks to prevent undefined variable errors in ManageResourcesPresenter and ManageUsersPresenter.