### PR TITLE
chore: remove dev dependency 'kint' as unused

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7.1",
         "phpcompatibility/php-compatibility": "^9.3.5",
-        "kint-php/kint": "^4.2.3",
         "phpunit/phpunit": "^11.3",
         "phpstan/phpstan": "^2.1"
     },


### PR DESCRIPTION
kint-php/kint is not used in the codebase. So remove it from composer.json