### PR TITLE
fix: include conditionally displaying title and description

### DIFF
--- a/tpl/Reservation/pdf.tpl
+++ b/tpl/Reservation/pdf.tpl
@@ -218,7 +218,7 @@ $('.btnPDF').click(function (e) {
 			body: [
 			[{ content: '{translate key="ReservationTitle"}', styles: { fontStyle: 'bold'}},
 			],
-			[{ content: '{if $ReservationTitle}{$ReservationTitle|unescape:'html'|escape:'javascript'}{/if}'},
+			[{ content: '{if isset($ReservationTitle)}{$ReservationTitle|unescape:'html'|escape:'javascript'}{/if}'},
 			],
 			[{ content: '{translate key="ReservationDescription"}', styles: { fontStyle: 'bold'}},
 			],

--- a/tpl/Reservation/pdf.tpl
+++ b/tpl/Reservation/pdf.tpl
@@ -7,7 +7,7 @@ function GetSelectedResourceIds() {
 	});
 	return resourceIds;
 }
-	
+
 function LoadCustomAttributesData() {
 	var url = 'ajax/reservation_attributes_print.php?uid=' + $('#userId').val() + '&rn=' + $('#referenceNumber').val() + '&ro=' + $('#reservation-box').hasClass('readonly');
 
@@ -15,7 +15,7 @@ function LoadCustomAttributesData() {
 	_.each(resourceIds, function (n) {
 		url += '&rid[]=' + n;
 	});
-	
+
 	return $.ajax({
         global: false,
         url: url,
@@ -97,12 +97,12 @@ $('.btnPDF').click(function (e) {
 			 { content: '{formatdate date=$EndDate key=embedded_datetime}'},
 			],
 			[{ content: '{translate key=ReservationLength}', styles: { fontStyle: 'bold'}},
-			 { colSpan: 3, content: durationText},	 
+			 { colSpan: 3, content: durationText},
 			],
 			[{ content: '{translate key=RepeatPrompt}', styles: { fontStyle: 'bold'}},
 			{if $IsRecurring}
 			 { content: '{translate key=$RepeatOptions[$RepeatType]['key']}'},
-			 { content: '{$RepeatInterval}'},	
+			 { content: '{$RepeatInterval}'},
 			 { content: '{translate key=$RepeatOptions[$RepeatType]['everyKey']}'},
 			{else}
 			 { colSpan: 3, content: '{translate key=$RepeatOptions[$RepeatType]['key']}'},
@@ -122,9 +122,9 @@ $('.btnPDF').click(function (e) {
 					[{ content: daysText, styles: { fontStyle: 'bold'}},
 					{ colSpan: 3, content: '{foreach from=$RepeatWeekdays item=day name=weekdaysLoop}{if $smarty.foreach.weekdaysLoop.last}{translate key=$DayNames[$day]}{else}{translate key=$DayNames[$day]},{/if} {/foreach}'},
 					],
-				{/if}	
+				{/if}
 				[{ content: '{{translate key=RepeatUntilPrompt}|escape:'javascript'}', styles: { fontStyle: 'bold'}},
-				 { colSpan: 3, content: '{formatdate date=$RepeatTerminationDate}'},	 
+				 { colSpan: 3, content: '{formatdate date=$RepeatTerminationDate}'},
 				],
 			{/if}
 			],
@@ -222,7 +222,7 @@ $('.btnPDF').click(function (e) {
 			],
 			[{ content: '{translate key="ReservationDescription"}', styles: { fontStyle: 'bold'}},
 			],
-			[{ content: '{if $Description}{$Description|unescape:'html'|escape:'javascript'}{/if}'},
+			[{ content: '{if isset($Description)}{$Description|unescape:'html'|escape:'javascript'}{/if}'},
 			],
 			]
 		});

--- a/tpl/Reservation/pdf.tpl
+++ b/tpl/Reservation/pdf.tpl
@@ -218,11 +218,11 @@ $('.btnPDF').click(function (e) {
 			body: [
 			[{ content: '{translate key="ReservationTitle"}', styles: { fontStyle: 'bold'}},
 			],
-			[{ content: '{$ReservationTitle|unescape:'html'|escape:'javascript'}'},
+			[{ content: '{if $ReservationTitle}{$ReservationTitle|unescape:'html'|escape:'javascript'}{/if}'},
 			],
 			[{ content: '{translate key="ReservationDescription"}', styles: { fontStyle: 'bold'}},
 			],
-			[{ content: '{$Description|unescape:'html'|escape:'javascript'}'},
+			[{ content: '{if $Description}{$Description|unescape:'html'|escape:'javascript'}{/if}'},
 			],
 			]
 		});


### PR DESCRIPTION
with no title or description there was a PHP (I assume 8+) warning being output directly into the JavaScript code, which creates an unescaped line break that causes a JS syntax error. Now neither Title nor Description can be NULL.