### PR TITLE
fix: error in WebAuthenticationTest and Facebook login

### DIFF
--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -290,8 +290,24 @@ class LoginPresenter
             if (!session_id()) {
                 session_start();
             }
+
+            // Build the full redirect URL
+            $redirectUri = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_REDIRECT_URI);
+            $scriptUrl = Configuration::Instance()->GetScriptUrl();
+
+            $scriptUrl = rtrim($scriptUrl, '/');
+            if (!str_starts_with($redirectUri, '/')) {
+                $redirectUri = '/' . $redirectUri;
+            }
+
+            if (str_ends_with($scriptUrl, '/Web') && str_starts_with($redirectUri, '/Web/')) {
+                $redirectUri = substr($redirectUri, 4); // Remove the first "/Web"
+            }
+
+            $fullRedirectUrl = $scriptUrl . $redirectUri;
+
             $FacebookUrl = $helper->getLoginUrl(
-                Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_REDIRECT_URI),
+                $fullRedirectUrl,
                 $permissions
             );
 

--- a/Web/facebook-auth.php
+++ b/Web/facebook-auth.php
@@ -15,13 +15,31 @@ if (isset($_GET['code'])) {
         ]);
 
         $helper = $facebook_Client->getRedirectLoginHelper();
-        $accesstoken = $helper->getAccessToken();
+
+        // Build the full redirect URL to ensure consistency with login URL generation
+        $redirectUri = Configuration::Instance()->GetSectionKey(ConfigSection::AUTHENTICATION, ConfigKeys::FACEBOOK_REDIRECT_URI);
+        $scriptUrl = Configuration::Instance()->GetScriptUrl();
+
+        // Handle the case where script URL already ends with /Web and redirect URI starts with /Web
+        $scriptUrl = rtrim($scriptUrl, '/');
+        if (!str_starts_with($redirectUri, '/')) {
+            $redirectUri = '/' . $redirectUri;
+        }
+
+        // If script URL ends with /Web and redirect URI starts with /Web, remove the duplicate
+        if (str_ends_with($scriptUrl, '/Web') && str_starts_with($redirectUri, '/Web/')) {
+            $redirectUri = substr($redirectUri, 4); // Remove the first "/Web"
+        }
+
+        $fullRedirectUrl = $scriptUrl . $redirectUri;
+
+        $accesstoken = $helper->getAccessToken($fullRedirectUrl);
         $_SESSION['facebook_access_token'] = serialize($accesstoken);
         
         $code = filter_input(INPUT_GET,'code');
         header("Location: ".ROOT_DIR."Web/external-auth.php?type=fb&code=".$code);
         exit;
-    } catch (\Facebook\Exceptions\FacebookResponseException | \Facebook\Exceptions\FacebookSDKException $e) {
+    } catch (\Facebook\Exception\ResponseException | \Facebook\Exception\SDKException $e) {
         Log::Debug("Exception during facebook login: %s", $e->getMessage());
         $_SESSION['facebook_error'] = true;
         header("Location:".ROOT_DIR."Web");

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "gregwar/captcha": "^1.3",
         "google/apiclient": "^2.0",
         "microsoft/microsoft-graph": "^2.0",
-        "nickdnk/graph-sdk": "^7.0",
+        "joelbutcher/facebook-graph-sdk": "^6.1",
         "mobiledetect/mobiledetectlib": "^4.8",
         "bacon/bacon-qr-code": "^3.0",
         "mibe/feedwriter": "^1.1",

--- a/tests/Application/Authentication/WebAuthenticationTest.php
+++ b/tests/Application/Authentication/WebAuthenticationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
+require_once(ROOT_DIR . 'Pages/LoginPage.php');
 
 class WebAuthenticationTest extends TestBase
 {


### PR DESCRIPTION
Facebook authentication flow:**

**Dependency updates:**
* Replaced the `nickdnk/graph-sdk` package with `joelbutcher/facebook-graph-sdk` in `composer.json` to use a more suitable Facebook SDK.

**Testing improvements:**

* Added a missing require for `Pages/LoginPage.php` in `WebAuthenticationTest.php` to ensure tests have the necessary dependencies.