### PR TITLE
chore(templates): remove unused Timepicker includes

### DIFF
--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -86,16 +86,11 @@
     {if isset($Select2) && $Select2}
         <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     {/if}
-    {if isset($Timepicker) && $Timepicker}
-        {cssfile src="scripts/css/timePicker.css" rel="stylesheet"}
-    {/if}
     {if isset($Fullcalendar) && $Fullcalendar}
         {cssfile src="scripts/css/fullcalendar.min.css"}
         <link rel='stylesheet' type='text/css' href='{$Path}scripts/css/fullcalendar.print.css' media='print' />
     {/if}
 
-    {jsfile src="js/jquery-ui-timepicker-addon.js"}
-    {cssfile src="scripts/css/jquery-ui-timepicker-addon.css"}
     {cssfile src="librebooking.css"}
     {if isset($cssFiles) && $cssFiles neq ''}
         {assign var='CssFileList' value=$cssFiles|split:','}

--- a/tpl/javascript-includes.tpl
+++ b/tpl/javascript-includes.tpl
@@ -76,10 +76,6 @@
 {if isset($Select2) && $Select2}
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
 {/if}
-{if isset($Timepicker) && $Timepicker}
-    {jsfile src="js/jquery.timePicker.min.js"}
-    {jsfile src="js/jquery-ui-timepicker-addon.js"}
-{/if}
 {if isset($Fullcalendar) && $Fullcalendar}
     {jsfile src="js/fullcalendar.js"}
     {if $HtmlLang != 'en'}


### PR DESCRIPTION
* Remove conditional inclusion of Timepicker assets from templates. This deletes the $Timepicker conditionals and removes references to timePicker.css, jquery-ui-timepicker-addon.css, jquery.timePicker.min.js and jquery-ui-timepicker-addon.js from tpl/globalheader.tpl and tpl/javascript-includes.tpl so those Timepicker resources are no longer loaded.
* Ensure any features depending on $Timepicker are updated accordingly.