### PR TITLE
refactor(manage_schedules): dateHelper for peak pickers & validation

### DIFF
--- a/Web/scripts/admin/schedule.js
+++ b/Web/scripts/admin/schedule.js
@@ -149,6 +149,8 @@ function ScheduleManagement(opts) {
 
 		elements.scheduleList.on('click', '.changePeakTimes', function (e) {
 			e.preventDefault();
+			document.getElementById('peakStartTime').classList.remove('is-invalid');
+			document.getElementById('peakEndTime').classList.remove('is-invalid');
 			showPeakTimesDialog(getActiveScheduleId());
 		});
 
@@ -285,7 +287,7 @@ function ScheduleManagement(opts) {
 		ConfigureAsyncForm(elements.changeLayoutForm, getSubmitCallback(options.changeLayoutAction));
 		ConfigureAsyncForm(elements.addForm, getSubmitCallback(options.addAction), null, handleAddError);
 		ConfigureAsyncForm(elements.deleteForm, getSubmitCallback(options.deleteAction));
-		ConfigureAsyncForm(elements.peakTimesForm, getSubmitCallback(options.peakTimesAction), refreshPeakTimes);
+		ConfigureAsyncForm(elements.peakTimesForm, getSubmitCallback(options.peakTimesAction), refreshPeakTimes, null, { onBeforeSubmit: validateTimes });
 		ConfigureAsyncForm(elements.availabilityForm, getSubmitCallback(options.availabilityAction), refreshAvailability);
 		ConfigureAsyncForm(elements.switchLayoutForm, getSubmitCallback(options.switchLayout));
 		ConfigureAsyncForm(elements.deleteCustomTimeSlotForm, getSubmitCallback(options.deleteLayoutSlot), afterDeleteSlot);
@@ -516,6 +518,8 @@ function ScheduleManagement(opts) {
 			peakOnAllYearChanged();
 		}
 
+		wireUpTimePickers(startTime, endTime);
+
 		elements.deletePeakTimes.val('');
 		elements.peakTimesDialog.modal('show');
 	};
@@ -698,4 +702,27 @@ function ScheduleManagement(opts) {
 		elements.deleteCustomLayoutDialog.hide();
 		_fullCalendar.fullCalendar('refetchEvents');
 	}
+
+	function wireUpTimePickers(startTime, endTime) {
+		document.querySelectorAll('.timepicker').forEach(el => {
+			if (el.id === 'peakStartTime') {
+				dateHelper.initTimePicker(el, startTime);
+			} else if (el.id === 'peakEndTime') {
+				dateHelper.initTimePicker(el, endTime);
+			} else {
+				dateHelper.initTimePicker(el);
+			}
+		});
+	}
+
+	var validateTimes = function () {
+		if (document.getElementById('peakAllDay').checked) {
+			return true;
+		}
+
+		return dateHelper.ValidateTimeRangeElements(
+			document.getElementById('peakStartTime'),
+			document.getElementById('peakEndTime')
+		);
+	};
 }

--- a/tpl/Admin/Schedules/manage_peak_times.tpl
+++ b/tpl/Admin/Schedules/manage_peak_times.tpl
@@ -1,13 +1,13 @@
 {if $Layout->HasPeakTimesDefined()}
 	{assign var=p value=$Layout->GetPeakTimes()}
 
-	<div class="peakTimes" data-all-day="{$p->IsAllDay()}" data-start-time="{$p->GetBeginTime()->Format('h:i A')}"
-		data-end-time="{$p->GetEndTime()->Format('h:i A')}">
+	<div class="peakTimes" data-all-day="{$p->IsAllDay()}" data-start-time="{$p->GetBeginTime()}"
+		data-end-time="{$p->GetEndTime()}">
 		{if $p->IsAllDay()}
 			{translate key=AllDay}
 		{else}
 			{translate key=Between}
-			{$p->GetBeginTime()->Format('h:i A')} - {$p->GetEndTime()->Format('h:i A')}
+			{formatdate date=$p->GetBeginTime() key='period_time'} - {formatdate date=$p->GetEndTime() key='period_time'}
 		{/if}
 	</div>
 

--- a/tpl/Admin/Schedules/manage_schedules.tpl
+++ b/tpl/Admin/Schedules/manage_schedules.tpl
@@ -1,4 +1,4 @@
-{include file='globalheader.tpl' InlineEdit=true Fullcalendar=true Timepicker=true DataTable=true}
+{include file='globalheader.tpl' InlineEdit=true Fullcalendar=true DataTable=true}
 
 <div id="page-manage-schedules" class="admin-page">
 
@@ -68,7 +68,13 @@
 															<span class="propertyValue scheduleAdmin fw-bold"
 																data-type="select" data-pk="{$id}"
 																data-value="{$schedule->GetAdminGroupId()}"
-																data-name="{FormKeys::SCHEDULE_ADMIN_GROUP_ID}">{($GroupLookup[$schedule->GetAdminGroupId()]) ? $GroupLookup[$schedule->GetAdminGroupId()]->Name : 'None'}</span>
+																data-name="{FormKeys::SCHEDULE_ADMIN_GROUP_ID}">
+																{if isset($GroupLookup[$schedule->GetAdminGroupId()])}
+																	{$GroupLookup[$schedule->GetAdminGroupId()]->Name|escape:'html'}
+																{else}
+																	None
+																{/if}
+															</span>
 															{if $AdminGroups|default:array()|count > 0}
 																<a class="link-primary update changeScheduleAdmin"><span
 																		class="visually-hidden">{translate key='ScheduleAdministrator'}</span><span
@@ -538,18 +544,18 @@
 								<label class="form-check-label" for="peakAllDay">{translate key=AllDay}</label>
 							</div>
 							<div id="peakTimes" class="d-flex align-items-center flex-wrap gap-1">
-								<label class="fw-bold" for="peakStartTime"> {translate key=Between}</label>
+								<label class="fw-bold" for="peakStartTime">{translate key=Between}</label>
 								<label for="peakStartTime" class="visually-hidden">Peak Begin Time</label>
 								<label for="peakEndTime" class="visually-hidden">Peak End Time</label>
-								<input type="text" id="peakStartTime"
-									class="form-control form-control-sm w-auto timeinput timepicker"
-									value="{formatdate date=$DefaultDate format='h:i A'}"
-									{formname key=PEAK_BEGIN_TIME} />
-								-
-								<input type="text" id="peakEndTime"
-									class="form-control form-control-sm w-auto timeinput timepicker"
-									value="{formatdate date=$DefaultDate->AddHours(9) format='h:i A'}"
-									{formname key=PEAK_END_TIME} />
+								<select {formname key=PEAK_BEGIN_TIME} id="peakStartTime"
+									class="form-select form-select-sm w-auto timepicker" data-format="{$TimeFormat}"
+									data-step="30" data-default="{$DefaultDate->format('H:i')}">
+								</select>
+								<div class='mx-1'>-</div>
+								<select {formname key=PEAK_END_TIME} id="peakEndTime"
+									class="form-select form-select-sm w-auto timepicker" data-format="{$TimeFormat}"
+									data-step="30" data-default="{$DefaultDate->AddHours(9)->format('H:i')}">
+								</select>
 							</div>
 						</div>
 						<div class="form-group mb-2">
@@ -838,9 +844,10 @@
 	{control type="DatePickerSetupControl" ControlId="availabilityEndDate" AltId="formattedEndDate" DefaultDate=$EndDate}
 
 	{csrf_token}
-	{include file="javascript-includes.tpl" InlineEdit=true Fullcalendar=true Timepicker=true DataTable=true}
+	{include file="javascript-includes.tpl" InlineEdit=true Fullcalendar=true DataTable=true}
 	{datatablefilter tableId=$tableIdFilter}
 	{jsfile src="ajax-helpers.js"}
+	{jsfile src="date-helper.js"}
 	{jsfile src="admin/schedule.js"}
 	{jsfile src="js/jquery.form-3.09.min.js"}
 
@@ -857,91 +864,97 @@
 			var updateUrl = '{$smarty.server.SCRIPT_NAME}?action=';
 
 			$('.scheduleName').editable({
-					url: updateUrl + '{ManageSchedules::ActionRename}', validate: function (value) {
-					if ($.trim(value) == '') {
-						return '{translate key=RequiredValue|escape:'javascript'}';
+				url: updateUrl + '{ManageSchedules::ActionRename}',
+				validate: function(value) {
+					if ($.trim(value) === '') {
+						return "{{translate key=RequiredValue}|escape:'javascript'}";
 					}
 				}
 			});
 
-		$('.daysVisible').editable({
-			url: updateUrl + '{ManageSchedules::ActionChangeDaysVisible}'
-		});
+			$('.daysVisible').editable({
+				url: updateUrl + '{ManageSchedules::ActionChangeDaysVisible}'
+			});
 
-		$('.dayName').editable({
-			url: updateUrl + '{ManageSchedules::ActionChangeStartDay}', source: [{
-			value: '{Schedule::Today}', text: '{$Today|escape:'javascript'}'
-		},
-		{foreach from=$DayNames item="dayName" key="dayIndex"}
-			{
-				value:{$dayIndex}, text: '{$dayName|escape:'javascript'}'
-			},
-		{/foreach}
-		]
-		});
+			$('.dayName').editable({
+				url: updateUrl + '{ManageSchedules::ActionChangeStartDay}',
+				source: [{
+						value: '{Schedule::Today}',
+						text: "{$Today|escape:'javascript'}"
+					}
+					{foreach from=$DayNames item="dayName" key="dayIndex"}
+						, {
+							value: {$dayIndex},
+							text: "{$dayName|escape:'javascript'}"
+						}
+					{/foreach}
+				]
+			});
 
-		$('.defaultScheduleStyle').editable({
-			url: updateUrl + '{ManageSchedules::ActionChangeDefaultStyle}', source: [
-			{foreach from=$StyleNames item="styleName" key="styleIndex"}
-				{
-					value: '{$styleIndex}', text: '{$styleName|escape:'javascript'}'
-				},
-			{/foreach}
-		]
-		});
+			$('.defaultScheduleStyle').editable({
+				url: updateUrl + '{ManageSchedules::ActionChangeDefaultStyle}',
+				source: [
+					{foreach from=$StyleNames item="styleName" key="styleIndex"}
+						{
+							value: '{$styleIndex}',
+							text: "{$styleName|escape:'javascript'}"
+						},
+					{/foreach}
+				]
+			});
 
-		$('.scheduleAdmin').editable({
-			url: updateUrl + '{ManageSchedules::ChangeAdminGroup}', emptytext: '{{translate key=None}|escape:'javascript'}', source: [{
-			value: '0', text: '{{translate key=None}|escape:'javascript'}'
-		},
-		{foreach from=$AdminGroups item=group}
-			{
-				value:{$group->Id()}, text: '{$group->Name()|escape:'javascript'}'
-			},
-		{/foreach}
-		]
-		});
+			$('.scheduleAdmin').editable({
+				url: updateUrl + '{ManageSchedules::ChangeAdminGroup}',
+				emptytext: "{{translate key=None}|escape:'javascript'}",
+				source: [{
+						value: '0',
+						text: "{{translate key=None}|escape:'javascript'}",
+					}
+					{foreach from=$AdminGroups item=group}
+						, {
+							value: {$group->Id()},
+							text: "{$group->Name()|escape:'javascript'}"
+						}
+					{/foreach}
+				]
+			});
 		}
 
 		$(document).ready(function() {
-					setUpEditables();
+			setUpEditables();
 
-					var opts = {
-						submitUrl: '{$smarty.server.SCRIPT_NAME}',
-						saveRedirect: '{$smarty.server.SCRIPT_NAME}',
-						changeLayoutAction: '{ManageSchedules::ActionChangeLayout}',
-						addAction: '{ManageSchedules::ActionAdd}',
-						peakTimesAction: '{ManageSchedules::ActionChangePeakTimes}',
-						makeDefaultAction: '{ManageSchedules::ActionMakeDefault}',
-						deleteAction: '{ManageSchedules::ActionDelete}',
-						availabilityAction: '{ManageSchedules::ActionChangeAvailability}',
-						enableSubscriptionAction: '{ManageSchedules::ActionEnableSubscription}',
-						disableSubscriptionAction: '{ManageSchedules::ActionDisableSubscription}',
-						switchLayout: '{ManageSchedules::ActionSwitchLayoutType}',
-						addLayoutSlot: '{ManageSchedules::ActionAddLayoutSlot}',
-						updateLayoutSlot: '{ManageSchedules::ActionUpdateLayoutSlot}',
-						deleteLayoutSlot: '{ManageSchedules::ActionDeleteLayoutSlot}',
-						maximumConcurrentAction: '{ManageSchedules::ActionChangeMaximumConcurrent}',
-						maximumResourcesAction: '{ManageSchedules::ActionChangeResourcesPerReservation}',
-						calendarOptions: {
-							buttonText: {
-								today: '{{translate key=Today}|escape:'javascript'}',
-								month: '{{translate key=Month}|escape:'javascript'}',
-								week: '{{translate key=Week}|escape:'javascript'}',
-								day: '{{translate key=Day}|escape:'javascript'}'
-								}, defaultDate: moment('{Date::Now()->ToTimezone({$Timezone})->Format('Y-m-d')}', 'YYYY-MM-DD'), eventsUrl: '{$smarty.server.SCRIPT_NAME}'
-							}
-						};
+			var opts = {
+				submitUrl: '{$smarty.server.SCRIPT_NAME}',
+				saveRedirect: '{$smarty.server.SCRIPT_NAME}',
+				changeLayoutAction: '{ManageSchedules::ActionChangeLayout}',
+				addAction: '{ManageSchedules::ActionAdd}',
+				peakTimesAction: '{ManageSchedules::ActionChangePeakTimes}',
+				makeDefaultAction: '{ManageSchedules::ActionMakeDefault}',
+				deleteAction: '{ManageSchedules::ActionDelete}',
+				availabilityAction: '{ManageSchedules::ActionChangeAvailability}',
+				enableSubscriptionAction: '{ManageSchedules::ActionEnableSubscription}',
+				disableSubscriptionAction: '{ManageSchedules::ActionDisableSubscription}',
+				switchLayout: '{ManageSchedules::ActionSwitchLayoutType}',
+				addLayoutSlot: '{ManageSchedules::ActionAddLayoutSlot}',
+				updateLayoutSlot: '{ManageSchedules::ActionUpdateLayoutSlot}',
+				deleteLayoutSlot: '{ManageSchedules::ActionDeleteLayoutSlot}',
+				maximumConcurrentAction: '{ManageSchedules::ActionChangeMaximumConcurrent}',
+				maximumResourcesAction: '{ManageSchedules::ActionChangeResourcesPerReservation}',
+				calendarOptions: {
+					buttonText: {
+						today: "{{translate key=Today}|escape:'javascript'}",
+						month: "{{translate key=Month}|escape:'javascript'}",
+						week: "{{translate key=Week}|escape:'javascript'}",
+						day: "{{translate key=Day}|escape:'javascript'}"
+					},
+					defaultDate: '{Date::Now()->ToTimezone({$Timezone})->Format("Y-m-d")}',
+					eventsUrl: '{$smarty.server.SCRIPT_NAME}'
+				}
+			};
 
-						var scheduleManagement = new ScheduleManagement(opts);
-						scheduleManagement.init();
-
-						$('.timepicker').timepicker({
-							timeFormat: '{$TimeFormat}'
-						});
-
-
-					});
+			var scheduleManagement = new ScheduleManagement(opts);
+			scheduleManagement.init();
+		});
 	</script>
 
 </div>


### PR DESCRIPTION
* Replace freeform peak time text inputs with select-based pickers and wire them to the shared dateHelper.
* Added wireUpTimePickers and validateTimes (used as onBeforeSubmit) so peak time ranges are validated before submit, and clear any 'is-invalid' classes when opening the dialog.
* Updated ConfigureAsyncForm for peakTimes to include the onBeforeSubmit hook.
* Include date-helper.js and pass a timeFormat option into ScheduleManagement; removed the old jQuery timepicker initialization.
* I also made a small Smarty null security fix for the schedule management group search and minor adjustments to the template/JS formatting using single and double quotes.