### PR TITLE
fix: availability edit button disappears after editing schedule

### DIFF
--- a/Web/scripts/admin/schedule.js
+++ b/Web/scripts/admin/schedule.js
@@ -573,8 +573,8 @@ function ScheduleManagement(opts) {
 	var showAvailabilityDialog = function (scheduleId) {
 		var placeholder = $('[data-schedule-id=' + scheduleId + ']').find('.availabilityPlaceHolder');
 		var dates = placeholder.find('.availableDates');
-		var startDate = formatDate(dates.data('start-date'));
-		var endDate = formatDate(dates.data('end-date'));
+		var startDate = dates.attr('data-start-date');
+		var endDate = dates.attr('data-end-date');
 		var hasAvailability = dates.data('has-availability') == '1';
 
 		//elements.availableAllYear.prop('checked', !hasAvailability);
@@ -588,16 +588,8 @@ function ScheduleManagement(opts) {
 		elements.availabilityDialog.modal('show');
 	};
 
-	function formatDate(dateString) {
-		var date = new Date(dateString);
-		var year = date.getFullYear();
-		var month = ('0' + (date.getMonth() + 1)).slice(-2);
-		var day = ('0' + date.getDate()).slice(-2);
-		return year + '-' + month + '-' + day;
-	}
-
 	var refreshAvailability = function (resultHtml) {
-		$('[data-schedule-id=' + getActiveScheduleId() + ']').find('.availabilityPlaceHolder').html(resultHtml);
+		$('[data-schedule-id=' + getActiveScheduleId() + ']').find('.availabilityContent').html(resultHtml);
 		elements.availabilityDialog.modal('hide');
 	};
 

--- a/tpl/Admin/Schedules/manage_availability.tpl
+++ b/tpl/Admin/Schedules/manage_availability.tpl
@@ -1,6 +1,6 @@
 <div class="availableDates" data-has-availability="{$schedule->HasAvailability()|intval}"
-    data-start-date="{formatdate date=$schedule->GetAvailabilityBegin() timezone=$timezone key=general_date}"
-    data-end-date="{formatdate date=$schedule->GetAvailabilityEnd() timezone=$timezone key=general_date}">
+    data-start-date="{formatdate date=$schedule->GetAvailabilityBegin() timezone=$timezone format='Y-m-d'}"
+    data-end-date="{formatdate date=$schedule->GetAvailabilityEnd() timezone=$timezone format='Y-m-d'}">
 </div>
 
 {translate key=Available}

--- a/tpl/Admin/Schedules/manage_schedules.tpl
+++ b/tpl/Admin/Schedules/manage_schedules.tpl
@@ -84,15 +84,16 @@
 
 														</div>
 
-														<div>
-															<div class="availabilityPlaceHolder d-inline-block">
+														<div class="availabilityPlaceHolder d-flex align-items-center">
+															<div class="availabilityContent">
 																{include file="Admin/Schedules/manage_availability.tpl" schedule=$schedule timezone=$Timezone}
-																<a class="update changeAvailability link-primary" href="#">
-																	<span
-																		class="visually-hidden">{translate key='Availability'}</span>
-																	<span class="bi bi-pencil-square"></span>
-																</a>
 															</div>
+
+															<a class="update changeAvailability link-primary ms-1" href="#">
+																<span
+																	class="visually-hidden">{translate key='Availability'}</span>
+																<span class="bi bi-pencil-square"></span>
+															</a>
 														</div>
 
 														<div class="maximumConcurrentContainer"


### PR DESCRIPTION
Render availability dates as Y-m-d on the server and stop client-side date formatting. JS now reads data-start-date/data-end-date via attr() and the formatDate helper was removed. refreshAvailability targets .availabilityContent (instead of .availabilityPlaceHolder) and hides the modal after update. Template changes: manage_availability.tpl uses format='Y-m-d' for start/end attributes; manage_schedules.tpl wraps the include in .availabilityContent, adjusts the .availabilityPlaceHolder layout to use flex alignment, and moves the edit link outside the refreshed content with spacing. These changes avoid locale/parse issues and make partial DOM refreshes more reliable.