### PR TITLE
Fixed confusing unit test for a default configuration value

### DIFF
--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -62,7 +62,7 @@ class ConfigTest extends TestBase
             $this->assertEquals(30, $timeout, "Invalid integer should be replaced with default");
 
             $loggingLevel = $config->GetKey(ConfigKeys::LOGGING_LEVEL);
-            $this->assertEquals('none', $loggingLevel, "Invalid choice should be replaced with default");
+            $this->assertEquals('error', $loggingLevel, "Invalid choice should be replaced with default");
 
             $minimumLetters = $config->GetKey(ConfigKeys::PASSWORD_MINIMUM_LETTERS, new IntConverter());
             $this->assertEquals(6, $minimumLetters, "Type conversion should return integer");


### PR DESCRIPTION
Unit tests fails with the following output:

 description "Invalid choice should be replaced with default"

```
1) ConfigTest::testMainConfigValidation
Invalid choice should be replaced with default
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'none'
+'error'
```

However ConfigKeys.LOGGING_LEVEL default value seems to be 'error', not 'none' (which should be None either way).

```
    public const LOGGING_LEVEL = [
        'key' => 'logging.level',
        'type' => 'string',
        'default' => 'error',
        'choices' => [
            'none' => 'None',
            'error' => 'error',
            'debug' => 'debug',
        ],
```

So unless im misreading the test case (it is admittedly confusing and i'd appreciate some context) the expected value _should_ be 'error', not 'none'. Therefore i've changed it to 'error' (the default value) and the test passed. Hope I didn't mis-understanding the purpose of the test.