### PR TITLE
fix(login): Language selector is not working due to httponly cookie

### DIFF
--- a/tpl/login.tpl
+++ b/tpl/login.tpl
@@ -160,7 +160,7 @@
             window.location.href = url + $(this).val();
         });
 
-        var langCode = readCookie('{CookieKeys::LANGUAGE}');
+        var langCode = '{$smarty.cookies.language|escape:"javascript"}';
 
         if (!langCode) {
             langCode = (navigator.language + "").replace("-", "_").toLowerCase();


### PR DESCRIPTION
The login page is set to the default browser language, but it's impossible to change the language using the select a the bottom of the login page. The page reload back the previous language.
The readCookie('language') returns null, the reason is that the cookie is set as HTTPonly and can not be read by javascript. The solution is to read the cookie via the tpl instead.

closes #747