### PR TITLE
test: prevent flaky tests caused by midnight boundary issues

### DIFF
--- a/tests/Application/Reservation/RetryOptionsTest.php
+++ b/tests/Application/Reservation/RetryOptionsTest.php
@@ -25,7 +25,7 @@ class RetryOptionsTest extends TestBase
 
     public function testRemovesConflictsFromReservation()
     {
-        $now = Date::Now();
+        $now = TestBase::GetTestDate();
         $layout = new FakeScheduleLayout();
         $layout->_SlotCount = new SlotCount(1, 0);
 

--- a/tests/Application/Reservation/ScheduleTotalConcurrentReservationsRuleTest.php
+++ b/tests/Application/Reservation/ScheduleTotalConcurrentReservationsRuleTest.php
@@ -30,7 +30,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testValidWhenScheduleIsUnlimited()
     {
-        $start = Date::Now()->AddMinutes(30);
+        $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(30);
         $resourceId = 1;
 
@@ -46,7 +46,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testValidWhenUpdating()
     {
-        $start = Date::Now()->AddMinutes(30);
+        $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(30);
         $resourceId = 1;
         $refNum = '123';
@@ -64,7 +64,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testValidWhenNotConflicting()
     {
-        $start = Date::Now()->AddMinutes(30);
+        $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(30);
         $resourceId = 1;
         $refNum = '123';
@@ -88,7 +88,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testInvalidWhenOverLimitDuringCreate()
     {
-        $start = Date::Now()->AddMinutes(30);
+        $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(30);
         $resourceId = 1;
         $refNum = '123';
@@ -106,7 +106,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testInvalidWhenOverLimitDuringUpdate()
     {
-        $start = Date::Now()->AddMinutes(30);
+        $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(30);
         $resourceId = 1;
         $refNum = '123';
@@ -129,7 +129,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testInvalidWhenSingleReservationContainsMoreResourcesThanLimit()
     {
-        $start = Date::Now()->AddMinutes(30);
+        $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(30);
         $this->reservationViewRepository->_Reservations = [];
         $series = ReservationSeries::Create($this->fakeUser->UserId, new FakeBookableResource(1), '', '', new DateRange($start, $end), new RepeatNone(), $this->fakeUser);
@@ -144,7 +144,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testChecksEachInstanceOfASeries()
     {
-        $start = Date::Now()->AddMinutes(30);
+        $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(30);
         $resourceId = 1;
         $this->reservationViewRepository->_Reservations = [new TestReservationItemView(1, $start->AddDays(2), $end->AddDays(2), $resourceId, "another res"),];
@@ -159,7 +159,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testIncludesBufferTime()
     {
-        $start = Date::Now()->AddMinutes(30);
+        $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(90);
         $resourceId = 1;
         $testReservationItemView = new TestReservationItemView(1, $end, $end->AddMinutes(30), $resourceId, "another res");

--- a/tests/Presenters/Reservation/ReservationCreditsPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationCreditsPresenterTest.php
@@ -187,7 +187,7 @@ class FakeReservationCreditsPage implements IReservationCreditsPage
 
     public function __construct()
     {
-        $start = Date::Now()->AddHours(1);
+        $start = TestBase::GetTestDate();
         $end = $start->AddHours(1);
 
         $this->_ResourceId = 1;

--- a/tests/Presenters/ResourceDisplayPresenterTest.php
+++ b/tests/Presenters/ResourceDisplayPresenterTest.php
@@ -190,6 +190,7 @@ class ResourceDisplayPresenterTest extends TestBase
 
     public function testDisplaysAvailable()
     {
+        Date::_SetNow(TestBase::GetTestDate());
         $now = Date::Now();
 
         $this->setupStandardExpectations();
@@ -211,6 +212,7 @@ class ResourceDisplayPresenterTest extends TestBase
 
     public function testDisplaysUnavailable()
     {
+        Date::_SetNow(TestBase::GetTestDate());
         $now = Date::Now();
 
         $this->setupStandardExpectations();

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -151,4 +151,31 @@ class TestBase extends TestCase
         $this->fakeResources = null;
         Date::_ResetNow();
     }
+
+    /**
+     * Creates a Date safely in the middle of the day to avoid timezone-related
+     * day boundary issues in tests.
+     *
+     * When tests use Date::Now()->AddHours() or similar, the resulting dates can
+     * cross midnight boundaries depending on when the tests run and which timezones
+     * are involved. This causes flaky tests that fail only at certain times of day.
+     *
+     * This helper creates a date at 10:00 AM tomorrow, which is safe from midnight
+     * boundary issues regardless of timezone conversions.
+     *
+     * @return Date A date set to 10:00 AM tomorrow in the server's timezone
+     */
+    public static function GetTestDate(): Date
+    {
+        $tomorrow = Date::Now()->AddDays(1);
+        return Date::Create(
+            year: $tomorrow->Year(),
+            month: $tomorrow->Month(),
+            day: $tomorrow->Day(),
+            hour: 10,
+            minute: 0,
+            second: 0,
+            timezone: $tomorrow->Timezone()
+        );
+    }
 }

--- a/tests/fakes/ExistingReservationSeriesBuilder.php
+++ b/tests/fakes/ExistingReservationSeriesBuilder.php
@@ -39,7 +39,8 @@ class ExistingReservationSeriesBuilder
     {
         $series = new ExistingReservationSeries();
 
-        $this->currentInstance = new Reservation($series, new DateRange(Date::Now()->AddMinutes(30), Date::Now()->AddMinutes(60)));
+        $start = TestBase::GetTestDate();
+        $this->currentInstance = new Reservation($series, new DateRange($start, $start->AddMinutes(30)));
         $this->repeatOptions = new RepeatNone();
         $this->instances = [];
         $this->events = [];


### PR DESCRIPTION
Tests were failing between 03:30-04:59 UTC and 23:00-23:59 UTC due to Date::Now() with time additions crossing day boundaries during timezone conversions.

Add TestBase::GetTestDate() helper that returns 10:00 AM tomorrow, providing a safe reference time that avoids midnight boundary issues regardless of when tests run.

Fixed tests:
* RetryOptionsTest::testRemovesConflictsFromReservation
* ResourceDisplayPresenterTest::testDisplaysAvailable
* ResourceDisplayPresenterTest::testDisplaysUnavailable

Also updated other tests using similar patterns to prevent future issues:
* ExistingReservationSeriesBuilder
* ReservationCreditsPresenterTest
* ScheduleTotalConcurrentReservationsRuleTest

Closes: #544