### PR TITLE
ci(release): use the RELEASE_GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Semantic Release (No-Op)
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           config_file: releaserc.toml
           no_operation_mode: true
           build: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           config_file: releaserc.toml
           build: false
 
@@ -36,5 +36,5 @@ jobs:
         uses: python-semantic-release/publish-action@v10.5.3
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
We can't use the normal 'GITHUB_TOKEN' to do releases