### PR TITLE
fix(image-upload): use correct directory for uploading image

### DIFF
--- a/lib/Application/Admin/ImageUploadDirectory.php
+++ b/lib/Application/Admin/ImageUploadDirectory.php
@@ -4,7 +4,7 @@ class ImageUploadDirectory
 {
     public function GetDirectory()
     {
-        $uploadDir = Configuration::Instance()->GetKey(ConfigKeys::UPLOAD_IMAGE_URL);
+        $uploadDir = Configuration::Instance()->GetKey(ConfigKeys::UPLOAD_IMAGE_DIRECTORY);
         if (is_dir($uploadDir)) {
             return $uploadDir;
         }


### PR DESCRIPTION
commit b81ba13acbae05469c46ab508ca5d1d3ed3f36d8 incorrectly changed 'IMAGE_UPLOAD_DIRECTORY' to 'UPLOAD_IMAGE_URL' but should have changed to 'UPLOAD_IMAGE_DIRECTORY'