### PR TITLE
fix(schedule): correct date display and layout issues

### DIFF
--- a/Web/css/schedule.css
+++ b/Web/css/schedule.css
@@ -173,7 +173,6 @@ table.reservations.mobile div.reservable {
 .buffer {
   background-color: var(--unreservable);
   color: #fff;
-  /*border-color: #482423;*/
 }
 
 td.reservable,
@@ -209,7 +208,6 @@ td.dropped {
 }
 
 .reserved.hilite {
-  /*background-color: #59A8EF;*/
   opacity: 0.75;
 }
 
@@ -218,7 +216,6 @@ td.dropped {
 }
 
 .reserved.mine.hilite {
-  /*background-color: #3f4446;*/
   opacity: 0.75;
   color: #ffffff;
 }
@@ -229,7 +226,6 @@ td.dropped {
 
 .reserved.participating.hilite {
   opacity: 0.75;
-  /*background-color: #a979d1;*/
 }
 
 .past {
@@ -242,7 +238,6 @@ td.dropped {
 }
 
 .reserved.pending.hilite {
-  /*background-color: #ffc973;*/
   opacity: 0.75;
 }
 
@@ -278,11 +273,9 @@ td.dropped {
   vertical-align: top;
 }
 
-/*.schedule-dates {
-  text-align: center;
-  font-size: 1.5em;
-  padding-bottom: 10px;
-}*/
+.removeSpecificDate {
+  cursor: pointer;
+}
 
 .ui-datepicker {
   margin-left: auto;
@@ -316,7 +309,6 @@ div.legend {
   border: solid #555 1px;
   text-align: center;
   display: inline-block;
-  /*display: inline;*/
   margin: 0 2px;
   -webkit-border-radius: 2px;
   -moz-border-radius: 2px;
@@ -524,24 +516,4 @@ a.toggle-sidebar {
 
 #reservations {
   position: relative;
-}
-
-#reservationsToTop {
-  display: none;
-  position: fixed;
-  bottom: 20px;
-  right: 30px;
-  z-index: 999;
-  border: none;
-  background-color: #D5DED9;
-  -webkit-border-radius: 20px;
-  -moz-border-radius: 20px;
-  border-radius: 20px;
-  color: #585754;
-  cursor: pointer;
-  padding: 5px;
-}
-
-#reservationsToTop:hover {
-  color: #000;
 }

--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -1205,6 +1205,7 @@ function AddSpecificDate(dateObj) {
     const formattedDate = dateObj.getFullYear() + '-' +
         String(dateObj.getMonth() + 1).padStart(2, '0') + '-' +
         String(dateObj.getDate()).padStart(2, '0');
+    const stringDate = flatpickr.formatDate(dateObj, scheduleOpts.altFormatDate);
 
     if (scheduleSpecificDates.includes(formattedDate)) {
         return;
@@ -1214,7 +1215,7 @@ function AddSpecificDate(dateObj) {
     scheduleSpecificDates.push(formattedDate);
 
     const dateItem = `<div data-date="${formattedDate}">
-        ${formattedDate} <i class="bi bi-x-circle text-danger icon remove removeSpecificDate"></i>
+        ${stringDate} <i class="bi bi-x-circle text-danger icon remove removeSpecificDate"></i>
     </div>`;
 
     $('#individualDatesList').append(dateItem);

--- a/tpl/Schedule/schedule-reservations-grid.tpl
+++ b/tpl/Schedule/schedule-reservations-grid.tpl
@@ -6,7 +6,6 @@
 {assign var=TodaysDate value=Date::Now()}
 {* Is this a view page and guests are allowed to book *}
 {assign var=GuestViewBookable value=($LoadViewOnly && $AllowGuestBooking)}
-<br/>
 {foreach from=$BoundDates item=date}
     {assign var=ts value=$date->Timestamp()}
     {$periods.$ts = $DailyLayout->GetPeriods($date, true)}

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -149,7 +149,9 @@
                 <button class="btn btn-sm btn-primary mx-auto" href="#" id="individualDatesGo">
                     <i class="bi bi-search me-1"></i>{translate key=SpecificDates}
                 </button>
-                <div type="text" id="datepicker" class="collapse"></div>
+                <div class="d-flex justify-content-center align-items-center">
+                    <div id="datepicker" class="collapse"></div>
+                </div>
             </div>
 
 
@@ -410,7 +412,6 @@
 {/block}
 
 {jsfile src="js/html2canvas.min.js"}
-{jsfile src="js/moment.min.js"}
 {jsfile src="schedule.js"}
 {jsfile src="resourcePopup.js"}
 {jsfile src="js/tree.jquery.js"}
@@ -447,6 +448,7 @@
         fastReservationLoad: "{$FastReservationLoad}",
         resourceMaxConcurrentReservations,
         autoScrollToday: {$AutoScrollToday|@json_encode},
+        altFormatDate: "{Resources::GetInstance()->GetDateFormat('schedule_daily')}",
     };
 
     const resourceOrder = [];
@@ -479,7 +481,7 @@
 
 {control type="DatePickerSetupControl"
 ControlId='datepicker'
-HasTimepicker=false
+AltInput=false
 Inline=true
 DefaultDate=$FirstDate
 NumberOfMonths=$PopupMonths


### PR DESCRIPTION

<img width="1030" height="205" alt="image" src="https://github.com/user-attachments/assets/e178db5e-281c-47e6-97cc-3234cd58c3f6" />

- Replaced the specific dates display with a text string using the `schedule_daily` format.
- Removed unused CSS to improve maintainability.
- Added a CSS class to the date removal icon to indicate it is clickable.
- Prevented duplicate loading of `moment.js`.
- Removed an unnecessary line break that caused grid misalignment relative to the filter.