### PR TITLE
refactor(search-availability): use select pickers for time inputs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "files.insertFinalNewline": true,
+    "files.trimTrailingWhitespace": true
+}

--- a/Web/scripts/availability-search.js
+++ b/Web/scripts/availability-search.js
@@ -20,7 +20,7 @@ function AvailabilitySearch(options) {
     var init = function () {
         ConfigureAsyncForm(elements.searchForm, function () {
             elements.availabilityResults.empty();
-        }, showSearchResults);
+        }, showSearchResults, null, { onBeforeSubmit: validateTimes });
 
         elements.availabilityResults.on('click', '.opening', function (e) {
             var opening = $(this);
@@ -52,6 +52,9 @@ function AvailabilitySearch(options) {
         });
 
         elements.specificTime.on('click', function (e) {
+            elements.beginTime.removeClass('is-invalid');
+            elements.endTime.removeClass('is-invalid');
+
             if (elements.specificTime.is(':checked')) {
                 elements.beginTime.removeAttr('disabled');
                 elements.endTime.removeAttr('disabled');
@@ -75,5 +78,14 @@ function AvailabilitySearch(options) {
         });
     };
 
+    var validateTimes = function () {
+        if (document.getElementById('specificTime').checked) {
+            return dateHelper.ValidateTimeRangeElements(
+                document.getElementById('startTime'),
+                document.getElementById('endTime')
+            );
+        }
+        return true;
+    };
     return { init: init };
 }

--- a/tpl/SearchAvailability/search-availability.tpl
+++ b/tpl/SearchAvailability/search-availability.tpl
@@ -1,4 +1,4 @@
-{include file='globalheader.tpl' Select2=true Timepicker=true}
+{include file='globalheader.tpl' Select2=true}
 
 <div class="page-search-availability">
     <div class="card shadow mb-3">
@@ -44,15 +44,16 @@
                                 {formname key=SPECIFIC_TIME} />
                             <label class="form-check-label" for="specificTime">{translate key=SpecificTime}</label>
                         </div>
-                        <input {formname key=BEGIN_TIME} type="text" id="startTime"
-                            class="form-control form-control-sm dateinput d-inline-block timepicker"
-                            value="{format_date format='h:00 A' date=now}" title="Start time" disabled="disabled" />
-                        <span>-</span>
-                        <input {formname key=END_TIME} type="text" id="endTime"
-                            class="form-control form-control-sm dateinput d-inline-block timepicker"
-                            value="{format_date format='h:00 A' date=Date::Now()->AddHours(1)}" title="End time"
-                            disabled="disabled" />
-
+                        <select {formname key=BEGIN_TIME} id="startTime" aria-label="{translate key=StartTime}"
+                            class="form-select form-select-sm w-auto timepicker" data-format='{$TimeFormat}'
+                            data-step='30' data-default="{Date::Now()->format('H:00')}" disabled="disabled">
+                        </select>
+                        <div class='mx-1'>-</div>
+                        <select {formname key=END_TIME} id="endTime" aria-label="{translate key=EndTime}"
+                            class="form-select form-select-sm w-auto timepicker" data-format='{$TimeFormat}'
+                            data-step='30' data-default="{Date::Now()->AddHours(1)->format('H:00')}"
+                            disabled="disabled">
+                        </select>
                     </div>
                 </div>
 
@@ -155,7 +156,7 @@
 
     {csrf_token}
 
-    {include file="javascript-includes.tpl" Select2=true Timepicker=true}
+    {include file="javascript-includes.tpl" Select2=true}
     {jsfile src="js/tree.jquery.js"}
     {jsfile src="js/jquery.cookie.js"}
     {jsfile src="ajax-helpers.js"}
@@ -192,8 +193,8 @@
                 placeholder: '{translate key=Resources}'
             });
 
-            $('.timepicker').timepicker({
-                timeFormat: '{$TimeFormat}'
+            document.querySelectorAll('.timepicker').forEach(el => {
+                dateHelper.initTimePicker(el);
             });
         });
     </script>


### PR DESCRIPTION
* Replaced the plain text time inputs with select-based timepickers in the search template and removed the Timepicker include flags.
* Updated frontend JS to initialize each .timepicker via dateHelper.initTimePicker instead of calling the jQuery timepicker directly.
* Added validateTimes() to validate the start/end range when SpecificTime is checked and wired it into ConfigureAsyncForm via the onBeforeSubmit option.
* Also clear invalid classes when toggling the SpecificTime checkbox.

These changes centralize timepicker initialization, use 30-minute step select controls with sensible defaults, and enforce time-range validation before submitting the availability search.