### PR TITLE
feat: optional: resource contact may be chosen via a drop-down list of users

### DIFF
--- a/Pages/Admin/ManageResourcesPage.php
+++ b/Pages/Admin/ManageResourcesPage.php
@@ -510,6 +510,9 @@ class ManageResourcesPage extends ActionPage implements IManageResourcesPage
         $url = $this->server->GetUrl();
         $exportUrl = BookedStringHelper::Contains($url, '?') ? $url . '&dr=export' : $this->server->GetRequestUri() . '?dr=export';
         $this->Set('ExportUrl', $exportUrl);
+
+        // If the contact for a resource must be chosen from a list of registered users.
+        $this->Set('ResourceContactIsUser', Configuration::Instance()->GetKey(ConfigKeys::RESOURCE_CONTACT_IS_USER, new BooleanConverter()));
     }
 
     public function ProcessPageLoad()

--- a/Pages/Ajax/AutoCompletePage.php
+++ b/Pages/Ajax/AutoCompletePage.php
@@ -12,6 +12,7 @@ class AutoCompletePage extends Page
         parent::__construct();
 
         $this->listMethods[AutoCompleteType::User] = 'GetUsers';
+        $this->listMethods[AutoCompleteType::XUser] = 'XGetUsers';
         $this->listMethods[AutoCompleteType::MyUsers] = 'GetMyUsers';
         $this->listMethods[AutoCompleteType::Group] = 'GetGroups';
         $this->listMethods[AutoCompleteType::Organization] = 'GetOrganizations';
@@ -57,6 +58,10 @@ class AutoCompletePage extends Page
         if ($term == 'group') {
             return $this->GetGroupUsers($this->GetQuerystring(QueryStringKeys::GROUP_ID));
         }
+        if (empty($term)) {
+            $term = '';
+        }
+
 
         $onlyActive = false;
         $activeQS = $this->GetQuerystring(QueryStringKeys::ACCOUNT_STATUS);
@@ -88,6 +93,22 @@ class AutoCompletePage extends Page
         }
 
         return $users;
+    }
+
+    /**
+     * @param $term string
+     * @return array|XAutocompleteUser[]
+     */
+    private function XGetUsers($term)
+    {
+        $users = $this->GetUsers($term);
+
+        $outUsers = [new XAutocompleteUser("", "")];
+        foreach ($users as $user) {
+            $value = $user->Name . " <" . $user->Email . ">";
+            $outUsers[] = new XAutocompleteUser($value, $value);
+        }
+        return $outUsers;
     }
 
     private function GetGroups($term)
@@ -167,6 +188,17 @@ class AutoCompletePage extends Page
     }
 }
 
+class XAutocompleteUser
+{
+    public $value;
+    public $text;
+    public function __construct($value, $text)
+    {
+        $this->value = $value;
+        $this->text = $text;
+    }
+}
+
 class AutocompleteUser
 {
     public $Id;
@@ -195,6 +227,7 @@ class AutocompleteUser
 class AutoCompleteType
 {
     public const User = 'user';
+    public const XUser = 'xuser';
     public const Group = 'group';
     public const MyUsers = 'myUsers';
     public const Organization = 'organization';

--- a/config/config.devel.php
+++ b/config/config.devel.php
@@ -36,6 +36,7 @@ $conf['settings']['disable.password.reset'] = 'false';          // if the passwo
 $conf['settings']['home.url'] = '';                             // the url to open when the logo is clicked
 $conf['settings']['logout.url'] = '';                           // the url to be directed to after logging out
 $conf['settings']['default.homepage'] = '1';                    // the default homepage to use when new users register (1 = Dashboard, 2 = Schedule, 3 = My Calendar, 4 = Resource Calendar)
+$conf['settings']['resource.contact.is.user'] = 'false';        // If Resource contact must be a registered user
 
 $conf['settings']['schedule']['use.per.user.colors'] = 'false';         // color reservations by user
 $conf['settings']['schedule']['show.inaccessible.resources'] = 'true';  // whether or not resources that are inaccessible to the user are visible

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -36,6 +36,7 @@ $conf['settings']['disable.password.reset'] = 'false';               // if the p
 $conf['settings']['home.url'] = '';                               // the url to open when the logo is clicked
 $conf['settings']['logout.url'] = '';                               // the url to be directed to after logging out
 $conf['settings']['default.homepage'] = '1';                       // the default homepage to use when new users register (1 = Dashboard, 2 = Schedule, 3 = My Calendar, 4 = Resource Calendar)
+$conf['settings']['resource.contact.is.user'] = 'false';        // If Resource contact must be a registered user
 
 $conf['settings']['schedule']['use.per.user.colors'] = 'false';         // color reservations by user
 $conf['settings']['schedule']['show.inaccessible.resources'] = 'true';  // whether or not resources that are inaccessible to the user are visible

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -27,6 +27,7 @@ class ConfigKeys
     public const REGISTRATION_REQUIRE_ACTIVATION = 'registration.require.email.activation';
     public const REGISTRATION_AUTO_SUBSCRIBE_EMAIL = 'registration.auto.subscribe.email';
     public const REGISTRATION_NOTIFY = 'registration.notify.admin';
+    public const RESOURCE_CONTACT_IS_USER = 'resource.contact.is.user';
 
     public const VERSION = 'version';
 

--- a/tpl/Admin/Resources/manage_resources.tpl
+++ b/tpl/Admin/Resources/manage_resources.tpl
@@ -393,7 +393,11 @@
 															<div>
 																<label
 																	class="inline fw-bold">{translate key='Contact'}</label>
-																<span class="propertyValue contactValue" data-type="text"
+																{if $ResourceContactIsUser}
+																	<span class="propertyValue contactValue" data-type="select"
+																{else}
+																	<span class="propertyValue contactValue" data-type="text"
+																{/if}
 																	data-pk="{$id}" data-value="{$resource->GetContact()}"
 																	data-name="{FormKeys::RESOURCE_CONTACT}">
 																	{if $resource->HasContact()}
@@ -2180,6 +2184,7 @@
 		};
 
 		var updateUrl = '{$smarty.server.SCRIPT_NAME}?action=';
+        var xUserAutocompleteUrl = "../ajax/autocomplete.php?type={AutoCompleteType::XUser}";
 
 		$('.resourceNameField').editable({
 				url: updateUrl + '{ManageResourcesActions::ActionRename}', validate: function (value) {
@@ -2222,7 +2227,13 @@
 	});
 
 	$('.contactValue').editable({
-		url: updateUrl + '{ManageResourcesActions::ActionChangeContact}', emptytext: "{translate key='NoContactLabel'|escape:'javascript'}"
+		url: updateUrl + '{ManageResourcesActions::ActionChangeContact}',
+		{if $ResourceContactIsUser}
+			emptytext: "{translate key='NoContactLabel'|escape:'javascript'}",
+			source: xUserAutocompleteUrl,
+		{else}
+			emptytext: "{translate key='NoContactLabel'|escape:'javascript'}"
+		{/if}
 	});
 
 	$('.descriptionValue').editable({


### PR DESCRIPTION
Optional feature, that when changing the contact of a resource in the
Web UI, the contact must be chosen from a list of users on the system.

This is enabled via:
    $conf['settings']['resource.contact.is.user'] = 'true';
