### PR TITLE
refactor(manage_blackouts): use dateHelper for timepickers

### DIFF
--- a/Web/scripts/admin/blackouts.js
+++ b/Web/scripts/admin/blackouts.js
@@ -252,8 +252,8 @@ function BlackoutManagement(opts) {
 	}
 
 	function wireUpTimePickers() {
-		$('.timepicker').timepicker({
-			timeFormat: options.timeFormat
+		document.querySelectorAll('.timepicker').forEach(el => {
+			dateHelper.initTimePicker(el);
 		});
 	}
 

--- a/tpl/Admin/Blackouts/manage_blackouts.tpl
+++ b/tpl/Admin/Blackouts/manage_blackouts.tpl
@@ -1,4 +1,4 @@
-{include file='globalheader.tpl' Timepicker=true DataTable=true}
+{include file='globalheader.tpl' DataTable=true}
 <div id="page-manage-blackouts" class="admin-page">
 	<h1 class="border-bottom mb-3">{translate key=ManageBlackouts}</h1>
 	<div class="accordion">
@@ -20,9 +20,10 @@
 									value="{formatdate date=$AddStartDate format='Y-m-d'}" />
 								<input {formname key=BEGIN_DATE} id="formattedAddStartDate" type="hidden"
 									value="{formatdate date=$AddStartDate key=system}" />
-								<input {formname key=BEGIN_TIME} type="text" id="addStartTime"
-									class="form-select form-select-sm dateinput timepicker"
-									value="{format_date format='h:00 A' date=now}" title="{translate key=StartTime}" />
+								<select {formname key=BEGIN_TIME} id="addStartTime"
+									class="form-select form-select-sm w-auto timepicker" data-format="{$TimeFormat}"
+									data-step="30" data-default="{format_date format='H:00' date=now}">
+								</select>
 								<label for="addStartTime" class="visually-hidden">{translate key=StartTime}</label>
 							</div>
 							<div class="d-flex align-items-center flex-wrap gap-1">
@@ -31,10 +32,11 @@
 									size="10" value="{formatdate date=$AddEndDate format='Y-m-d'}" />
 								<input {formname key=END_DATE} type="hidden" id="formattedAddEndDate"
 									value="{formatdate date=$AddEndDate key=system}" />
-								<input {formname key=END_TIME} type="text" id="addEndTime"
-									class="form-select form-select-sm dateinput timepicker"
-									value="{format_date format='h:00 A' date=Date::Now()->AddHours(1)}"
-									title="{translate key=EndTime}" />
+								<select {formname key=END_TIME} id="addEndTime"
+									class="form-select form-select-sm w-auto timepicker" data-format="{$TimeFormat}"
+									data-step="30"
+									data-default="{format_date format='H:00' date=Date::Now()->AddHours(1)}">
+								</select>
 								<label for="addEndTime" class="visually-hidden">{translate key=EndTime}</label>
 							</div>
 						</div>
@@ -311,7 +313,7 @@
 	</div>
 
 	{csrf_token}
-	{include file="javascript-includes.tpl" Timepicker=true DataTable=true}
+	{include file="javascript-includes.tpl" DataTable=true}
 	{datatable tableId=$tableId}
 	{jsfile src="reservationPopup.js"}
 	{jsfile src="ajax-helpers.js"}

--- a/tpl/Admin/Blackouts/manage_blackouts_edit.tpl
+++ b/tpl/Admin/Blackouts/manage_blackouts_edit.tpl
@@ -6,9 +6,9 @@
 				value="{formatdate date=$BlackoutStartDate format='Y-m-d'}" />
 			<input {formname key=BEGIN_DATE} id="formattedUpdateStartDate" type="hidden"
 				value="{formatdate date=$BlackoutStartDate key=system}" />
-			<input {formname key=BEGIN_TIME} type="text" id="updateStartTime"
-				class="form-select form-select-sm dateinput timepicker"
-				value="{formatdate date=$BlackoutStartDate format='h:i A'}" />
+			<select {formname key=BEGIN_TIME} id="updateStartTime" class="form-select form-select-sm w-auto timepicker"
+				data-format="{$TimeFormat}" data-step="30" data-default="{$BlackoutStartDate->format('H:i')}"
+				title="{translate key=StartTime}"></select>
 		</div>
 
 		<div class="form-group col-12 col-md-6 d-flex align-items-center gap-1">
@@ -17,9 +17,9 @@
 				value="{formatdate date=$BlackoutEndDate format='Y-m-d'}" />
 			<input {formname key=END_DATE} type="hidden" id="formattedUpdateEndDate"
 				value="{formatdate date=$BlackoutEndDate key=system}" />
-			<input {formname key=END_TIME} type="text" id="updateEndTime"
-				class="form-select form-select-sm dateinput timepicker"
-				value="{formatdate date=$BlackoutEndDate format='h:i A'}" />
+			<select {formname key=END_TIME} id="updateEndTime" class="form-select form-select-sm w-auto timepicker"
+				data-format="{$TimeFormat}" data-step="30" data-default="{$BlackoutEndDate->format('H:i')}"
+				title="{translate key=EndTime}"></select>
 		</div>
 
 		<label class="col-12 mt-2 mb-0 fw-bold">{translate key=Resources}</label>


### PR DESCRIPTION
* Replace jQuery-based .timepicker initialization with dateHelper.initTimePicker called on document.querySelectorAll('.timepicker').
* Convert time inputs into <select> elements with data-format, data-step and data-default attributes in both manage and edit blackouts templates, and remove the explicit Timepicker include flags from the global header and javascript includes.

This migrates the UI away from the old text-input/timepicker combo toward a standardized/select-backed timepicker initialized by dateHelper.