### PR TITLE
fix(htaccess): Prevent redirect loop for /Web path without trailing slash

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,7 +5,7 @@ RewriteEngine On
 #RewriteCond %{HTTPS} off
 #RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
-RewriteCond %{REQUEST_URI} !^/Web/
+RewriteCond %{REQUEST_URI} !^/Web(/|$)
 RewriteRule ^(.*)$ /Web/$1 [R]
 
 #Header Set Access-Control-Allow-Origin "*"


### PR DESCRIPTION
Update RewriteCond pattern from `!^/Web/` to `!^/Web(/|$)` to properly exclude both `/Web/` and `/Web` from rewrite rules.

The previous pattern only matched `/Web/` (with trailing slash), causing requests to `/Web` (without trailing slash) to be incorrectly rewritten to `/Web/Web`, resulting in a redirect loop.

The new pattern uses `(/|$)` to match either:
- `/Web/` followed by more path segments
- `/Web` at the end of the URI

This ensures the rewrite rule correctly redirects all non-Web paths to the Web directory while avoiding the redirect loop.