### PR TITLE
Fix api issue with new configkey validation

### DIFF
--- a/Web/Services/index.php
+++ b/Web/Services/index.php
@@ -22,9 +22,6 @@ require_once(ROOT_DIR . 'WebServices/AccountWebService.php');
 
 require_once(ROOT_DIR . 'Web/Services/Help/ApiHelpPage.php');
 
-if (!Configuration::Instance()->GetKey(ConfigKeys::API_ENABLED, new BooleanConverter())) {
-    die("LibreBooking API has been configured as disabled.<br/><br/>Set \$conf['settings']['api']['enabled'] = 'true' to enable.");
-}
 
 \Slim\Slim::registerAutoloader();
 $app = new \Slim\Slim();
@@ -46,6 +43,10 @@ RegisterAccessories($server, $registry);
 RegisterAccounts($server, $registry);
 
 $app->hook('slim.before.dispatch', function () use ($app, $server, $registry) {
+if (!Configuration::Instance()->GetKey(ConfigKeys::API_ENABLED, new BooleanConverter())) {
+        $app->halt(RestResponse::SERVICE_UNAVAILABLE, 'LibreBooking API is disabled. Set ["api"]["enabled"] = true');
+    }
+
     $routeName = $app->router()->getCurrentRoute()->getName();
     if ($registry->IsSecure($routeName)) {
         $security = new WebServiceSecurity(new UserSessionRepository());

--- a/Web/Services/index.php
+++ b/Web/Services/index.php
@@ -98,7 +98,7 @@ function RegisterHelp(SlimWebServiceRegistry $registry, \Slim\Slim $app)
 
 function RegisterAuthentication(SlimServer $server, SlimWebServiceRegistry $registry)
 {
-    $api_access_group_id = GetConfigGroup(config_group: "Authentication.group");
+    $api_access_group_id = GetConfigGroup(ConfigKeys::API_AUTHENTICATION_GROUP);
     $webService = new AuthenticationWebService(
         $server,
         new WebServiceAuthentication(PluginManager::Instance()->LoadAuthentication(), new UserSessionRepository()),
@@ -116,8 +116,8 @@ function RegisterReservations(SlimServer $server, SlimWebServiceRegistry $regist
     $readService = new ReservationsWebService($server, new ReservationViewRepository(), new PrivacyFilter(new ReservationAuthorization(PluginManager::Instance()->LoadAuthorization())), new AttributeService(new AttributeRepository()));
     $writeService = new ReservationWriteWebService($server, new ReservationSaveController(new ReservationPresenterFactory()));
 
-    $roGroupId = GetConfigGroup('Reservations.ro.group');
-    $rwGroupId = GetConfigGroup('Reservations.rw.group');
+    $roGroupId = GetConfigGroup(ConfigKeys::API_RESERVATIONS_RO_GROUP);
+    $rwGroupId = GetConfigGroup(ConfigKeys::API_RESERVATIONS_RW_GROUP);
     $category = new SlimWebServiceRegistryCategory('Reservations', roGroupId: $roGroupId, rwGroupId: $rwGroupId);
 
     $category->AddSecurePost('/', [$writeService, 'Create'], WebServices::CreateReservation);
@@ -139,7 +139,7 @@ function RegisterResources(SlimServer $server, SlimWebServiceRegistry $registry)
     $webService = new ResourcesWebService($server, $resourceRepository, $attributeService, new ReservationViewRepository());
     $writeWebService = new ResourcesWriteWebService($server, new ResourceSaveController($resourceRepository, new ResourceRequestValidator($attributeService)));
 
-    $roGroupId = GetConfigGroup('Resources.ro.group');
+    $roGroupId = GetConfigGroup(ConfigKeys::API_RESOURCES_RO_GROUP);
     $category = new SlimWebServiceRegistryCategory('Resources', roGroupId: $roGroupId);
 
     $category->AddGet('/Status', [$webService, 'GetStatuses'], WebServices::GetStatuses);
@@ -160,7 +160,7 @@ function RegisterAccessories(SlimServer $server, SlimWebServiceRegistry $registr
 {
     $webService = new AccessoriesWebService($server, new ResourceRepository(), new AccessoryRepository());
 
-    $roGroupId = GetConfigGroup('Accessories.ro.group');
+    $roGroupId = GetConfigGroup(ConfigKeys::API_ACCESSORIES_RO_GROUP);
     $category = new SlimWebServiceRegistryCategory('Accessories', roGroupId: $roGroupId);
 
     $category->AddSecureGet('/', [$webService, 'GetAll'], WebServices::AllAccessories);
@@ -177,7 +177,7 @@ function RegisterUsers(SlimServer $server, SlimWebServiceRegistry $registry)
         new UserSaveController(new ManageUsersServiceFactory(), new UserRequestValidator($attributeService, new UserRepository()))
     );
 
-    $roGroupId = GetConfigGroup('Users.ro.group');
+    $roGroupId = GetConfigGroup(ConfigKeys::API_USERS_RO_GROUP);
     $category = new SlimWebServiceRegistryCategory('Users', roGroupId: $roGroupId);
 
     $category->AddSecureGet('/', [$webService, 'GetUsers'], WebServices::AllUsers);
@@ -193,7 +193,7 @@ function RegisterSchedules(SlimServer $server, SlimWebServiceRegistry $registry)
 {
     $webService = new SchedulesWebService($server, new ScheduleRepository(), new PrivacyFilter(new ReservationAuthorization(PluginManager::Instance()->LoadAuthorization())));
 
-    $roGroupId = GetConfigGroup('Schedules.ro.group');
+    $roGroupId = GetConfigGroup(ConfigKeys::API_SCHEDULES_RO_GROUP);
     $category = new SlimWebServiceRegistryCategory('Schedules', roGroupId: $roGroupId);
 
     $category->AddSecureGet('/', [$webService, 'GetSchedules'], WebServices::AllSchedules);
@@ -207,7 +207,7 @@ function RegisterAttributes(SlimServer $server, SlimWebServiceRegistry $registry
     $webService = new AttributesWebService($server, new AttributeService(new AttributeRepository()));
     $writeWebService = new AttributesWriteWebService($server, new AttributeSaveController(new AttributeRepository()));
 
-    $roGroupId = GetConfigGroup('Attributes.ro.group');
+    $roGroupId = GetConfigGroup(ConfigKeys::API_ATTRIBUTES_RO_GROUP);
     $category = new SlimWebServiceRegistryCategory('Attributes', roGroupId: $roGroupId);
 
     $category->AddSecureGet('Category/:categoryId', [$webService, 'GetAttributes'], WebServices::AllCustomAttributes);
@@ -215,7 +215,7 @@ function RegisterAttributes(SlimServer $server, SlimWebServiceRegistry $registry
     $category->AddAdminPost('/', [$writeWebService, 'Create'], WebServices::CreateCustomAttribute);
     $category->AddAdminPost('/:attributeId', [$writeWebService, 'Update'], WebServices::UpdateCustomAttribute);
     $category->AddAdminDelete('/:attributeId', [$writeWebService, 'Delete'], WebServices::DeleteCustomAttribute);
-    $registry->AddCategory($category);
+    $registry->AddCategory(category: $category);
 }
 
 function RegisterGroups(SlimServer $server, SlimWebServiceRegistry $registry)
@@ -224,7 +224,7 @@ function RegisterGroups(SlimServer $server, SlimWebServiceRegistry $registry)
     $webService = new GroupsWebService($server, $groupRepository, $groupRepository);
     $writeWebService = new GroupsWriteWebService($server, new GroupSaveController($groupRepository, new ResourceRepository(), new ScheduleRepository()));
 
-    $roGroupId = GetConfigGroup('Groups.ro.group');
+    $roGroupId = GetConfigGroup(ConfigKeys::API_GROUPS_RO_GROUP);
     $category = new SlimWebServiceRegistryCategory('Groups', roGroupId: $roGroupId);
 
     $category->AddSecureGet('/', [$webService, 'GetGroups'], WebServices::AllGroups);
@@ -249,30 +249,41 @@ function RegisterAccounts(SlimServer $server, SlimWebServiceRegistry $registry)
 
     $webService = new AccountWebService($server, $controller);
 
-    $roGroupId = GetConfigGroup('Accounts.ro.group');
-    $rwGroupId = GetConfigGroup('Accounts.rw.group');
+    $roGroupId = GetConfigGroup(ConfigKeys::API_ACCOUNTS_RO_GROUP);
+    $rwGroupId = GetConfigGroup(ConfigKeys::API_ACCOUNTS_RW_GROUP);
     $category = new SlimWebServiceRegistryCategory('Accounts', roGroupId: $roGroupId, rwGroupId: $rwGroupId);
 
     $category->AddPost('/', [$webService, 'Create'], WebServices::CreateAccount);
     $category->AddSecurePost('/:userId', [$webService, 'Update'], WebServices::UpdateAccount);
     $category->AddSecurePost('/:userId/Password', [$webService, 'UpdatePassword'], WebServices::UpdateAccountPassword);
-    $category->AddSecureGet('/:userId', [$webService, 'GetAccount'], WebServices::GetAccount);
+    $category->AddSecureGet('/:userId',  [$webService, 'GetAccount'], WebServices::GetAccount);
 
     $registry->AddCategory($category);
 }
 
-function GetConfigGroup(string $config_group): string|null {
-    $group_name = Configuration::Instance()->GetKey($config_group) ?? '';
-    if ($group_name == '') {
+
+/**
+ * Resolve a group ID from a configuration key that stores a group name.
+ *
+ * @param string|array $configDef Configuration key whose value is the desired group name.
+ * @return string|null The matching group ID, or `null` if the config value is empty.
+ */
+function GetConfigGroup($configDef): string|null
+{
+    $groupName = Configuration::Instance()->GetKey($configDef) ?? '';
+    if ($groupName == '') {
         return null;
     }
     $groupRepository = new GroupRepository();
     $groups = $groupRepository->GetList()->Results();
     foreach ($groups as $group) {
-        if ($group->Name == $group_name) {
+        if ($group->Name == $groupName) {
             return $group->Id();
         }
     }
-    die("Unable to find group: '$group_name' for API group '$config_group'. Please contact the administrator to resolve this issue in the `config.php` file.");
-    return null;
+
+    $confKeyLabel = is_string($configDef) ? $configDef : 'config key';
+    throw new \RuntimeException(
+        "Group '{$groupName}' for {$confKeyLabel} not found. Please fix config.php."
+    );
 }

--- a/Web/Services/index.php
+++ b/Web/Services/index.php
@@ -67,7 +67,7 @@ if (!Configuration::Instance()->GetKey(ConfigKeys::API_ENABLED, new BooleanConve
         // Check if the user is allowed API access to the route
         if (!$registry->IsUserAllowedApiAccess(routeName: $routeName, userId: $userSession->UserId)) {
             $app->halt(
-                RestResponse::FORBIDDEN,
+                RestResponse::FORBIDDEN_CODE,
                 'You are not authorized to access this service.<br/>'
             );
         }

--- a/WebServices/AuthenticationWebService.php
+++ b/WebServices/AuthenticationWebService.php
@@ -58,7 +58,7 @@ class AuthenticationWebService
             if (!$session->IsAdmin && is_numeric($this->api_access_group_id)) {
                 if (!UserGroupHelper::isUserInGroup(groupId: $this->api_access_group_id, userId: $session->UserId)) {
                     Log::Debug('WebService Authenticate, user %s was denied API access', $username);
-                    $this->server->WriteResponse(AuthenticationResponse::NotAuthorized(), statusCode: RestResponse::FORBIDDEN);
+                    $this->server->WriteResponse(AuthenticationResponse::NotAuthorized(), statusCode: RestResponse::FORBIDDEN_CODE);
                     return;
                 }
             }
@@ -75,7 +75,7 @@ class AuthenticationWebService
         } else {
             Log::Debug('WebService Authenticate, user %s was not authenticated', $username);
 
-            $this->server->WriteResponse(AuthenticationResponse::Failed());
+            $this->server->WriteResponse(AuthenticationResponse::Failed(), RestResponse::UNAUTHORIZED_CODE);
         }
     }
 

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -439,7 +439,10 @@ class ConfigurationFile implements IConfigurationFile
     public function GetKey($configDef, $converter = null)
     {
         if (!is_array($configDef) || !isset($configDef['key'])) {
-            throw new InvalidArgumentException('Config definition not found"');
+            throw new InvalidArgumentException(sprintf(
+                'Config definition not found for: %s',
+                json_encode($configDef, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+            ));
         }
 
         $value = null;

--- a/lib/WebService/RestResponse.php
+++ b/lib/WebService/RestResponse.php
@@ -6,7 +6,7 @@ class RestResponse
     public const CREATED_CODE = 201;
     public const BAD_REQUEST_CODE = 400;
     public const UNAUTHORIZED_CODE = 401;
-    public const FORBIDDEN = 403;
+    public const FORBIDDEN_CODE = 403;
     public const NOT_FOUND_CODE = 404;
     public const SERVER_ERROR = 500;
     public const SERVICE_UNAVAILABLE = 503;

--- a/lib/WebService/RestResponse.php
+++ b/lib/WebService/RestResponse.php
@@ -9,6 +9,7 @@ class RestResponse
     public const FORBIDDEN = 403;
     public const NOT_FOUND_CODE = 404;
     public const SERVER_ERROR = 500;
+    public const SERVICE_UNAVAILABLE = 503;
 
     /**
      * @var array|RestServiceLink[]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -715,18 +715,6 @@ parameters:
 			path: tests/WebServices/AccessoriesWebServiceTest.php
 
 		-
-			message: '#^Method AuthenticationWebService\:\:Authenticate\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 2
-			path: tests/WebServices/AuthenticationWebServiceTest.php
-
-		-
-			message: '#^Method AuthenticationWebService\:\:SignOut\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: tests/WebServices/AuthenticationWebServiceTest.php
-
-		-
 			message: '#^Call to an undefined method IReservationPresenterFactory\:\:expects\(\)\.$#'
 			identifier: method.notFound
 			count: 4

--- a/tests/WebServices/AuthenticationWebServiceTest.php
+++ b/tests/WebServices/AuthenticationWebServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(ROOT_DIR . 'WebServices/AuthenticationWebService.php');
+require_once(ROOT_DIR . 'Domain/Values/WebService/WebServiceUserSession.php');
 
 class AuthenticationWebServiceTest extends TestBase
 {
@@ -33,7 +34,7 @@ class AuthenticationWebServiceTest extends TestBase
     {
         $username = 'un';
         $password = 'pw';
-        $session = new UserSession(1);
+    $session = new WebServiceUserSession(1);
 
         $request = new AuthenticationRequest($username, $password);
         $this->server->SetRequest($request);
@@ -48,10 +49,12 @@ class AuthenticationWebServiceTest extends TestBase
                 ->with($this->equalTo($username))
                 ->willReturn($session);
 
-        $this->service->Authenticate($this->server);
+    $this->service->Authenticate();
 
         $expectedResponse = AuthenticationResponse::Success($this->server, $session, 0);
+        $expectedResponseCode = RestResponse::OK_CODE;
         $this->assertEquals($expectedResponse, $this->server->_LastResponse);
+        $this->assertEquals($expectedResponseCode, $this->server->_LastResponseCode);
     }
 
     public function testRestrictsUserIfInvalidCredentials()
@@ -67,10 +70,12 @@ class AuthenticationWebServiceTest extends TestBase
                 ->with($this->equalTo($username), $this->equalTo($password))
                 ->willReturn(false);
 
-        $this->service->Authenticate($this->server);
+    $this->service->Authenticate();
 
         $expectedResponse = AuthenticationResponse::Failed();
+        $expectedResponseCode = RestResponse::UNAUTHORIZED_CODE;
         $this->assertEquals($expectedResponse, $this->server->_LastResponse);
+        $this->assertEquals($expectedResponseCode, $this->server->_LastResponseCode);
     }
 
     public function testSignsUserOut()
@@ -85,6 +90,6 @@ class AuthenticationWebServiceTest extends TestBase
                 ->method('Logout')
                 ->with($this->equalTo($userId), $this->equalTo($sessionToken));
 
-        $this->service->SignOut($this->server);
+    $this->service->SignOut();
     }
 }


### PR DESCRIPTION
This pull request refactors how API group configuration is handled and improves error handling and logging consistency throughout the codebase. The main changes include centralizing configuration key usage, improving error messages, and standardizing log level values.

**Configuration and Error Handling Improvements:**

* Refactored all API group configuration lookups in `Web/Services/index.php` to use constants from `ConfigKeys` instead of string literals, ensuring consistency and reducing the risk of typos. [[1]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L101-R102) [[2]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L119-R121) [[3]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L142-R143) [[4]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L163-R164) [[5]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L180-R181) [[6]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L196-R197) [[7]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L210-R219) [[8]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L227-R228) [[9]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L252-R254)
* Updated the `GetConfigGroup` function to accept either a string or array config key, improved its documentation, and changed error handling to throw a `RuntimeException` with a clear message if the group cannot be found, instead of calling `die()`.
* Moved the API enabled check from the global scope to the Slim `slim.before.dispatch` hook, using `$app->halt()` with a `503 Service Unavailable` status code and a clear message when the API is disabled. [[1]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81L25-L27) [[2]](diffhunk://#diff-c966d0211b9c12b49dd812601ba838967e63b5d5019eb481d3ea331d2b542c81R46-R49)
* Updated the call to `AddCategory` in `RegisterAttributes` to use a named parameter for clarity.

**Logging Consistency:**

* Standardized logging level values in `ConfigKeys` to use lowercase (`debug`, `info`, `warning`, `error`) instead of uppercase, and updated descriptions accordingly.
* Ensured the log folder path in `Log.php` is always normalized by removing any trailing slash.

**HTTP Status Codes:**

* Added a `SERVICE_UNAVAILABLE` (503) constant to the `RestResponse` class for clearer and more maintainable HTTP responses.

Fixes #805 