### PR TITLE
fix(schedule): ensure flatpickr respects week start when using Starts Today

### DIFF
--- a/tpl/Controls/DatePickerSetup.tpl
+++ b/tpl/Controls/DatePickerSetup.tpl
@@ -24,7 +24,9 @@
                 shorthand: {$MonthNamesShort},
                 longhand: {$MonthNames}
             },
-            firstDayOfWeek: {$FirstDay|default:0}
+            {if $FirstDay >= 0 && $FirstDay <= 6}
+                firstDayOfWeek: {$FirstDay},
+            {/if}
         },
         showMonths: {$NumberOfMonths|default:1},
         weekNumbers: {if $ShowWeekNumbers}true{else}false{/if},


### PR DESCRIPTION
This PR fixes an issue where the configured week start day ($FirstDay) was not being applied to flatpickr when rendering a schedule that uses the “Starts Today” option. Because the firstDayOfWeek setting was omitted, flatpickr defaulted to Monday, causing inconsistencies between the system configuration and the displayed calendar.

The update now conditionally outputs the firstDayOfWeek value only when $FirstDay is within the valid 0–6 range, ensuring that flatpickr correctly reflects the system’s configured week start.