### PR TITLE
refactor(date-helper.js): centralize midnight handling in time-range validation

### DIFF
--- a/Web/scripts/admin/quota.js
+++ b/Web/scripts/admin/quota.js
@@ -80,25 +80,9 @@ function QuotaManagement(opts) {
 			return true;
 		}
 
-		// NOTE(jlvillal): 2026-01-31: If we update datehelper.ValidateTimeRangeElements()
-		// to handle the 'midnight' case we can simplify this code.
 		var startElement = document.getElementById('enforce-time-start');
 		var endElement = document.getElementById('enforce-time-end');
-		// Preserve legacy behavior: allow midnight (00:00) as a valid end time,
-		// representing an interval that spans into the next day.
-		if (endElement && typeof endElement.value === 'string') {
-			var endValue = endElement.value;
-			if (endValue) {
-				var timeParts = endValue.split(':');
-				if (timeParts.length >= 2) {
-					var endHour = parseInt(timeParts[0], 10);
-					var endMinute = parseInt(timeParts[1], 10);
-					if (!isNaN(endHour) && !isNaN(endMinute) && endHour === 0 && endMinute === 0) {
-						return true;
-					}
-				}
-			}
-		}
+
 		return dateHelper.ValidateTimeRangeElements(startElement, endElement);
 	};
 }

--- a/Web/scripts/date-helper.js
+++ b/Web/scripts/date-helper.js
@@ -259,7 +259,15 @@ var dateHelper = (function () {
 				return false;
 			}
 
-			const diff = this.GetTimeDifference(startEl.value, endEl.value);
+			let startValue = startEl.value;
+			let endValue = endEl.value;
+
+			// Special case: '00:00' is treated as the end of the day (24:00) for validation
+			if (endValue === '00:00') {
+				endValue = '24:00';
+			}
+
+			const diff = this.GetTimeDifference(startValue, endValue);
 
 			if (diff <= 0) {
 				startEl.classList.add(invalidClass);


### PR DESCRIPTION
Centralize midnight handling in date-helper: treat an end time of '00:00' as '24:00' for time-difference validation. Remove the legacy midnight-special-case code from admin/quota.js and delegate validation to dateHelper.ValidateTimeRangeElements instead, preserving the previous behavior where midnight represents an interval that spans into the next day.