### PR TITLE
fix: ignore invalid configs in ManageConfiguration

### DIFF
--- a/Presenters/Admin/ManageConfigurationPresenter.php
+++ b/Presenters/Admin/ManageConfigurationPresenter.php
@@ -125,7 +125,7 @@ class ManageConfigurationPresenter extends ActionPresenter
     private function AddSettingFromMeta($key, $section, $value)
     {
         $meta = call_user_func([$this->configKeyClass, 'findByKey'], $key);
-        if ($this->ShouldBeSkipped($key, $meta)) {
+        if (!isset($meta) || $this->ShouldBeSkipped($key, $meta)) {
             return;
         }
 


### PR DESCRIPTION
This pull request makes a minor improvement to the `AddSettingFromMeta` method in `ManageConfigurationPresenter.php` by adding a check to ensure that `$meta` is set before proceeding. This helps prevent potential errors if the configuration key is not found.