### PR TITLE
chore: add text to the "More Resource Actions" drop-down

### DIFF
--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -796,6 +796,7 @@ class en_us extends Language
         $strings['CheckingAvailabilityError'] = 'Cannot get resource availability - too many resources';
         $strings['ScanToSchedule'] = 'Scan to schedule';
         $strings['MaintenanceNotice'] = 'Currently performing maintenance. We will be back soon.';
+        $strings['MoreResourceActions'] = 'More Resource Actions';
         // End Strings
 
         // Install

--- a/tpl/Admin/Resources/manage_resources.tpl
+++ b/tpl/Admin/Resources/manage_resources.tpl
@@ -10,8 +10,7 @@
 				</button>
 				<button class="btn btn-primary dropdown-toggle" type="button" id="moreResourceActions"
 					data-bs-toggle="dropdown">
-					<span class="visually-hidden">{translate key='More'}</span>
-					<i class="bi bi-three-dots"></i>
+					{translate key="MoreResourceActions"}
 				</button>
 				<ul class="dropdown-menu" role="menu" aria-labelledby="moreResourceActions">
 


### PR DESCRIPTION
Before it was easy to miss the "..." and not realize there were more things that could be done on the Manage Resources page.

Change "..." to "More Resource Actions" for `en_us`