### PR TITLE
fix(chore): Resolve many html escape issues

### DIFF
--- a/Pages/Ajax/AutoCompletePage.php
+++ b/Pages/Ajax/AutoCompletePage.php
@@ -212,7 +212,7 @@ class AutocompleteUser
 
     public function __construct($userId, $firstName, $lastName, $email, $userName, $currentCreditCount = null)
     {
-        $full = new FullName($firstName, $lastName);
+        $full = new FullName(htmlspecialchars_decode($firstName, ENT_QUOTES), htmlspecialchars_decode($lastName, ENT_QUOTES));
         $this->Id = $userId;
         $this->First = $firstName;
         $this->Last = $lastName;

--- a/tpl/Admin/Reservations/manage_reservations.tpl
+++ b/tpl/Admin/Reservations/manage_reservations.tpl
@@ -230,7 +230,7 @@
 								data-bs-html="true">
 								<td class="id d-none">{$reservationId}</td>
 								<td class="user">
-									{fullname first=$reservation->FirstName last=$reservation->LastName ignorePrivacy=true}
+									{fullname first=$reservation->FirstName|unescape:'html' last=$reservation->LastName|unescape:'html' ignorePrivacy=true}
 								</td>
 								<td class="resource">{$reservation->ResourceName}
 									{if $reservation->ResourceStatusId == ResourceStatus::AVAILABLE}
@@ -244,8 +244,8 @@
 										{*<span class="reservationResourceStatusReason">{$StatusReasons[$reservation->ResourceStatusReasonId]->Description()}</span>*}
 									{*{/if}*}
 								</td>
-								<td class="reservationTitle">{$reservation->Title}</td>
-								<td class="description">{$reservation->Description}</td>
+								<td class="reservationTitle">{$reservation->Title|escape:'html'}</td>
+								<td class="description">{$reservation->Description|escape:'html'}</td>
 								<td class="date">
 									{formatdate date=$reservation->StartDate timezone=$Timezone key=short_reservation_date}
 								</td>

--- a/tpl/Admin/Resources/manage_resources_user_permissions.tpl
+++ b/tpl/Admin/Resources/manage_resources_user_permissions.tpl
@@ -10,7 +10,7 @@
             <tr>
                 <td>
                     <div class="form-group clearfix">
-                        <label for="permission{$u->Id}" class="float-start">{fullname first=$u->First last=$u->Last}</label>
+                        <label for="permission{$u->Id}" class="float-start">{fullname first=$u->First|unescape:'html' last=$u->Last|unescape:'html'}</label>
                         <select class="change-permission-type float-end form-select form-select-sm" style="width:auto;"
                             id="permission{$u->Id}" data-user-id="{$u->Id}">
                             <option value="{ResourcePermissionType::None}" class="none"

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -100,7 +100,7 @@
                         {foreach from=$users item=user}
                             {assign var=id value=$user->Id}
                             <tr data-userId="{$id}">
-                                <td>{fullname first=$user->First last=$user->Last ignorePrivacy="true"}</td>
+                                <td>{fullname first=$user->First|unescape:'html' last=$user->Last|unescape:'html' ignorePrivacy="true"}</td>
                                 <td>{$user->Username}</td>
                                 <td><a href="mailto:{$user->Email}" class="link-primary">{$user->Email}</a></td>
                                 <td>{$user->Phone}</td>

--- a/tpl/Admin/Users/user-update.tpl
+++ b/tpl/Admin/Users/user-update.tpl
@@ -14,7 +14,7 @@
 				<label class="fw-bold" for="username">{translate key="Username"}<i
 						class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 				<input type="text" {formname key="USERNAME"} class="required form-control has-feedback" required
-					id="username" value="{$User->Username()|escape:html}" />
+					id="username" value="{$User->Username()}" />
 			</div>
 		</div>
 
@@ -23,7 +23,7 @@
 				<label class="fw-bold" for="email">{translate key="Email"}<i
 						class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 				<input type="text" {formname key="EMAIL"} class="required form-control has-feedback" required id="email"
-					value="{$User->EmailAddress()|escape:html}" />
+					value="{$User->EmailAddress()}" />
 			</div>
 		</div>
 
@@ -32,7 +32,7 @@
 				<label class="fw-bold" for="fname">{translate key="FirstName"}<i
 						class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 				<input type="text" {formname key="FIRST_NAME"} class="required form-control has-feedback" required
-					id="fname" value="{$User->FirstName()|escape:html}" />
+					id="fname" value="{$User->FirstName()}" />
 			</div>
 		</div>
 
@@ -41,7 +41,7 @@
 				<label class="fw-bold" for="lname">{translate key="LastName"}<i
 						class="bi bi-asterisk text-danger align-top" style="font-size: 0.5rem;"></i></label>
 				<input type="text" {formname key="LAST_NAME"} class="required form-control has-feedback" required
-					id="lname" value="{$User->LastName()|escape:html}" />
+					id="lname" value="{$User->LastName()}" />
 			</div>
 		</div>
 
@@ -58,7 +58,7 @@
 			<div class="form-group">
 				<label class="fw-bold" for="phone">{translate key="Phone"}</label>
 				<input type="text" {formname key="PHONE"} class="form-control" id="phone"
-					value="{$User->GetAttribute(UserAttribute::Phone)|escape:html}" />
+					value="{$User->GetAttribute(UserAttribute::Phone)}" />
 			</div>
 		</div>
 
@@ -66,7 +66,7 @@
 			<div class="form-group">
 				<label class="fw-bold" for="organization">{translate key="Organization"}</label>
 				<input type="text" {formname key="ORGANIZATION"} class="form-control" id="organization"
-					value="{$User->GetAttribute(UserAttribute::Organization)|escape:html}" />
+					value="{$User->GetAttribute(UserAttribute::Organization)}" />
 			</div>
 		</div>
 
@@ -74,7 +74,7 @@
 			<div class="form-group">
 				<label class="fw-bold" for="position">{translate key="Position"}</label>
 				<input type="text" {formname key="POSITION"} class="form-control" id="position"
-					value="{$User->GetAttribute(UserAttribute::Position)|escape:html}" />
+					value="{$User->GetAttribute(UserAttribute::Position)}" />
 			</div>
 		</div>
 

--- a/tpl/Ajax/respopup.tpl
+++ b/tpl/Ajax/respopup.tpl
@@ -56,7 +56,7 @@
 
         {capture "title"}
             {if !$hideDetails && $isResourcePermitted}
-                <div class="title">{if $title neq ''}{$title}{else}{translate key=NoTitleLabel}{/if}</div>
+                <div class="title">{if $title neq ''}{$title|escape:'html'}{else}{translate key=NoTitleLabel}{/if}</div>
             {/if}
         {/capture}
         {$formatter->Add('title', $smarty.capture.title)}
@@ -82,7 +82,7 @@
                     {translate key="Participants"} ({$participants|@count}):
                     {foreach from=$participants item=user name=participant_loop}
                         {if !$user->IsOwner()}
-                            {fullname first=$user->FirstName last=$user->LastName}
+                            {fullname first=$user->FirstName|unescape:'html' last=$user->LastName|unescape:'html'}
                         {/if}
                         {if !$smarty.foreach.participant_loop.last}, {/if}
                     {/foreach}
@@ -107,7 +107,7 @@
         {capture "description"}
             {if !$hideDetails && $isResourcePermitted}
                 <div class="summary">
-                    {if $summary neq ''}{$summary|truncate:300:"..."|nl2br}{else}{translate key=NoDescriptionLabel}{/if}</div>
+                    {if $summary neq ''}{$summary|truncate:300:"..."|escape:'html'|nl2br}{else}{translate key=NoDescriptionLabel}{/if}</div>
             {/if}
         {/capture}
         {$formatter->Add('description', $smarty.capture.description)}

--- a/tpl/Ajax/user_details.tpl
+++ b/tpl/Ajax/user_details.tpl
@@ -1,7 +1,7 @@
 {if $CanViewUser}
 	<div id="userDetailsPopup">
 		<div class="card-header fw-bold">
-			{fullname first=$User->FirstName() last=$User->LastName() ignorePrivacy=true}
+			{fullname first=$User->FirstName()|unescape:'html' last=$User->LastName()|unescape:'html' ignorePrivacy=true}
 		</div>
 		<div id="userDetailsName" class="card-body">
 			{if $User->EmailAddress()}

--- a/tpl/Dashboard/dashboard_reservation.tpl
+++ b/tpl/Dashboard/dashboard_reservation.tpl
@@ -5,9 +5,9 @@
 <div class="reservation row gx-0 {$class} border-bottom p-2 border-bottom align-items-center {if isset($orangePending)}bg-white{/if}"
     id="{$reservation->ReferenceNumber}" data-bs-custom-class="respopup-tooltip" data-bs-html="true">
     {*doesn't show pending approval reservations as orange in the Pending Approval Reservations displayer in the dashboard*}
-    <div class="col-sm-3 col-12">{$reservation->Title|default:$DefaultTitle}</div>
+    <div class="col-sm-3 col-12">{$reservation->Title|escape:'html'|default:$DefaultTitle}</div>
     <div class="col-sm-3 col-12">
-        {fullname first=$reservation->FirstName last=$reservation->LastName ignorePrivacy=$reservation->IsUserOwner($UserId)}
+        {fullname first=$reservation->FirstName|unescape:'html' last=$reservation->LastName|unescape:'html' ignorePrivacy=$reservation->IsUserOwner($UserId)}
         {if !$reservation->IsUserOwner($UserId)}<i class="bi bi-people-fill"></i> {/if}</div>
     <div class="col-sm-3 col-6">{formatdate date=$reservation->StartDate->ToTimezone($Timezone) key=dashboard} -
         {formatdate date=$reservation->EndDate->ToTimezone($Timezone) key=dashboard}</div>

--- a/tpl/Reservation/pdf.tpl
+++ b/tpl/Reservation/pdf.tpl
@@ -74,7 +74,7 @@ $('.btnPDF').click(function (e) {
 		  styles: { lineWidth: 0.02},
 		  theme: 'plain',
 		  body: [
-			{ user: '{$ReservationUserName|escape:'javascript'}'},
+			{ user: '{$ReservationUserName|unescape:'html'|escape:'javascript'}'},
 		  ],
 		  columns: [
 			{ header: '{translate key='User'}', dataKey: 'user' },
@@ -184,7 +184,7 @@ $('.btnPDF').click(function (e) {
 		 { content: '{translate key="Email"}', styles: { fontStyle: 'bold', fontSize: 7}},
 		],
 		{foreach from=$Participants item=user}
-			[{ content: '{$user->FullName|escape:'javascript'}'},
+			[{ content: '{$user->FullName|unescape:'html'|escape:'javascript'}'},
 			 { content: '{$user->Email}'},
 			],
 		{/foreach}
@@ -202,7 +202,7 @@ $('.btnPDF').click(function (e) {
 		 { content: '{translate key="Email"}', styles: { fontStyle: 'bold', fontSize: 7}},
 		],
 		{foreach from=$Invitees item=user}
-			[{ content: '{$user->FullName|escape:'javascript'}'},
+			[{ content: '{$user->FullName|unescape:'html'|escape:'javascript'}'},
 			 { content: '{$user->Email}'},
 			],
 		{/foreach}
@@ -217,11 +217,11 @@ $('.btnPDF').click(function (e) {
 		body: [
 		[{ content: '{translate key="ReservationTitle"}', styles: { fontStyle: 'bold'}},
 		],
-		[{ content: '{$ReservationTitle|escape:'javascript'}'},
+		[{ content: '{$ReservationTitle|unescape:'html'|escape:'javascript'}'},
 		],
 		[{ content: '{translate key="ReservationDescription"}', styles: { fontStyle: 'bold'}},
 		],
-		[{ content: '{$Description|escape:'javascript'}'},
+		[{ content: '{$Description|unescape:'html'|escape:'javascript'}'},
 		],
 		]
 	});


### PR DESCRIPTION
The html characters are not (un)escaped properly in many TPLs. This fix the display of user names containing an apostrophe or html code. It also prevent the html display of the description and title of the reservation that
 can break the html pages.

closes #762