### PR TITLE
test(plugins): Use correct directory name

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -40,7 +40,7 @@
       <directory suffix=".php">Jobs</directory>
       <directory suffix=".php">lib</directory>
       <directory suffix=".php">Pages</directory>
-      <directory suffix=".php">Plugins</directory>
+      <directory suffix=".php">plugins</directory>
       <directory suffix=".php">Presenters</directory>
       <directory suffix=".php">Web</directory>
       <directory suffix=".php">WebServices</directory>


### PR DESCRIPTION
Previous had 'Plugins' but the directory is called 'plugins'