### PR TITLE
fix(logging): have default log level be 'error'

### DIFF
--- a/lib/Common/Logging/Log.php
+++ b/lib/Common/Logging/Log.php
@@ -37,7 +37,7 @@ class Log
         $log_sql = false;
 
         if ($log_level != 'none') {
-            $log_folder = Configuration::Instance()->GetKey(ConfigKeys::LOGGING_FOLDER);
+            $log_folder = rtrim(Configuration::Instance()->GetKey(ConfigKeys::LOGGING_FOLDER), '/');
             $log_sql = Configuration::Instance()->GetKey(ConfigKeys::LOGGING_SQL, new BooleanConverter());
             switch ($log_level) {
                 case 'debug':
@@ -72,7 +72,7 @@ class Log
      */
     public static function Debug($message, $args = [])
     {
-        $log_level = Configuration::Instance()->GetKey(ConfigKeys::LOGGING_LEVEL);
+        $log_level = strtolower(Configuration::Instance()->GetKey(ConfigKeys::LOGGING_LEVEL));
         if ($log_level == 'none') {
             return;
         }

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -414,16 +414,14 @@ class ConfigKeys
     public const LOGGING_LEVEL = [
         'key' => 'logging.level',
         'type' => 'string',
-        'default' => 'none',
+        'default' => 'error',
         'choices' => [
             'none' => 'None',
-            'WARNING' => 'WARNING',
-            'ERROR' => 'ERROR',
-            'INFO' => 'INFO',
-            'DEBUG' => 'DEBUG',
+            'error' => 'error',
+            'debug' => 'debug',
         ],
         'label' => 'Logging Level',
-        'description' => 'Logging level: none, DEBUG, INFO, WARNING, ERROR',
+        'description' => 'Logging level: none, debug, error',
         'section' => 'logging'
     ];
 

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -462,6 +462,15 @@ class ConfigurationFile implements IConfigurationFile
                 $value = $this->_values[$fullKey];
             }
         }
+
+        if ($value === null || $value === '') {
+            if (array_key_exists('default', $configDef)) {
+                $value = $configDef['default'];
+            } else {
+                $value = null;
+            }
+        }
+
         return $this->Convert($value, $converter);
     }
 


### PR DESCRIPTION
If no logging level is set then default to 'error'

Previously it was 'none'. In that case critical errors could be happening but none of them would show up in the log.

Change logging levels to lowercase to fix bug as uppercase is incorrect.

Enable default values to work for config items.