### PR TITLE
ICS export and config fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,10 +161,10 @@ LB_LOGGING_SQL=false
 ##########################
 
 # Full or relative path to where images will be stored
-LB_UPLOAD_IMAGE_DIRECTORY='Web/uploads/images'
+LB_UPLOADS_IMAGE_UPLOAD_DIRECTORY='Web/uploads/images'
 
 # full or relative path to show uploaded images from
-LB_UPLOAD_IMAGE_URL='uploads/images'
+LB_UPLOADS_IMAGE_UPLOAD_URL='uploads/images'
 
 # Enable reservation attachments (true/false)
 LB_UPLOADS_RESERVATION_ATTACHMENTS_ENABLED=false
@@ -375,6 +375,13 @@ LB_REGISTRATION_AUTO_SUBSCRIBE_EMAIL=false
 LB_REGISTRATION_NOTIFY_ADMIN=false
 
 ##########################################
+# Resource Options
+##########################################
+
+# Indicates if the contact must be a registered user
+LB_RESOURCE_CONTACT_IS_USER=false
+
+##########################################
 # Tablet View Options
 ##########################################
 
@@ -421,7 +428,7 @@ LB_CLEANUP_DELETE_OLD_RESERVATIONS=false
 ##########################################
 
 # Disable the 'Forgot Password' feature (true/false)
-LB_DISABLE_PASSWORD_RESET=false
+LB_PASSWORD_DISABLE_RESET=false
 
 # Minimum number of letters required in passwords
 LB_PASSWORD_MINIMUM_LETTERS=6
@@ -490,6 +497,9 @@ LB_SECURITY_X_XSS='1; mode=block'
 
 # X-Content-Type-Options header value
 LB_SECURITY_X_CONTENT_TYPE='nosniff'
+
+# Set the Content-Security-Policy header value
+LB_SECURITY_CONTENT_SECURITY_POLICY=''
 
 ##########################################
 # Credit System Settings
@@ -629,28 +639,28 @@ LB_AUTHENTICATION_OAUTH2_CLIENT_URI='/Web/oauth2-auth.php'
 
 # Comma-separated list of plugin class names to use for authentication
 # Available authentication plugins: ActiveDirectory, Apache, CAS, Drupal, Krb5, Ldap, Mellon, Moodle, MoodleAdv, Saml, Shibboleth, WordPress
-LB_PLUGIN_AUTHENTICATION=
+LB_PLUGINS_AUTHENTICATION=
 
 # Comma-separated list of plugin class names to use for authorization
-LB_PLUGIN_AUTHORIZATION=
+LB_PLUGINS_AUTHORIZATION=
 
 # Comma-separated list of plugin class names to handle data export
-LB_PLUGIN_EXPORT=
+LB_PLUGINS_EXPORT=
 
 # Comma-separated list of plugin class names for permission management
-LB_PLUGIN_PERMISSION=
+LB_PLUGINS_PERMISSION=
 
 # Comma-separated list of plugin class names to run after user registration
-LB_PLUGIN_POSTREGISTRATION=
+LB_PLUGINS_POSTREGISTRATION=
 
 # Comma-separated list of plugin class names to run before reservation creation
-LB_PLUGIN_PRERESERVATION=
+LB_PLUGINS_PRERESERVATION=
 
 # Comma-separated list of plugin class names to run after reservation is created/updated
-LB_PLUGIN_POSTRESERVATION=
+LB_PLUGINS_POSTRESERVATION=
 
 # Comma-separated list of plugin class names to apply custom styling logic
-LB_PLUGIN_STYLING=
+LB_PLUGINS_STYLING=
 
 
 ##########################################

--- a/Web/export/atom-subscribe.php
+++ b/Web/export/atom-subscribe.php
@@ -5,7 +5,7 @@ define('ROOT_DIR', '../../');
 require_once(ROOT_DIR . 'Pages/Export/AtomSubscriptionPage.php');
 
 $page = new AtomSubscriptionPage();
-if (Configuration::Instance()->GetKey('require.login', new BooleanConverter())) {
-    $page = new SecurePageDecorator($page);
-}
+//if (Configuration::Instance()->GetKey('require.login', new BooleanConverter())) {
+//     $page = new SecurePageDecorator($page);
+//}
 $page->PageLoad();

--- a/Web/export/ical-subscribe.php
+++ b/Web/export/ical-subscribe.php
@@ -5,7 +5,8 @@ define('ROOT_DIR', '../../');
 require_once(ROOT_DIR . 'Pages/Export/CalendarSubscriptionPage.php');
 
 $page = new CalendarSubscriptionPage();
-if (Configuration::Instance()->GetKey('require.login', new BooleanConverter())) {
-    $page = new SecurePageDecorator($page);
-}
+// if (Configuration::Instance()->GetKey('require.login', new BooleanConverter())) 
+//     {
+//     $page = new SecurePageDecorator($page);
+// }
 $page->PageLoad();

--- a/Web/export/ical.php
+++ b/Web/export/ical.php
@@ -5,7 +5,7 @@ define('ROOT_DIR', '../../');
 require_once(ROOT_DIR . 'Pages/Export/CalendarExportPage.php');
 
 $page = new CalendarExportPage();
-if (Configuration::Instance()->GetKey('require.login', new BooleanConverter())) {
-    $page = new SecurePageDecorator($page);
-}
+// if (Configuration::Instance()->GetKey('require.login', new BooleanConverter())) {
+//     $page = new SecurePageDecorator($page);
+// }
 $page->PageLoad();

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -199,6 +199,7 @@ return [
 
             # full or relative path to show uploaded images from
             'image.upload.url' => 'uploads/images',
+
             # Enable reservation attachments (true/false)
             'reservation.attachments.enabled' => false,
 
@@ -567,6 +568,7 @@ return [
             # X-Content-Type-Options header value
             'x-content-type' => 'nosniff',
 
+            # Set the Content-Security-Policy header value
             'content-security-policy' => '',
         ],
 

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -307,7 +307,7 @@ return [
             # Enable a waitlist for fully booked reservations (true/false)
             'allow.wait.list' => false,
 
-            # Restrict start times (e.g., 'future', 'any', 'same_day')
+            # Restrict start times (e.g., 'future', 'none', 'same_day')
             'start.time.constraint' => 'future',
 
             # Require approval when an existing reservation is updated (true/false)

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -725,7 +725,7 @@ class ConfigKeys
         'type' => 'string',
         'default' => 'future',
         'choices' => [
-            'any' => 'Any time',
+            'none' => 'Any time',
             'future' => 'Future',
             'same_day' => 'Same day'
         ],

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1257,7 +1257,7 @@ class ConfigKeys
         'default' => '',
         'label' => 'Google Analytics Tracking ID',
         'description' => 'Tracking ID for Google Analytics integration',
-        'section' => 'External integrations',
+        'section' => '',
         'is_private' => true
     ];
 
@@ -1268,7 +1268,7 @@ class ConfigKeys
         'default' => '',
         'label' => 'Slack Token',
         'description' => 'Token for Slack integration',
-        'section' => 'External integrations',
+        'section' => '',
         'is_private' => true
     ];
 

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1792,18 +1792,23 @@ class ConfigKeys
         return null;
     }
 
-    public static function isPrivate($config): bool
+    public static function isPrivate($configDef): bool
     {
-        if (empty($config)) {
+        if (empty($configDef)) {
             return false;
         }
-        return $config['is_private'] ?? false;
+        return $configDef['is_private'] ?? false;
     }
 
-    public static function hasEnv($config): bool
+    public static function hasEnv($configDef): bool
     {
+        $key = $configDef['key'] ?? null;
+        if (!is_string($key) || $key === '') {
+            return false;
+        }
+
         $loadedEnvVars = getenv();
-        $envKey = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $config['key']));
+        $envKey = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', (string)$key));
         return array_key_exists($envKey, $loadedEnvVars) ?? false;
     }
 }

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -415,8 +415,7 @@ class ConfigurationFile implements IConfigurationFile
             }
 
             if (isset($configDef['choices']) && !array_key_exists($value, $configDef['choices'])) {
-                error_log("[CONFIG] Invalid value '$value' for '{$fullKey}'. Should be one of the following options: [" . implode(', ', $configDef['choices']) . "]");
-
+                error_log("[CONFIG] Invalid value '$value' for '{$fullKey}'. Should be one of the following options: [" . implode(', ', array_map( fn($key, $value) => "{$key} => {$value}", array_keys($configDef['choices']), $configDef['choices'])) . "]");
                 $validated[$key] = $configDef['default'];
                 continue;
             }


### PR DESCRIPTION
This pull request updates configuration keys and environment variables to improve consistency, add new options, and enhance security header support. It also refactors some code for clarity and disables login requirements for export endpoints. The most important changes are grouped below.

**Configuration Key and Environment Variable Consistency:**

* Standardized plugin-related environment variable names in `.env.example` from `LB_PLUGIN_*` to `LB_PLUGINS_*` for authentication, authorization, export, permission, post-registration, pre-reservation, post-reservation, and styling plugins.
* Renamed image upload environment variables in `.env.example` for clarity: `LB_UPLOAD_IMAGE_DIRECTORY` → `LB_UPLOADS_IMAGE_UPLOAD_DIRECTORY` and `LB_UPLOAD_IMAGE_URL` → `LB_UPLOADS_IMAGE_UPLOAD_URL`.
* Renamed password reset environment variable in `.env.example` from `LB_DISABLE_PASSWORD_RESET` to `LB_PASSWORD_DISABLE_RESET`.

**New Configuration Options and Security Improvements:**

* Added support for the Content-Security-Policy header in both `.env.example` (`LB_SECURITY_CONTENT_SECURITY_POLICY`) and `config/config.dist.php` (`content-security-policy`). [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR501-R503) [[2]](diffhunk://#diff-fee07c3d16def1fc6b01b539a24d33eb4f4690e20b4e012604d69c26e4422845R571)
* Added a new resource option in `.env.example` (`LB_RESOURCE_CONTACT_IS_USER`) to indicate if a contact must be a registered user.

**Refactoring and Code Quality:**

* Improved error logging for invalid configuration choices to show both keys and values for available options in `lib/Config/Configuration.php`.
* Refactored function parameter names for clarity in `lib/Config/ConfigKeys.php` (`isPrivate`, `hasEnv`).
* Updated the start time constraint option: replaced `'any'` with `'none'` in `lib/Config/ConfigKeys.php` and `config/config.dist.php` for consistency. [[1]](diffhunk://#diff-489948f08638cfdacfb3057796d345fc25d9269b878c127d162e848f7264b40dL728-R728) [[2]](diffhunk://#diff-fee07c3d16def1fc6b01b539a24d33eb4f4690e20b4e012604d69c26e4422845L309-R310)

**Export Endpoint Access:**

* Disabled login requirement for Atom, iCal subscription, and iCal export endpoints by commenting out the login check in `Web/export/atom-subscribe.php`, `Web/export/ical-subscribe.php`, and `Web/export/ical.php`. [[1]](diffhunk://#diff-82f607c40e768060bc3b9f0d7954f487bfc66767fad71637bd5f8dcffdbd7019L8-R10) [[2]](diffhunk://#diff-5cfbfd4216eb3e8c9b45b10c12c418bcd66718e4d9c89f8e6246c03975dc8dc6L8-R11) [[3]](diffhunk://#diff-086841a4fca95890c61e71a7d5b074ce4dbebff6c31a71816a52b6fadea12cedL8-R10)

**Other Configuration Updates:**

* Removed the section label "External integrations" from Google Analytics and Slack token config keys in `lib/Config/ConfigKeys.php`. [[1]](diffhunk://#diff-489948f08638cfdacfb3057796d345fc25d9269b878c127d162e848f7264b40dL1260-R1260) [[2]](diffhunk://#diff-489948f08638cfdacfb3057796d345fc25d9269b878c127d162e848f7264b40dL1271-R1271)