### PR TITLE
Added Dev Container configuration to simplify local setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+FROM mcr.microsoft.com/devcontainers/php:1-8.2-bookworm
+# All necessary PHP dependnencies
+RUN apt update && \
+    apt install -y \
+        libpng-dev libjpeg-dev libfreetype6-dev \
+        libldap2-dev \
+        build-essential autoconf pkg-config && \
+    docker-php-ext-configure gd --with-freetype --with-jpeg && \
+    docker-php-ext-install gd mysqli ldap && \
+    rm -rf /var/lib/apt/lists/*
+# Enable Xdebug
+RUN XDEBUG_INI="/usr/local/etc/php/conf.d/xdebug.ini" && \
+    mkdir -p "$(dirname "$XDEBUG_INI")" && \
+    if ! php -m | grep -qi xdebug; then \
+        docker-php-ext-install xdebug; \
+    fi && \
+    if [ ! -f "$XDEBUG_INI" ]; then \
+        echo "xdebug.mode=off" > "$XDEBUG_INI" && \
+        echo "xdebug.start_with_request=no" >> "$XDEBUG_INI" && \
+        echo "xdebug.client_host=host.docker.internal" >> "$XDEBUG_INI" && \
+        echo "xdebug.client_port=9003" >> "$XDEBUG_INI"; \
+    else \
+        sed -i '/^zend_extension/d' "$XDEBUG_INI"; \
+        grep -q "xdebug.mode" "$XDEBUG_INI" || echo "xdebug.mode=off" >> "$XDEBUG_INI"; \
+        grep -q "xdebug.start_with_request" "$XDEBUG_INI" || echo "xdebug.start_with_request=no" >> "$XDEBUG_INI"; \
+        grep -q "xdebug.client_host" "$XDEBUG_INI" || echo "xdebug.client_host=host.docker.internal" >> "$XDEBUG_INI"; \
+        grep -q "xdebug.client_port" "$XDEBUG_INI" || echo "xdebug.client_port=9003" >> "$XDEBUG_INI"; \
+    fi
+
+# Optional: confirm extensions are active for debugging
+RUN php -m | grep -E 'mysqli|ldap|gd'

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	"name": "LibreBooking Dev",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"features": {
+		"ghcr.io/devcontainers/features/git-lfs:1": {}
+	},
+	"postCreateCommand": "composer install",
+	"postStartCommand": "bash .devcontainer/ldap_setup.sh",
+	"forwardPorts": [
+		8080
+	],
+	"remoteUser": "root"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,6 @@
+# Setup LDAP
+mkdir -p plugins/Authentication/Ldap plugins/Authentication/ActiveDirectory
+echo "<?php return ['enabled' => false];" > plugins/Authentication/Ldap/Ldap.config.php
+echo "<?php return ['enabled' => false];" > plugins/Authentication/ActiveDirectory/ActiveDirectory.config.php
+# Copy default config to be usable right away for testing
+cp config/config.dist.php config/config.php


### PR DESCRIPTION
Struggling to get the project to work on my system which lacks various dependencies like PHP 8.2 or Ant, I've decided to go ahead and try dev-containers (asdf was too much of a pain) and after much tinkering was pleased with the result.

I've created a devcontainer.json that enables you to spin up a container and develop there. All PHP dependencies including XDEBUG are set up in a Dockerfile that is being read by devcontainer.json.

I've also added postInstall commands like:
- composer install
- cp config.dist.php config.php
- some LDAP setup so composer test doesn't complain

In conclusion i've tried to boil down everything you have to manually do before you can run testing. I'm also thinking about a way to easily populate the config.php from the command line, or even do the install from the terminal so people new to the project (like myself) wouldn't have to struggle so much.

BTW this is my first ever PR. New to contributing to open source so please any feedback is welcome.