### PR TITLE
ci(release): add the 'id-token' permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
 
     permissions:
       contents: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v6.0.1


### PR DESCRIPTION
This is mentioned in the python-semantic-release documentation