### PR TITLE
chore(phpstan): add `lang/` directory to scan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,9 +13,7 @@ parameters:
         - Web
         - WebServices
         - config
-        - lang/AvailableLanguage.php
-        - lang/AvailableLanguages.php
-        - lang/Language.php
+        - lang
         - lib
         - phing-tasks
         - plugins


### PR DESCRIPTION
Had previously fixed the errors but had not checked in change to `phpstan.neon`