### PR TITLE
fix(templates): Replace regex check with empty check in Italian email templates

### DIFF
--- a/lang/it_it/AccountCreation.tpl
+++ b/lang/it_it/AccountCreation.tpl
@@ -7,7 +7,7 @@
     <strong>Posizione:</strong> {$Position}
 </p>
 <p>
-    {if preg_match("/[a-zA-Z]+/",$CreatedBy)}
+    {if !empty($CreatedBy)}
         <strong>Creato da:</strong> {$CreatedBy}
     {/if}
 </p>

--- a/lang/it_it/AccountCreationForUser.tpl
+++ b/lang/it_it/AccountCreationForUser.tpl
@@ -9,7 +9,7 @@
     <strong>Password:</strong> <em>{$Password}</em>
 </p>
 <p>
-    {if preg_match("/[a-zA-Z]+/",$CreatedBy)}
+    {if !empty($CreatedBy)}
         <strong>Created by:</strong> {$CreatedBy}
     {/if}
 </p>

--- a/lang/it_it/ReservationCreated.tpl
+++ b/lang/it_it/ReservationCreated.tpl
@@ -101,10 +101,10 @@
         {/if}
     </p>
 {/if}
-{if preg_match("/[a-zA-Z]+/",$CreatedBy)}
+{if !empty($CreatedBy)}
 	  <p><strong>Creata da:</strong> {$CreatedBy}</p>
 {/if}
-{if preg_match("/[a-zA-Z]+/",$ApprovedBy)}
+{if !empty($ApprovedBy)}
 	  <p><strong>Approvata da:</strong> {$ApprovedBy}</p>
 {/if}
 <p><strong>Numero riferimento:</strong> {$ReferenceNumber}</p>

--- a/lang/it_it/ReservationCreatedAdmin.tpl
+++ b/lang/it_it/ReservationCreatedAdmin.tpl
@@ -2,7 +2,7 @@
 <p>Dettagli della prenotazione:</p>
 <p>
     <strong>Utente:</strong> {$UserName}<br />
-    {if preg_match("/[a-zA-Z]+/",$CreatedBy)}
+    {if !empty($CreatedBy)}
         <strong>Creata da:</strong> {$CreatedBy}<br />
     {/if}
     <strong>Inizio:</strong> {formatdate date=$StartDate key=reservation_email}<br />

--- a/lang/it_it/ReservationDeleted.tpl
+++ b/lang/it_it/ReservationDeleted.tpl
@@ -39,7 +39,7 @@
         {/foreach}
 		</p>
 {/if}
-{if preg_match("/[a-zA-Z]+/",$CreatedBy)}
+{if !empty($CreatedBy)}
     <p>
 		    <strong>Cancellata da:</strong> {$CreatedBy}
 		    <br />

--- a/lang/it_it/ReservationInvitation.tpl
+++ b/lang/it_it/ReservationInvitation.tpl
@@ -4,7 +4,7 @@
 {else}
     <p>{$UserName} l&apos;ha invitata ad una prenotazione.</p>
 {/if}
-{if preg_match("/[a-zA-Z]+/",$DeleteReason)}
+{if !empty($DeleteReason)}
     <p><strong>Motivazione:</strong> <em>{$DeleteReason|nl2br}</em></p>
 {/if}
 <p>Dettagli della prenotazione:</p>


### PR DESCRIPTION
Replace `preg_match("/[a-zA-Z]+/", $var)` with `!empty($var)` in Italian email templates for checking variable presence.

The original regex pattern only matched alphabetic characters, which would fail for numeric usernames or mixed content. The `!empty()` check is more appropriate, performant, and correctly expresses the intent of verifying that a variable has content before displaying it.