### PR TITLE
ci(cz-lint): Give a more helpful message when 'cz' fails

### DIFF
--- a/ci/cz-check.sh
+++ b/ci/cz-check.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+trap 'echo "Exit status $? at line $LINENO from: $BASH_COMMAND"' ERR
+
+export PS4='+ ${BASH_SOURCE:-}:${FUNCNAME[0]:-}:L${LINENO:-}:   '
+# set -x
+
+# Ensure that our starting commit is really an ancestor of HEAD
+git merge-base --is-ancestor 8a420dd06cb2b07748953255420556b0ded7d769 HEAD || exit 1
+if ! cz check --rev-range 8a420dd06cb2b07748953255420556b0ded7d769..HEAD; then
+    echo ""
+    echo ""
+    echo "ERROR: The 'cz' check failed. "
+    echo "Commit messages must start with a valid commit 'type'"
+    echo "Valid commit 'types' are: build:, ci:, docs:, feat:, fix:, perf:, refactor:, style:, test:, chore:, revert:, bump:"
+    echo "A 'scope' can be provided in parenthesis if desired. Like: 'docs(API): Improve the API documentation'"
+    echo ""
+    echo "For example a commit message could be something like:"
+    echo "  ci(cz-lint): Give a more helpful message when 'cz' fails"
+    echo ""
+    echo "For more info, see: https://www.conventionalcommits.org/"
+    echo ""
+    echo ""
+    exit 1
+fi

--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,11 @@ isolated_build = True
 [testenv:cz]
 basepython = python3
 deps = -r{toxinidir}/requirements-lint.txt
-allowlist_externals = git
+allowlist_externals = git,{toxinidir}/ci/cz-check.sh
 commands =
   # Ensure that our starting commit is really an ancestor of HEAD
   git merge-base --is-ancestor 8a420dd06cb2b07748953255420556b0ded7d769 HEAD
-  cz check --rev-range 8a420dd06cb2b07748953255420556b0ded7d769..HEAD
+  {toxinidir}/ci/cz-check.sh
 
 [testenv:config-check]
 basepython = python3


### PR DESCRIPTION
The 'cz' error message is fairly cryptic. Give more information when it fails.