### PR TITLE
fix: standardize log messages and improve error handling in config test

### DIFF
--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -151,9 +151,9 @@ class Configuration implements IConfiguration
             // directly load new config format
             $conf = $loadedConfig;
         } elseif (isset($conf['settings'])) {
-            error_log("Legacy config format detected in $configFile. Please consider updating to the new format.");
+            error_log("[CONFIG] Legacy config format detected in $configFile. Please consider updating to the new format.");
         } else {
-            throw new Exception("Invalid config file: 'settings' section missing");
+            throw new Exception("[CONFIG] Invalid config file: 'settings' section missing");
         }
 
         $this->AddConfig($configId, $conf, $overwrite, $configKeysClass);

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -69,6 +69,78 @@ class TestBase extends TestCase
         PluginManager::SetInstance($this->fakePluginManager);
     }
 
+    /**
+     * Helper method to capture error logs during test execution
+     * @param callable $testFunction The function to execute while capturing logs
+     * @param bool $displayLogs Whether to display captured logs (for debugging)
+     * @return array Array of captured error log entries
+     */
+    protected function captureErrorLog(callable $testFunction, bool $displayLogs = false): array
+    {
+        $errorLogs = [];
+        $originalErrorLog = ini_get('error_log');
+
+        // Create a temporary log file
+        $tempLogFile = tempnam(sys_get_temp_dir(), 'test_error_log');
+        if ($tempLogFile === false) {
+            throw new \RuntimeException('Failed to create a temporary error log file in ' . sys_get_temp_dir());
+        }
+        if (ini_set('error_log', $tempLogFile) === false) {
+            throw new \RuntimeException("Failed to set error_log to temporary file: $tempLogFile");
+        }
+        
+        try {
+            // Execute the test function
+            $testFunction();
+        } finally {
+            // Read captured error logs
+            if (file_exists($tempLogFile)) {
+                $errorLogs = file($tempLogFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+            }
+
+            // Restore original error log setting
+            ini_set('error_log', $originalErrorLog);
+
+            // Clean up temporary file
+            if (file_exists($tempLogFile)) {
+                unlink($tempLogFile);
+            }
+        }
+
+        // Optionally display logs for debugging
+        if ($displayLogs && !empty($errorLogs)) {
+            echo "\n=== Captured Error Logs ===\n";
+            foreach ($errorLogs as $logEntry) {
+                echo "ERROR LOG: " . $logEntry . "\n";
+            }
+            echo "=== End Error Logs ===\n";
+        }
+
+        return $errorLogs;
+    }
+
+    /**
+     * Assert that a specific log message is found in captured error logs
+     * 
+     * @param array $logs Array of captured error log messages
+     * @param string $expectedPattern Expected log message pattern to find
+     * @param string $description Description of what should be logged (for assertion message)
+     * @param string $logPrefix Prefix to filter logs by (e.g., '[CONFIG]')
+     */
+    protected function assertLogMessage(array $logs, string $expectedPattern, string $description, string $logPrefix = '[CONFIG]')
+    {
+        $filteredLogs = array_filter($logs, fn($log) => str_contains($log, $logPrefix));
+        $found = false;
+        foreach ($filteredLogs as $log) {
+            if (str_contains($log, $expectedPattern)) {
+                $found = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($found, "Should log: $description");
+    }
+
     public function teardown(): void
     {
         $this->db = null;

--- a/tests/data/test_config.php
+++ b/tests/data/test_config.php
@@ -10,7 +10,7 @@ return [
             'type' => 'mysql',
         ],
         'plugins' => [
-            'Authentication' => 'ActiveDirectory',
+            'authentication' => 'ActiveDirectory',
         ],
     ],
 ];


### PR DESCRIPTION
Duplicate of #787 as it was on the wrong branch

**Error Logging Improvements**
* Updated error log messages in `Configuration.php` to include the `[CONFIG]` prefix for better traceability and clarity when reporting legacy config format detection and invalid config file structure.

**Test Infrastructure Enhancements**
* Added `captureErrorLog` and `assertLogMessage` helper methods to `TestBase.php` to enable capturing and asserting error log output during test execution, improving reliability of log-related test assertions.

**Expanded Configuration Validation Tests**
* Improved `ConfigTest.php` by capturing error logs during config registration and adding assertions for specific log messages related to legacy format detection, deprecated keys, and type/value validation errors for both main and plugin configs. [[1]](diffhunk://#diff-5a7b6ce601edcbe710a4978a4e814dfc47d09e40b7cede985d9e0cb9f02ab137R31-R48) [[2]](diffhunk://#diff-5a7b6ce601edcbe710a4978a4e814dfc47d09e40b7cede985d9e0cb9f02ab137R69-R75) [[3]](diffhunk://#diff-5a7b6ce601edcbe710a4978a4e814dfc47d09e40b7cede985d9e0cb9f02ab137R95-R106)
* Commented out the `testConfigDistLoadsCorrectly` test, possibly to avoid issues with environment-dependent values or to refactor its approach.

**Test Fixture Correction**
* Standardized the `Authentication` config key to lowercase `authentication` in `test_config.php` to match expected usage and prevent case-sensitivity issues.