### PR TITLE
feat(resource-display.php): add allow-reservations config for tablet …

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -385,6 +385,9 @@ LB_RESOURCE_CONTACT_IS_USER=false
 # Tablet View Options
 ##########################################
 
+# Allows to make reservations in the tablet view (true/false)
+LB_TABLET_VIEW_ALLOW_RESERVATIONS=true
+
 # Allow guest users to make reservations in tablet view (true/false)
 LB_TABLET_VIEW_ALLOW_GUEST_RESERVATIONS=false
 

--- a/Pages/ResourceDisplayPage.php
+++ b/Pages/ResourceDisplayPage.php
@@ -167,6 +167,7 @@ class ResourceDisplayPage extends ActionPage implements IResourceDisplayPage, IR
             new TermsOfServiceRepository()
         );
 
+        $this->Set('AllowReservations', Configuration::Instance()->GetKey(ConfigKeys::TABLET_VIEW_ALLOW_RESERVATIONS, new BooleanConverter()));
         $this->Set('AllowAutocomplete', Configuration::Instance()->GetKey(ConfigKeys::TABLET_VIEW_AUTO_SUGGEST_EMAILS, new BooleanConverter()));
         $this->Set('ShouldLogout', false);
     }
@@ -243,7 +244,7 @@ class ResourceDisplayPage extends ActionPage implements IResourceDisplayPage, IR
         $parsedDate = $this->GetQuerystring(QueryStringKeys::START_DATE);
         if (!empty($parsedDate)) {
             $startDate = Date::Parse($parsedDate, $userTimezone);
-        }else{
+        } else {
             $startDate = Date::Now()->ToTimezone($userTimezone);
         }
         return $startDate;
@@ -290,7 +291,8 @@ class ResourceDisplayPage extends ActionPage implements IResourceDisplayPage, IR
         if ($futureDays == 0) {
             $futureDays = 1;
         }
-        $this->Set('MaxFutureDate', Date::Now()->AddDays($futureDays-1));
+        $this->Set('MinDate', Date::Now());
+        $this->Set('MaxFutureDate', Date::Now()->AddDays($futureDays - 1));
         $this->Display('ResourceDisplay/resource-display-shell.tpl');
     }
 

--- a/Presenters/ResourceDisplayPresenter.php
+++ b/Presenters/ResourceDisplayPresenter.php
@@ -234,7 +234,7 @@ class ResourceDisplayPresenter extends ActionPresenter
 
     public function Reserve()
     {
-        if (!Configuration::Instance()->GetKey(ConfigKeys::TABLET_VIEW_ALLOW_RESERVATIONS)) {
+        if (!Configuration::Instance()->GetKey(ConfigKeys::TABLET_VIEW_ALLOW_RESERVATIONS, new BooleanConverter())) {
             $resultCollector = new ReservationResultCollector();
             $resultCollector->SetSaveSuccessfulMessage(false);
             $resultCollector->SetErrors(['Reservations are disabled in tablet view']);

--- a/Presenters/ResourceDisplayPresenter.php
+++ b/Presenters/ResourceDisplayPresenter.php
@@ -163,9 +163,9 @@ class ResourceDisplayPresenter extends ActionPresenter
 
         $layout = $this->scheduleRepository->GetLayout($scheduleId, new ScheduleLayoutFactory($timezone));
         $slots = $layout->GetLayout($now, true);
-        if(!empty($startDate)){
+        if (!empty($startDate)) {
             $reservationDate = $startDate;
-        }else{
+        } else {
             $reservationDate = $now;
             if ($slots[count($slots) - 1]->EndDate()->LessThanOrEqual($now)) {
                 $now = $now->AddDays(1)->GetDate();
@@ -234,6 +234,15 @@ class ResourceDisplayPresenter extends ActionPresenter
 
     public function Reserve()
     {
+        if (!Configuration::Instance()->GetKey(ConfigKeys::TABLET_VIEW_ALLOW_RESERVATIONS)) {
+            $resultCollector = new ReservationResultCollector();
+            $resultCollector->SetSaveSuccessfulMessage(false);
+            $resultCollector->SetErrors(['Reservations are disabled in tablet view']);
+
+            $this->page->SetReservationSaveResults(false, $resultCollector);
+            return;
+        }
+
         $timezone = $this->page->GetTimezone();
         $resourceId = $this->page->GetResourceId();
         $email = $this->page->GetEmail();
@@ -245,7 +254,7 @@ class ResourceDisplayPresenter extends ActionPresenter
         if ($maxFutureDays == 0) {
             $maxFutureDays = 1;
         }
-        $maxDate = Date::Now()->ToTimezone($timezone)->AddDays($maxFutureDays+1)->GetDate();
+        $maxDate = Date::Now()->ToTimezone($timezone)->AddDays($maxFutureDays + 1)->GetDate();
 
         $resultCollector = new ReservationResultCollector();
 
@@ -253,7 +262,7 @@ class ResourceDisplayPresenter extends ActionPresenter
             $resultCollector->SetSaveSuccessfulMessage(false);
             $resultCollector->SetErrors(["Unauthorized"]);
             $success = false;
-        }else{
+        } else {
 
             $userSession = $this->guestUserService->CreateOrLoad($email);
             $resource = $this->resourceRepository->LoadById($resourceId);
@@ -380,23 +389,17 @@ class ReservationResultCollector implements IReservationSaveResultsView
     /**
      * @param array|string[] $messages
      */
-    public function SetRetryMessages($messages)
-    {
-    }
+    public function SetRetryMessages($messages) {}
 
     /**
      * @param bool $canBeRetried
      */
-    public function SetCanBeRetried($canBeRetried)
-    {
-    }
+    public function SetCanBeRetried($canBeRetried) {}
 
     /**
      * @param ReservationRetryParameter[] $retryParameters
      */
-    public function SetRetryParameters($retryParameters)
-    {
-    }
+    public function SetRetryParameters($retryParameters) {}
 
     /**
      * @return ReservationRetryParameter[]

--- a/Web/scripts/resourceDisplay.js
+++ b/Web/scripts/resourceDisplay.js
@@ -79,11 +79,9 @@ function ResourceDisplay(opts) {
 
         elements.placeholder.on('click', '#reservePopup', function (e) {
             pauseRefresh();
-            //showPopup();
         });
 
         elements.placeholder.on('click', '#reserveCancel', function (e) {
-            //hidePopup();
             resumeRefresh();
             refreshResource();
         });
@@ -101,7 +99,6 @@ function ResourceDisplay(opts) {
                 var validationErrors = $('#validationErrors');
                 if (data.success) {
                     validationErrors.find('ul').empty().addClass('d-none');
-                    //hidePopup();
                     resumeRefresh();
                     refreshResource();
                     $('#reservation-box').modal('hide');
@@ -147,32 +144,15 @@ function ResourceDisplay(opts) {
             $(this).removeClass('hilite');
         });
 
-        elements.startDate.on('change', function () {
+        elements.rawStartDate.on('change', function () {
             showWait();
             refreshResource(hideWait);
         });
 
         var beginIndex = 0;
 
-        function showPopup() {
-            /*$('#reservation-box-wrapper').show();
-            var reservationBox = $('#reservation-box');
-            reservationBox.show();
-            var offsetFromTop = ($('body').height() - reservationBox.height()) / 2;
-            reservationBox.css(
-                { top: offsetFromTop + 'px' }
-            );
-
-            $('#emailAddress').focus();*/
-        }
-
         function pauseRefresh() {
             _refreshEnabled = false;
-        }
-
-        function hidePopup() {
-            // $('#reservation-box').hide();
-            // $('#reservation-box-wrapper').hide();
         }
 
         function resumeRefresh() {
@@ -196,8 +176,6 @@ function ResourceDisplay(opts) {
                     return;
                 }
                 elements.placeholder.html(data);
-
-                //$('#resource-display').height($('body').height());
 
                 var formCheckin = $('#formCheckin');
                 formCheckin.unbind('submit');

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -440,6 +440,9 @@ return [
         ##########################################
 
         'tablet.view' => [
+            # Allow users to make reservations in the tablet view (true/false)
+            'allow.reservations' => true,
+
             # Allow guest users to make reservations in tablet view (true/false)
             'allow.guest.reservations' => false,
 

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -962,6 +962,14 @@ class ConfigKeys
     ];
 
     // Tablet View Options
+    public const TABLET_VIEW_ALLOW_RESERVATIONS = [
+        'key' => 'tablet.view.allow.reservations',
+        'type' => 'boolean',
+        'default' => true,
+        'label' => 'Allows reservations',
+        'description' => 'Allows users to make reservations in the tablet view',
+        'section' => 'tablet.view'
+    ];
 
     # previously TABLET_VIEW_ALLOW_GUESTS
     public const TABLET_VIEW_ALLOW_GUEST_RESERVATIONS = [

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -54,6 +54,7 @@ class TestBase extends TestCase
         $this->fakeEmailService = new FakeEmailService();
         $this->fakeConfig = new FakeConfig();
         $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_TIMEZONE, 'America/Chicago');
+        $this->fakeConfig->SetKey(ConfigKeys::TABLET_VIEW_ALLOW_RESERVATIONS, true);
 
         $this->fakeResources = new FakeResources();
         $this->fakeUser = $this->fakeServer->UserSession;
@@ -88,7 +89,7 @@ class TestBase extends TestCase
         if (ini_set('error_log', $tempLogFile) === false) {
             throw new \RuntimeException("Failed to set error_log to temporary file: $tempLogFile");
         }
-        
+
         try {
             // Execute the test function
             $testFunction();

--- a/tpl/ResourceDisplay/resource-display-resource.tpl
+++ b/tpl/ResourceDisplay/resource-display-resource.tpl
@@ -1,5 +1,5 @@
 {function name=displayReservation}
-    <div class="card shadow-sm mb-3">
+    <div class="card shadow-sm">
         <div class="card-body p-2">
             <div class="d-flex justify-content-between align-items-center mb-1">
                 <small class="text-muted">
@@ -80,7 +80,7 @@
                         {foreach from=$UpcomingReservations item=r name=upcoming}
                             {call name=displayReservation reservation=$r}
                             {if !$smarty.foreach.upcoming.last}
-                                <hr class="my-2 text-muted">
+                                <hr class="my-3 text-muted">
                             {/if}
                         {/foreach}
                     {else}
@@ -89,167 +89,168 @@
                         </div>
                     {/if}
                 </div>
-                <div class="col-12 mt-3">
-                    <div class="d-grid gap-2">
-                        <button type="button" class="btn btn-primary" data-bs-toggle="modal"
-                            data-bs-target="#reservation-box">
-                            <i class="bi bi-plus-lg me-1"></i>{translate key=Reserve}
-                        </button>
-                    </div>
-                    <!-- Modal -->
-                    <div class="modal fade" id="reservation-box" tabindex="-1">
-                        <div class="modal-dialog modal-fullscreen">
-                            <div class="modal-content">
-                                <div class="modal-header">
-                                    <h1 class="modal-title">{translate key=Reserve}</h1>
-                                    <button type="button" class="btn-close" data-bs-dismiss="modal"
-                                        aria-label="Close"></button>
-                                </div>
-                                <div class="modal-body">
-                                    <form role="form" method="post" id="formReserve"
-                                        action="{$smarty.server.SCRIPT_NAME}?action=reserve">
-                                        <div class="row mt-3">
-                                            <div class="col-12">
-                                                <div id="validationErrors"
-                                                    class="validationSummary alert alert-danger d-none">
-                                                    <ul></ul>
-                                                </div>
-                                                <div>
-                                                    <table class="reservations my-5">
-                                                        <thead>
-                                                            <tr>
-                                                                {foreach from=$DailyLayout->GetPeriods($ReservationDate, true) item=period}
-                                                                    <td class="reslabel" colspan="{$period->Span()}">
-                                                                        {$period->Label($ReservationDate)}
-                                                                    </td>
-                                                                {/foreach}
-                                                            </tr>
-                                                        </thead>
-                                                        <tbody>
-                                                            <tr>
-                                                                {assign var=slots value=$DailyLayout->GetLayout($ReservationDate, $ResourceId)}
-                                                                {foreach from=$slots item=slot}
-                                                                    {assign var="referenceNumber" value=""}
-                                                                    {if $slot->IsReserved()}
-                                                                        {assign var="class" value="reserved"}
-                                                                        {assign var="referenceNumber" value=$slot->Reservation()->ReferenceNumber}
-                                                                    {elseif $slot->IsReservable()}
-                                                                        {assign var="class" value="reservable"}
-                                                                        {if $slot->IsPastDate(Date::Now())}
-                                                                            {assign var="class" value="pasttime"}
+                {if $AllowReservations}
+                    <div class="col-12 mt-3">
+                        <div class="d-grid gap-2">
+                            <button type="button" class="btn btn-primary" data-bs-toggle="modal"
+                                data-bs-target="#reservation-box">
+                                <i class="bi bi-plus-lg me-1"></i>{translate key=Reserve}
+                            </button>
+                        </div>
+                        <!-- Modal -->
+                        <div class="modal fade" id="reservation-box" tabindex="-1">
+                            <div class="modal-dialog modal-fullscreen">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h1 class="modal-title">{translate key=Reserve}</h1>
+                                        <button type="button" class="btn-close" data-bs-dismiss="modal"
+                                            aria-label="Close"></button>
+                                    </div>
+                                    <div class="modal-body">
+                                        <form role="form" method="post" id="formReserve"
+                                            action="{$smarty.server.SCRIPT_NAME}?action=reserve">
+                                            <div class="row mt-3">
+                                                <div class="col-12">
+                                                    <div id="validationErrors"
+                                                        class="validationSummary alert alert-danger d-none">
+                                                        <ul></ul>
+                                                    </div>
+                                                    <div>
+                                                        <table class="reservations my-5">
+                                                            <thead>
+                                                                <tr>
+                                                                    {foreach from=$DailyLayout->GetPeriods($ReservationDate, true) item=period}
+                                                                        <td class="reslabel" colspan="{$period->Span()}">
+                                                                            {$period->Label($ReservationDate)}
+                                                                        </td>
+                                                                    {/foreach}
+                                                                </tr>
+                                                            </thead>
+                                                            <tbody>
+                                                                <tr>
+                                                                    {assign var=slots value=$DailyLayout->GetLayout($ReservationDate, $ResourceId)}
+                                                                    {foreach from=$slots item=slot}
+                                                                        {assign var="referenceNumber" value=""}
+                                                                        {if $slot->IsReserved()}
+                                                                            {assign var="class" value="reserved"}
+                                                                            {assign var="referenceNumber" value=$slot->Reservation()->ReferenceNumber}
+                                                                        {elseif $slot->IsReservable()}
+                                                                            {assign var="class" value="reservable"}
+                                                                            {if $slot->IsPastDate(Date::Now())}
+                                                                                {assign var="class" value="pasttime"}
+                                                                            {/if}
+                                                                        {else}
+                                                                            {assign var="class" value="unreservable"}
                                                                         {/if}
-                                                                    {else}
-                                                                        {assign var="class" value="unreservable"}
-                                                                    {/if}
-                                                                    {if $slot->HasCustomColor()}
-                                                                        {assign var=color value='style="background-color:'|cat:$slot->Color()|cat:';color:'|cat:$slot->TextColor()|cat:';"'}
-                                                                    {/if}
-                                                                    <td colspan="{$slot->PeriodSpan()}" {$color}
-                                                                        data-begin="{$slot->Begin()}"
-                                                                        data-end="{$slot->End()}" class="slot {$class}"
-                                                                        data-refnum="{$referenceNumber}">
-                                                                        {$slot->Label($SlotLabelFactory)|escape|default:'&nbsp;'}
-                                                                    </td>
-                                                                {/foreach}
-                                                            </tr>
-                                                        </tbody>
-                                                    </table>
-                                                </div>
+                                                                        {if $slot->HasCustomColor()}
+                                                                            {assign var=color value='style="background-color:'|cat:$slot->Color()|cat:';color:'|cat:$slot->TextColor()|cat:';"'}
+                                                                        {/if}
+                                                                        <td colspan="{$slot->PeriodSpan()}" {$color}
+                                                                            data-begin="{$slot->Begin()}"
+                                                                            data-end="{$slot->End()}" class="slot {$class}"
+                                                                            data-refnum="{$referenceNumber}">
+                                                                            {$slot->Label($SlotLabelFactory)|escape|default:'&nbsp;'}
+                                                                        </td>
+                                                                    {/foreach}
+                                                                </tr>
+                                                            </tbody>
+                                                        </table>
+                                                    </div>
 
-                                                <div class="input-group input-group-lg">
-                                                    <span class="input-group-text" id="email-addon"><span
-                                                            class="bi bi-envelope"></span></span>
-                                                    <label for="emailAddress"
-                                                        class="visually-hidden">{translate key=Email}</label>
-                                                    <input id="emailAddress" type="email" class="form-control"
-                                                        placeholder="{translate key=Email}"
-                                                        aria-describedby="email-addon" required="required"
-                                                        {formname key=EMAIL} />
+                                                    <div class="input-group input-group-lg">
+                                                        <span class="input-group-text" id="email-addon"><span
+                                                                class="bi bi-envelope"></span></span>
+                                                        <label for="emailAddress"
+                                                            class="visually-hidden">{translate key=Email}</label>
+                                                        <input id="emailAddress" type="email" class="form-control"
+                                                            placeholder="{translate key=Email}"
+                                                            aria-describedby="email-addon" required="required"
+                                                            {formname key=EMAIL} />
+                                                    </div>
                                                 </div>
                                             </div>
-                                        </div>
-                                        <div class="row mt-3">
-                                            <div class="col-6">
-                                                <div class="input-group input-group-lg has-feedback">
-                                                    <span class="input-group-text" id="starttime-addon">
-                                                        <span class="bi bi-clock"></span>
-                                                    </span>
-                                                    <select title="Begin" class="form-select"
-                                                        aria-describedby="starttime-addon" id="beginPeriod"
-                                                        {formname key=BEGIN_PERIOD}>
-                                                        {foreach from=$slots item=slot}
-                                                            {if $slot->IsReservable() && !$slot->IsPastDate($ReservationDate)}
-                                                                <option value="{$slot->Begin()}">
-                                                                    {$slot->Begin()->Format($TimeFormat)}</option>
-                                                            {/if}
+                                            <div class="row mt-3">
+                                                <div class="col-6">
+                                                    <div class="input-group input-group-lg has-feedback">
+                                                        <span class="input-group-text" id="starttime-addon">
+                                                            <span class="bi bi-clock"></span>
+                                                        </span>
+                                                        <select title="Begin" class="form-select"
+                                                            aria-describedby="starttime-addon" id="beginPeriod"
+                                                            {formname key=BEGIN_PERIOD}>
+                                                            {foreach from=$slots item=slot}
+                                                                {if $slot->IsReservable() && !$slot->IsPastDate($ReservationDate)}
+                                                                    <option value="{$slot->Begin()}">
+                                                                        {$slot->Begin()->Format($TimeFormat)}</option>
+                                                                {/if}
+                                                            {/foreach}
+                                                        </select>
+                                                    </div>
+                                                </div>
+                                                <div class="col-6">
+                                                    <div class="input-group input-group-lg">
+                                                        <span class="input-group-text" id="endtime-addon"><span
+                                                                class="bi bi-clock"></span></span>
+                                                        <select title="End" class="form-select input-lg"
+                                                            aria-describedby="endtime-addon" id="endPeriod"
+                                                            {formname key=END_PERIOD}>
+                                                            {foreach from=$slots item=slot}
+                                                                {if $slot->IsReservable() && !$slot->IsPastDate($ReservationDate)}
+                                                                    <option value="{$slot->End()}">
+                                                                        {$slot->End()->Format($TimeFormat)}
+                                                                    </option>
+                                                                {/if}
+                                                            {/foreach}
+                                                        </select>
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                            {if $Terms != null}
+                                                <div class="mt-3" id="termsAndConditions">
+                                                    <div class="form-check">
+                                                        <input class="form-check-input" type="checkbox"
+                                                            id="termsAndConditionsAcknowledgement"
+                                                            {formname key=TOS_ACKNOWLEDGEMENT}
+                                                            {if $TermsAccepted}checked="checked" {/if} />
+                                                        <label class="form-check-label"
+                                                            for="termsAndConditionsAcknowledgement">{translate key=IAccept}</label>
+                                                        <a href="{$Terms->DisplayUrl()}" class="link-primary"
+                                                            target="_blank">{translate key=TheTermsOfService}</a>
+                                                    </div>
+                                                </div>
+                                            {/if}
+
+                                            {if $Attributes|default:array()|count > 0}
+                                                <div class="mt-3">
+                                                    <div class="customAttributes row gy-3">
+                                                        {foreach from=$Attributes item=attribute name=attributeEach}
+                                                            <div class="customAttribute col-6">
+                                                                {control type="AttributeControl" attribute=$attribute}
+                                                            </div>
                                                         {/foreach}
-                                                    </select>
+                                                    </div>
                                                 </div>
-                                            </div>
-                                            <div class="col-6">
-                                                <div class="input-group input-group-lg">
-                                                    <span class="input-group-text" id="endtime-addon"><span
-                                                            class="bi bi-clock"></span></span>
-                                                    <select title="End" class="form-select input-lg"
-                                                        aria-describedby="endtime-addon" id="endPeriod"
-                                                        {formname key=END_PERIOD}>
-                                                        {foreach from=$slots item=slot}
-                                                            {if $slot->IsReservable() && !$slot->IsPastDate($ReservationDate)}
-                                                                <option value="{$slot->End()}">
-                                                                    {$slot->End()->Format($TimeFormat)}
-                                                                </option>
-                                                            {/if}
-                                                        {/foreach}
-                                                    </select>
-                                                </div>
-                                            </div>
-                                        </div>
+                                            {/if}
 
-                                        {if $Terms != null}
-                                            <div class="mt-3" id="termsAndConditions">
-                                                <div class="form-check">
-                                                    <input class="form-check-input" type="checkbox"
-                                                        id="termsAndConditionsAcknowledgement"
-                                                        {formname key=TOS_ACKNOWLEDGEMENT}
-                                                        {if $TermsAccepted}checked="checked" {/if} />
-                                                    <label class="form-check-label"
-                                                        for="termsAndConditionsAcknowledgement">{translate key=IAccept}</label>
-                                                    <a href="{$Terms->DisplayUrl()}" class="link-primary"
-                                                        target="_blank">{translate key=TheTermsOfService}</a>
-                                                </div>
+                                            <div class="d-grid gap-2 mt-3">
+                                                <input type="submit" class="action-reserve btn btn-primary"
+                                                    value="{translate key=Reserve}" />
+                                                <a href="#" class="action-cancel btn btn-outline-secondary"
+                                                    data-bs-dismiss="modal" id="reserveCancel">{translate key=Cancel}</a>
                                             </div>
-                                        {/if}
 
-                                        {if $Attributes|default:array()|count > 0}
-                                            <div class="mt-3">
-                                                <div class="customAttributes row gy-3">
-                                                    {foreach from=$Attributes item=attribute name=attributeEach}
-                                                        <div class="customAttribute col-6">
-                                                            {control type="AttributeControl" attribute=$attribute}
-                                                        </div>
-                                                    {/foreach}
-                                                </div>
-                                            </div>
-                                        {/if}
-
-                                        <div class="d-grid gap-2 mt-3">
-                                            <input type="submit" class="action-reserve btn btn-primary"
-                                                value="{translate key=Reserve}" />
-                                            <a href="#" class="action-cancel btn btn-outline-secondary"
-                                                data-bs-dismiss="modal" id="reserveCancel">{translate key=Cancel}</a>
-                                        </div>
-
-                                        <input type="hidden" {formname key=RESOURCE_ID} value="{$ResourceId}" />
-                                        <input type="hidden" {formname key=SCHEDULE_ID} value="{$ScheduleId}" />
-                                        <input type="hidden" {formname key=TIMEZONE} value="{$Timezone}" />
-                                        <input type="hidden" {formname key=BEGIN_DATE} value="{$ReservationDate}" />
-                                    </form>
+                                            <input type="hidden" {formname key=RESOURCE_ID} value="{$ResourceId}" />
+                                            <input type="hidden" {formname key=SCHEDULE_ID} value="{$ScheduleId}" />
+                                            <input type="hidden" {formname key=TIMEZONE} value="{$Timezone}" />
+                                            <input type="hidden" {formname key=BEGIN_DATE} value="{$ReservationDate}" />
+                                        </form>
+                                    </div>
                                 </div>
                             </div>
                         </div>
                     </div>
-
-                </div>
+                {/if}
             </div>
         </div>
     </div>

--- a/tpl/ResourceDisplay/resource-display-shell.tpl
+++ b/tpl/ResourceDisplay/resource-display-shell.tpl
@@ -15,7 +15,7 @@
         <div id="placeholder"></div>
 </div>
 
-<div class="modal" id="waitModal" tabindex="-1" role="dialog" aria-labelledby="waitModalLabel" data-bs-backdrop="static"
+<div class="modal" id="wait-modal" tabindex="-1" role="dialog" aria-labelledby="waitModalLabel" data-bs-backdrop="static"
         aria-hidden="true">
         {include file="wait-box.tpl" translateKey='Working'}
 </div>
@@ -25,7 +25,7 @@
 {jsfile src="ajax-helpers.js"}
 {jsfile src="autocomplete.js"}
 
-{control type="DatePickerSetupControl" ControlId="availabilityStartDate" AltId="formattedBeginDate" MaxDate=$MaxFutureDate}
+{control type="DatePickerSetupControl" ControlId="availabilityStartDate" AltId="formattedBeginDate" MaxDate=$MaxFutureDate MinDate=$MinDate DefaultDate=$MinDate}
 
 <script type="text/javascript">
         function getResourceId() {


### PR DESCRIPTION
…view

Introduces a new configuration option 'tablet.view.allow.reservations' to control whether reservations can be made from the tablet view. Updates backend logic, templates, and tests to respect this setting, conditionally rendering reservation UI and blocking reservation actions when disabled. Removes unnecessary code related to previous UI handling due to the Bootstrap 5 update.