### PR TITLE
fix: allow setting language for non-HTTPS

### DIFF
--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -168,7 +168,7 @@ class LoginPresenter
         $languageCode = $this->_page->GetRequestedLanguage();
 
         if ($resources->SetLanguage($languageCode)) {
-            ServiceLocator::GetServer()->SetCookie(new Cookie(CookieKeys::LANGUAGE, $languageCode));
+            ServiceLocator::GetServer()->SetCookie(new Cookie(CookieKeys::LANGUAGE, $languageCode, secure: false));
             $this->_page->SetSelectedLanguage($languageCode);
             $this->_page->Redirect(Pages::LOGIN);
         }


### PR DESCRIPTION
Previously the `language` cookie was being set for only 'secure' connections. Change this so that the cookie can be sent even for non secure connections. Now it will for for 'http://' in addition to 'https://'

Closes: #493