### PR TITLE
test: allow unit tests to be run without setup

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -87,19 +87,6 @@ jobs:
       - name: Create main config.php for unit tests
         run: cp config/config.dist.php config/config.php
 
-      - name: Create plugin config.php for unit tests
-        run: |
-          for source in $(find plugins -type f -name "*dist*"); do
-            target=$(echo "${source}" | sed -e "s/.dist//")
-            if ! [ -f "config/$(basename ${target})" ]; then
-              cp --no-clobber "${source}" "config/$(basename ${target})"
-              sudo chown www-data:www-data "config/$(basename ${target})"
-            fi
-            if ! [ -f ${target} ]; then
-              ln -s "$(pwd)/config/$(basename ${target})" "${target}"
-            fi
-          done
-
       - name: Unit Tests
         run: |
           set -o pipefail

--- a/plugins/Authentication/ActiveDirectory/ActiveDirectoryOptions.php
+++ b/plugins/Authentication/ActiveDirectory/ActiveDirectoryOptions.php
@@ -8,10 +8,15 @@ class ActiveDirectoryOptions
 
     public function __construct()
     {
-        require_once(dirname(__FILE__) . '/ActiveDirectory.config.php');
+        $configPath = dirname(__FILE__) . '/ActiveDirectory.config.php';
+        if (!file_exists($configPath) && getenv('APP_ENV') === 'testing') {
+            $configPath = dirname(__FILE__) . '/ActiveDirectory.config.dist.php';
+        }
+
+        require_once($configPath);
 
         Configuration::Instance()->Register(
-            dirname(__FILE__) . '/ActiveDirectory.config.php',
+            $configPath,
             '',
             ActiveDirectoryConfigKeys::CONFIG_ID,
             false,

--- a/plugins/Authentication/Ldap/LdapOptions.php
+++ b/plugins/Authentication/Ldap/LdapOptions.php
@@ -8,10 +8,15 @@ class LdapOptions
 
     public function __construct()
     {
-        require_once(dirname(__FILE__) . '/Ldap.config.php');
+        $configPath = dirname(__FILE__) . '/Ldap.config.php';
+        if (!file_exists($configPath) && getenv('APP_ENV') === 'testing') {
+            $configPath = dirname(__FILE__) . '/Ldap.config.dist.php';
+        }
+
+        require_once($configPath);
 
         Configuration::Instance()->Register(
-            dirname(__FILE__) . '/Ldap.config.php',
+            $configPath,
             '',
             LdapConfigKeys::CONFIG_ID,
             false,


### PR DESCRIPTION
Currently the unit tests don't work without some prework of copying config files around. Fix it so that is no longer required.