### PR TITLE
docs: repository renamed to 'Librebooking/librebooking'

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 <!--
 Please validate that the issue is a bug and not a question. If you have a
 question please ask it in the Discussions area:
-https://github.com/LibreBooking/app/discussions
+https://github.com/LibreBooking/librebooking/discussions
 -->
 
 []: I understand that the best way to resolve this issue is to solve it and propose a Pull Request.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: LibreBooking Community Support
-    url: https://github.com/LibreBooking/app/discussions
+    url: https://github.com/LibreBooking/librebooking/discussions
     about: Please ask and answer questions here.
   - name: 💬 Discord Chat
-    url: https://discord.gg/AEvcebqB
+    url: https://discord.gg/4TGThPtmX8
     about: Chat with devs and community. If the link doesn't work please file an issue.

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release_dry_run:
-    if: github.repository == 'LibreBooking/app'
+    if: github.repository == 'LibreBooking/librebooking'
     runs-on: ubuntu-latest
     concurrency: release-dry-run
     environment: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release:
-    if: github.repository == 'LibreBooking/app'
+    if: github.repository == 'LibreBooking/librebooking'
     runs-on: ubuntu-latest
     concurrency: release
     environment: release

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -47,7 +47,7 @@ jobs:
 
             This is documented in CONTRIBUTING.md
 
-            https://github.com/LibreBooking/app/blob/develop/CONTRIBUTING.md
+            https://github.com/LibreBooking/librebooking/blob/develop/CONTRIBUTING.md
 
           days-before-issue-stale: 60
           days-before-issue-close: 15
@@ -77,7 +77,7 @@ jobs:
 
             This is documented in CONTRIBUTING.md
 
-            https://github.com/LibreBooking/app/blob/develop/CONTRIBUTING.md
+            https://github.com/LibreBooking/librebooking/blob/develop/CONTRIBUTING.md
 
           stale-pr-message: >
             This Pull Request (PR) was marked stale because it has been open 90 days

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,303 +8,303 @@
 ### Bug Fixes
 
 - Add command-line usage instructions for CombineDbFilesTask and UpgradeDbTask causing phpstan issue
-  ([`bea840d`](https://github.com/LibreBooking/app/commit/bea840dd2ff194ad4316b7677b1d5bc3306cc708))
+  ([`bea840d`](https://github.com/LibreBooking/librebooking/commit/bea840dd2ff194ad4316b7677b1d5bc3306cc708))
 
 - Add default value handling in ConfigurationFile::GetKey method
-  ([`0f785cb`](https://github.com/LibreBooking/app/commit/0f785cb08f37486879dd79626bb7e8ccbe1fd2b0))
+  ([`0f785cb`](https://github.com/LibreBooking/librebooking/commit/0f785cb08f37486879dd79626bb7e8ccbe1fd2b0))
 
 - Add null check in EnsureNull method
-  ([`1bda603`](https://github.com/LibreBooking/app/commit/1bda603569bc903eb097405eabff13f4cf75cb52))
+  ([`1bda603`](https://github.com/LibreBooking/librebooking/commit/1bda603569bc903eb097405eabff13f4cf75cb52))
 
 - Api group update will create a new group rather than updating the group
-  ([`b939389`](https://github.com/LibreBooking/app/commit/b9393897362f25b1ac1933c5ea0a3d4c7dcb2fa1))
+  ([`b939389`](https://github.com/LibreBooking/librebooking/commit/b9393897362f25b1ac1933c5ea0a3d4c7dcb2fa1))
 
 - Availability edit button disappears after editing schedule
-  ([`f12d65f`](https://github.com/LibreBooking/app/commit/f12d65f5190fcc2f6daaefea67ef796f06c031b0))
+  ([`f12d65f`](https://github.com/LibreBooking/librebooking/commit/f12d65f5190fcc2f6daaefea67ef796f06c031b0))
 
 - Cannot access offset type on ShibbolethConfigKeys
-  ([`a853e09`](https://github.com/LibreBooking/app/commit/a853e0945f027369a83e1e0deac75685559bf73a))
+  ([`a853e09`](https://github.com/LibreBooking/librebooking/commit/a853e0945f027369a83e1e0deac75685559bf73a))
 
 - Changed wrong auth details response code to 401
-  ([`da4d633`](https://github.com/LibreBooking/app/commit/da4d633be39e614addb450cd620bd77aff8b96a6))
+  ([`da4d633`](https://github.com/LibreBooking/librebooking/commit/da4d633be39e614addb450cd620bd77aff8b96a6))
 
 - Database migration for 4.0
-  ([`0b6c844`](https://github.com/LibreBooking/app/commit/0b6c844824e1ca70afc8b21145ead1c2e575dacc))
+  ([`0b6c844`](https://github.com/LibreBooking/librebooking/commit/0b6c844824e1ca70afc8b21145ead1c2e575dacc))
 
 - Display current reservation on tablet view and refine layout
-  ([#803](https://github.com/LibreBooking/app/pull/803),
-  [`570b889`](https://github.com/LibreBooking/app/commit/570b889ac2799d9c3314cb6e0ab0d73ec42fde98))
+  ([#803](https://github.com/LibreBooking/librebooking/pull/803),
+  [`570b889`](https://github.com/LibreBooking/librebooking/commit/570b889ac2799d9c3314cb6e0ab0d73ec42fde98))
 
 - Edited plugin config example to use nested layout
-  ([`1b14b35`](https://github.com/LibreBooking/app/commit/1b14b35504da7c0548a87cb2da0cf0cb73ce33c9))
+  ([`1b14b35`](https://github.com/LibreBooking/librebooking/commit/1b14b35504da7c0548a87cb2da0cf0cb73ce33c9))
 
 - Error in keycloak/oauth url generation
-  ([`eb548ff`](https://github.com/LibreBooking/app/commit/eb548ff7319e0ec2c2d291face166087829e4871))
+  ([`eb548ff`](https://github.com/LibreBooking/librebooking/commit/eb548ff7319e0ec2c2d291face166087829e4871))
 
 - Error in reservation.start.time.constraint
-  ([`98b72b4`](https://github.com/LibreBooking/app/commit/98b72b4c4546045f947c1da957a4a22c67a76951))
+  ([`98b72b4`](https://github.com/LibreBooking/librebooking/commit/98b72b4c4546045f947c1da957a4a22c67a76951))
 
 - Exporter page broken after config validation
-  ([`f7c6c3d`](https://github.com/LibreBooking/app/commit/f7c6c3db240030122a0377cedf3a1aeab3ee1e8d))
+  ([`f7c6c3d`](https://github.com/LibreBooking/librebooking/commit/f7c6c3db240030122a0377cedf3a1aeab3ee1e8d))
 
 - Flatpickr week start day ignored for Starts Today schedules
-  ([`a46c31a`](https://github.com/LibreBooking/app/commit/a46c31a991942dcf69b357512b479edbfa965a4d))
+  ([`a46c31a`](https://github.com/LibreBooking/librebooking/commit/a46c31a991942dcf69b357512b479edbfa965a4d))
 
 - GetConfigGroup and ConfiKeys in API
-  ([`12fc5dc`](https://github.com/LibreBooking/app/commit/12fc5dc360b4da7a5f7e5ab95e6e18a3cf5030a1))
+  ([`12fc5dc`](https://github.com/LibreBooking/librebooking/commit/12fc5dc360b4da7a5f7e5ab95e6e18a3cf5030a1))
 
 - Ignore invalid configs in ManageConfiguration
-  ([`711e01e`](https://github.com/LibreBooking/app/commit/711e01e8319843cd7d8b3266e5dc9bd33e08bdf0))
+  ([`711e01e`](https://github.com/LibreBooking/librebooking/commit/711e01e8319843cd7d8b3266e5dc9bd33e08bdf0))
 
 - Include conditionally displaying title and description
-  ([#941](https://github.com/LibreBooking/app/pull/941),
-  [`46d3069`](https://github.com/LibreBooking/app/commit/46d3069cf6184c4eb6596d6d8be60ebfaa0f958d))
+  ([#941](https://github.com/LibreBooking/librebooking/pull/941),
+  [`46d3069`](https://github.com/LibreBooking/librebooking/commit/46d3069cf6184c4eb6596d6d8be60ebfaa0f958d))
 
 - Informational log message changed to more appropriate level (DEBUG instead of ERROR)
-  ([`dadca6b`](https://github.com/LibreBooking/app/commit/dadca6b11259e976e2868a2910d1576b87806e34))
+  ([`dadca6b`](https://github.com/LibreBooking/librebooking/commit/dadca6b11259e976e2868a2910d1576b87806e34))
 
 - Null error on unknown key
-  ([`a8363f1`](https://github.com/LibreBooking/app/commit/a8363f15835b988026268093b1b53be9f1d362a5))
+  ([`a8363f1`](https://github.com/LibreBooking/librebooking/commit/a8363f15835b988026268093b1b53be9f1d362a5))
 
 - Reorder PSR12 rule
-  ([`7c3473a`](https://github.com/LibreBooking/app/commit/7c3473a2404ce1b40f77b485c01899a9b4f2ba14))
+  ([`7c3473a`](https://github.com/LibreBooking/librebooking/commit/7c3473a2404ce1b40f77b485c01899a9b4f2ba14))
 
 - Show option key rather than values on config wrong choice
-  ([`e35a030`](https://github.com/LibreBooking/app/commit/e35a0301a30b41fa9c4d95b65f59c9ee32881770))
+  ([`e35a030`](https://github.com/LibreBooking/librebooking/commit/e35a0301a30b41fa9c4d95b65f59c9ee32881770))
 
 - Standardize log messages and improve error handling in configuration tests
-  ([`0214c6d`](https://github.com/LibreBooking/app/commit/0214c6da38a3db8bc82e833797a95ed637b3897f))
+  ([`0214c6d`](https://github.com/LibreBooking/librebooking/commit/0214c6da38a3db8bc82e833797a95ed637b3897f))
 
 - Trumbowyg fails to load when use.local.js.libs is set to true
-  ([`ccaba0b`](https://github.com/LibreBooking/app/commit/ccaba0b1cb03eaf8f3dc2cb6a374115831c5f79b))
+  ([`ccaba0b`](https://github.com/LibreBooking/librebooking/commit/ccaba0b1cb03eaf8f3dc2cb6a374115831c5f79b))
 
 - Update environment variable keys and add resource options in config files
-  ([`5cbd1a1`](https://github.com/LibreBooking/app/commit/5cbd1a191ca457b5ffb8e1a565e78666dae1db44))
+  ([`5cbd1a1`](https://github.com/LibreBooking/librebooking/commit/5cbd1a191ca457b5ffb8e1a565e78666dae1db44))
 
 - Update manual database setup documentation
-  ([`9c175bf`](https://github.com/LibreBooking/app/commit/9c175bf985b06934675e98454f913e2cf169ccb4))
+  ([`9c175bf`](https://github.com/LibreBooking/librebooking/commit/9c175bf985b06934675e98454f913e2cf169ccb4))
 
 - Use BooleanConverter for TABLET_VIEW_ALLOW_RESERVATIONS
-  ([`d941886`](https://github.com/LibreBooking/app/commit/d941886d7bc32d96aefeea3105f5b5a8413a3edc))
+  ([`d941886`](https://github.com/LibreBooking/librebooking/commit/d941886d7bc32d96aefeea3105f5b5a8413a3edc))
 
 - Use ConfigKey instead of hard-coded name
-  ([`62a1e9b`](https://github.com/LibreBooking/app/commit/62a1e9b0a4903c93813f2bafaa5edc091d7189a5))
+  ([`62a1e9b`](https://github.com/LibreBooking/librebooking/commit/62a1e9b0a4903c93813f2bafaa5edc091d7189a5))
 
 - Use default logging level of 'error'
-  ([`0e850d3`](https://github.com/LibreBooking/app/commit/0e850d3e20769bb9d1b62f7c9ca7f9f07e96f272))
+  ([`0e850d3`](https://github.com/LibreBooking/librebooking/commit/0e850d3e20769bb9d1b62f7c9ca7f9f07e96f272))
 
 - Use lower-case log_level
-  ([`44ca668`](https://github.com/LibreBooking/app/commit/44ca668cb4b4cb2a1a4cbbcf057deb2c8e5ca6fb))
+  ([`44ca668`](https://github.com/LibreBooking/librebooking/commit/44ca668cb4b4cb2a1a4cbbcf057deb2c8e5ca6fb))
 
 - Wrong section for slack token
-  ([`f407878`](https://github.com/LibreBooking/app/commit/f407878ae7fdf16c63d1a7de33fa8b1895209f77))
+  ([`f407878`](https://github.com/LibreBooking/librebooking/commit/f407878ae7fdf16c63d1a7de33fa8b1895209f77))
 
 - **auth**: Prevent auto-registration when self-registration is disabled
-  ([`9f24a5a`](https://github.com/LibreBooking/app/commit/9f24a5adf7a9b4817718960ebfa3bfcd5c16a8b6))
+  ([`9f24a5a`](https://github.com/LibreBooking/librebooking/commit/9f24a5adf7a9b4817718960ebfa3bfcd5c16a8b6))
 
 - **auth**: Updated plugin configuration keys into nested structures
-  ([`1cfe196`](https://github.com/LibreBooking/app/commit/1cfe196eeea3ca3dc9624a315df6a86a4f0d22d8))
+  ([`1cfe196`](https://github.com/LibreBooking/librebooking/commit/1cfe196eeea3ca3dc9624a315df6a86a4f0d22d8))
 
 - **AutocompleteUser**: Handle potential null values
-  ([`d90b7ab`](https://github.com/LibreBooking/app/commit/d90b7ab6d37241c74d048c8e5c224cd3b334189c))
+  ([`d90b7ab`](https://github.com/LibreBooking/librebooking/commit/d90b7ab6d37241c74d048c8e5c224cd3b334189c))
 
 - **chore**: Resolve many html escape issues
-  ([`c8a6396`](https://github.com/LibreBooking/app/commit/c8a6396831ebcc8d4bf9dadd9bf26da79a92b79f))
+  ([`c8a6396`](https://github.com/LibreBooking/librebooking/commit/c8a6396831ebcc8d4bf9dadd9bf26da79a92b79f))
 
 - **config**: Preserve unknown subkeys in original structure for validation and improve error
   logging for invalid config values
-  ([`723f238`](https://github.com/LibreBooking/app/commit/723f238289f4bac69883b5763e5ee7f7f92592c1))
+  ([`723f238`](https://github.com/LibreBooking/librebooking/commit/723f238289f4bac69883b5763e5ee7f7f92592c1))
 
 - **config**: Update configurator to new plugin config
-  ([`3fe962b`](https://github.com/LibreBooking/app/commit/3fe962b020787e3239e4451805fd05c88b2c0244))
+  ([`3fe962b`](https://github.com/LibreBooking/librebooking/commit/3fe962b020787e3239e4451805fd05c88b2c0244))
 
 - **htaccess**: Prevent redirect loop for /Web path without trailing slash
-  ([`ad8bde2`](https://github.com/LibreBooking/app/commit/ad8bde2acbfbe5f678f12b67c76cbeec5d4a5bca))
+  ([`ad8bde2`](https://github.com/LibreBooking/librebooking/commit/ad8bde2acbfbe5f678f12b67c76cbeec5d4a5bca))
 
 - **image-upload**: Use correct directory for uploading image
-  ([`88cb94a`](https://github.com/LibreBooking/app/commit/88cb94a07ec03f679cec1e0f94f68f332bdc68e6))
+  ([`88cb94a`](https://github.com/LibreBooking/librebooking/commit/88cb94a07ec03f679cec1e0f94f68f332bdc68e6))
 
 - **ldap**: Rename debug configuration key for consistency
-  ([`f8efae3`](https://github.com/LibreBooking/app/commit/f8efae3fc87b510040bfc987a1a43171ee3a1c79))
+  ([`f8efae3`](https://github.com/LibreBooking/librebooking/commit/f8efae3fc87b510040bfc987a1a43171ee3a1c79))
 
 - **ldap**: Update default search filter to be optional with improved description
-  ([`7c17c7c`](https://github.com/LibreBooking/app/commit/7c17c7c6f39bc693298e220ca8c0022740305308))
+  ([`7c17c7c`](https://github.com/LibreBooking/librebooking/commit/7c17c7c6f39bc693298e220ca8c0022740305308))
 
 - **pdf**: Enhance PDF generation error handling and improve table formatting
-  ([`b165000`](https://github.com/LibreBooking/app/commit/b16500067725385863bdb20ebed2c93897a8c931))
+  ([`b165000`](https://github.com/LibreBooking/librebooking/commit/b16500067725385863bdb20ebed2c93897a8c931))
 
 - **pdf**: Handle default values for repeat options and reservation details in PDF generation
-  ([`fda8a76`](https://github.com/LibreBooking/app/commit/fda8a76967f090bd25896d220cf47455fba782ca))
+  ([`fda8a76`](https://github.com/LibreBooking/librebooking/commit/fda8a76967f090bd25896d220cf47455fba782ca))
 
 - **profile**: Resolve loading the profile page when multiple attributes
-  ([`e5e423f`](https://github.com/LibreBooking/app/commit/e5e423f6b122c0e8c20c80137ba5eb29fbedb306))
+  ([`e5e423f`](https://github.com/LibreBooking/librebooking/commit/e5e423f6b122c0e8c20c80137ba5eb29fbedb306))
 
 - **profile**: Resolve saving of unchecked checkbox in the profile
-  ([`2672584`](https://github.com/LibreBooking/app/commit/26725844ff9eec2f9bf921f0859c432a1b7c7aa5))
+  ([`2672584`](https://github.com/LibreBooking/librebooking/commit/26725844ff9eec2f9bf921f0859c432a1b7c7aa5))
 
 - **reservation**: Resolve html rendering in announcement emails
-  ([`1fad3be`](https://github.com/LibreBooking/app/commit/1fad3bee7afbb5ad8c9d9b24843d3e6b5703b0ac))
+  ([`1fad3be`](https://github.com/LibreBooking/librebooking/commit/1fad3bee7afbb5ad8c9d9b24843d3e6b5703b0ac))
 
 - **reservation**: Resolve weekly series checkbox status on load
-  ([`d7a62b4`](https://github.com/LibreBooking/app/commit/d7a62b4f00fba49068a23bd03f46d0e9d70da173))
+  ([`d7a62b4`](https://github.com/LibreBooking/librebooking/commit/d7a62b4f00fba49068a23bd03f46d0e9d70da173))
 
 - **Resources**: Improve string retrieval logic
-  ([`7e27ac5`](https://github.com/LibreBooking/app/commit/7e27ac552e2d583c238f18d98edfb0abdc557458))
+  ([`7e27ac5`](https://github.com/LibreBooking/librebooking/commit/7e27ac552e2d583c238f18d98edfb0abdc557458))
 
 - **schedule**: Correct date display and layout issues
-  ([`d684695`](https://github.com/LibreBooking/app/commit/d684695996e5f509c9a095974a7f624370e1fc04))
+  ([`d684695`](https://github.com/LibreBooking/librebooking/commit/d684695996e5f509c9a095974a7f624370e1fc04))
 
 - **templates**: Replace regex check with empty check in Italian email templates
-  ([`1e71f81`](https://github.com/LibreBooking/app/commit/1e71f81dc77ddb1477252c2d07f7113fb090af7b))
+  ([`1e71f81`](https://github.com/LibreBooking/librebooking/commit/1e71f81dc77ddb1477252c2d07f7113fb090af7b))
 
 - **test**: Update configuration key test
-  ([`3444e6c`](https://github.com/LibreBooking/app/commit/3444e6c8449bd7f33f7e8ca7634ff76da1997071))
+  ([`3444e6c`](https://github.com/LibreBooking/librebooking/commit/3444e6c8449bd7f33f7e8ca7634ff76da1997071))
 
 - **tests**: Update symbolic link creation and improve PHPUnit error handling
-  ([`ae628bc`](https://github.com/LibreBooking/app/commit/ae628bcce7f4fe82dcf77c5b42b27d51c1d0cf23))
+  ([`ae628bc`](https://github.com/LibreBooking/librebooking/commit/ae628bcce7f4fe82dcf77c5b42b27d51c1d0cf23))
 
 ### Chores
 
 - Update phpstan-baseline.neon
-  ([`200517a`](https://github.com/LibreBooking/app/commit/200517a5fe8c6f7451559c980579bdf9378d6a59))
+  ([`200517a`](https://github.com/LibreBooking/librebooking/commit/200517a5fe8c6f7451559c980579bdf9378d6a59))
 
 - **git**: Enforce LF line endings
-  ([`85a929f`](https://github.com/LibreBooking/app/commit/85a929f93753111d36bf1f45a1ce54b210ccc024))
+  ([`85a929f`](https://github.com/LibreBooking/librebooking/commit/85a929f93753111d36bf1f45a1ce54b210ccc024))
 
 - **git**: Normalize all line endings to LF
-  ([`b211a9a`](https://github.com/LibreBooking/app/commit/b211a9a5f9b6cf10c28a27fbc55d2a56d675490a))
+  ([`b211a9a`](https://github.com/LibreBooking/librebooking/commit/b211a9a5f9b6cf10c28a27fbc55d2a56d675490a))
 
 - **phpstan**: Update for 2.1.25 release
-  ([`86594c1`](https://github.com/LibreBooking/app/commit/86594c140cf09b96585ae7907ce7f82b46b804d8))
+  ([`86594c1`](https://github.com/LibreBooking/librebooking/commit/86594c140cf09b96585ae7907ce7f82b46b804d8))
 
 - **phpstan**: Update phpstan-baseline.neon
-  ([`79ac102`](https://github.com/LibreBooking/app/commit/79ac1027a52cc52d603f5428831564762f16fc3e))
+  ([`79ac102`](https://github.com/LibreBooking/librebooking/commit/79ac1027a52cc52d603f5428831564762f16fc3e))
 
 - **scripts**: Remove jQuery Timepicker plugin files
-  ([`1632653`](https://github.com/LibreBooking/app/commit/16326535d894ea6948e75f335595a3873af55993))
+  ([`1632653`](https://github.com/LibreBooking/librebooking/commit/16326535d894ea6948e75f335595a3873af55993))
 
 - **templates**: Remove unused Timepicker includes
-  ([`9d25543`](https://github.com/LibreBooking/app/commit/9d25543cb568a33077f82a6bbc88778dab18918d))
+  ([`9d25543`](https://github.com/LibreBooking/librebooking/commit/9d25543cb568a33077f82a6bbc88778dab18918d))
 
 ### Code Style
 
 - Enhance PHP-CS-Fixer rules with Symfony standards
-  ([`a42d5f8`](https://github.com/LibreBooking/app/commit/a42d5f8be34ba7fc0496b55301aa7688d030c190))
+  ([`a42d5f8`](https://github.com/LibreBooking/librebooking/commit/a42d5f8be34ba7fc0496b55301aa7688d030c190))
 
 - Redesign API help page with Bootstrap and improved UI
-  ([`3f13add`](https://github.com/LibreBooking/app/commit/3f13add6f5b2c98d92a23b2933025685237f8a20))
+  ([`3f13add`](https://github.com/LibreBooking/librebooking/commit/3f13add6f5b2c98d92a23b2933025685237f8a20))
 
 - **vscode**: Add initial `.vscode/settings.json`
-  ([`afae984`](https://github.com/LibreBooking/app/commit/afae98455c2e7f6f572703e1085d7176761f0556))
+  ([`afae984`](https://github.com/LibreBooking/librebooking/commit/afae98455c2e7f6f572703e1085d7176761f0556))
 
 ### Continuous Integration
 
 - Mark the 'develop' branch as a release branch
-  ([`02c4e20`](https://github.com/LibreBooking/app/commit/02c4e20673fabe7e7d2889c506006b3aec6cbbb6))
+  ([`02c4e20`](https://github.com/LibreBooking/librebooking/commit/02c4e20673fabe7e7d2889c506006b3aec6cbbb6))
 
 - Prevent merge-commits in a PR
-  ([`ebe5589`](https://github.com/LibreBooking/app/commit/ebe5589ae5f33749f205060f6c484f8d9b60219d))
+  ([`ebe5589`](https://github.com/LibreBooking/librebooking/commit/ebe5589ae5f33749f205060f6c484f8d9b60219d))
 
 - **cz-lint**: Give a more helpful message when 'cz' fails
-  ([`4a3a105`](https://github.com/LibreBooking/app/commit/4a3a1050d9f1d7d3dbdbf8b760640f5c50b6a906))
+  ([`4a3a105`](https://github.com/LibreBooking/librebooking/commit/4a3a1050d9f1d7d3dbdbf8b760640f5c50b6a906))
 
 - **release**: Add the 'id-token' permissions
-  ([`9b6b28a`](https://github.com/LibreBooking/app/commit/9b6b28a14d8a013b3032c3003a7d6337f537858e))
+  ([`9b6b28a`](https://github.com/LibreBooking/librebooking/commit/9b6b28a14d8a013b3032c3003a7d6337f537858e))
 
 - **release**: Setup an automated release system
-  ([`464e117`](https://github.com/LibreBooking/app/commit/464e117967ee33917f7147fed1d79a394cdf814d))
+  ([`464e117`](https://github.com/LibreBooking/librebooking/commit/464e117967ee33917f7147fed1d79a394cdf814d))
 
 - **release**: Use the 'release' environment
-  ([`397e1bf`](https://github.com/LibreBooking/app/commit/397e1bf9edc60a8ed591ea1c9a4cd7f72d7470e9))
+  ([`397e1bf`](https://github.com/LibreBooking/librebooking/commit/397e1bf9edc60a8ed591ea1c9a4cd7f72d7470e9))
 
 - **release**: Use the release token for the git checkout action
-  ([`bd1e881`](https://github.com/LibreBooking/app/commit/bd1e8815023a41c354da2cd9ca3de4d63ee3c3f1))
+  ([`bd1e881`](https://github.com/LibreBooking/librebooking/commit/bd1e8815023a41c354da2cd9ca3de4d63ee3c3f1))
 
 - **release**: Use the RELEASE_GITHUB_TOKEN
-  ([`1bdd93d`](https://github.com/LibreBooking/app/commit/1bdd93d5c4638d62609694348aa0c1a54391740a))
+  ([`1bdd93d`](https://github.com/LibreBooking/librebooking/commit/1bdd93d5c4638d62609694348aa0c1a54391740a))
 
 ### Documentation
 
 - Add info on privacy.view.schedules config option
-  ([`9fed6b2`](https://github.com/LibreBooking/app/commit/9fed6b2c4d436f1349a9ea14f0b97aa58a9f6b73))
+  ([`9fed6b2`](https://github.com/LibreBooking/librebooking/commit/9fed6b2c4d436f1349a9ea14f0b97aa58a9f6b73))
 
 - Update comment for privacy->view.schedules
-  ([`8ae0a5f`](https://github.com/LibreBooking/app/commit/8ae0a5f23f5ec8696ac8c9e9a3c13e5c09041b0c))
+  ([`8ae0a5f`](https://github.com/LibreBooking/librebooking/commit/8ae0a5f23f5ec8696ac8c9e9a3c13e5c09041b0c))
 
 - **auth**: Add detailed configuration instructions for LDAP and Active Directory authentication
-  ([`40b00f6`](https://github.com/LibreBooking/app/commit/40b00f6d7ced8b2166265538fbda9a66e82de34d))
+  ([`40b00f6`](https://github.com/LibreBooking/librebooking/commit/40b00f6d7ced8b2166265538fbda9a66e82de34d))
 
 - **auth**: Enhance description for Admin Username in Active Directory configuration
-  ([`c150e2f`](https://github.com/LibreBooking/app/commit/c150e2fa4442be385019d416a858d1d1aa94fd70))
+  ([`c150e2f`](https://github.com/LibreBooking/librebooking/commit/c150e2fa4442be385019d416a858d1d1aa94fd70))
 
 - **auth**: Enhance description for properties in plugins
-  ([`12dfeea`](https://github.com/LibreBooking/app/commit/12dfeeaff9c9bbbdd45af05ae3c2ce4b587131ea))
+  ([`12dfeea`](https://github.com/LibreBooking/librebooking/commit/12dfeeaff9c9bbbdd45af05ae3c2ce4b587131ea))
 
 ### Features
 
 - Improved error handling for missing configkey and api
-  ([`adc4637`](https://github.com/LibreBooking/app/commit/adc463791ed0e3c0eb8bf7cb3476840b04184fc7))
+  ([`adc4637`](https://github.com/LibreBooking/librebooking/commit/adc463791ed0e3c0eb8bf7cb3476840b04184fc7))
 
 - **reservation**: Highlight negative durations
-  ([`6c5a229`](https://github.com/LibreBooking/app/commit/6c5a229be23ca68319f0321fbbeedff9e77f7086))
+  ([`6c5a229`](https://github.com/LibreBooking/librebooking/commit/6c5a229be23ca68319f0321fbbeedff9e77f7086))
 
 - **resource-display.php**: Add allow-reservations config for tablet view
-  ([`ba22074`](https://github.com/LibreBooking/app/commit/ba2207434dcd18936bdc18871f7a11d46e3d180b))
+  ([`ba22074`](https://github.com/LibreBooking/librebooking/commit/ba2207434dcd18936bdc18871f7a11d46e3d180b))
 
 ### Refactoring
 
 - Pageload in Login presenter
-  ([`2a554b1`](https://github.com/LibreBooking/app/commit/2a554b1b94d29b226e0ae9b3c888decc5abc10a0))
+  ([`2a554b1`](https://github.com/LibreBooking/librebooking/commit/2a554b1b94d29b226e0ae9b3c888decc5abc10a0))
 
 - Replaced die for proper server response
-  ([`4c75a91`](https://github.com/LibreBooking/app/commit/4c75a918eb523620ba0d68af9bd944c9fca46d11))
+  ([`4c75a91`](https://github.com/LibreBooking/librebooking/commit/4c75a918eb523620ba0d68af9bd944c9fca46d11))
 
 - Unify time formats using period_time
-  ([`35f6295`](https://github.com/LibreBooking/app/commit/35f629520bc503cc0646d516dd4eacd3cec1e10e))
+  ([`35f6295`](https://github.com/LibreBooking/librebooking/commit/35f629520bc503cc0646d516dd4eacd3cec1e10e))
 
 - Url generation for external login
-  ([`26511e3`](https://github.com/LibreBooking/app/commit/26511e3f245230454bbee4804df3d6cecc55cff2))
+  ([`26511e3`](https://github.com/LibreBooking/librebooking/commit/26511e3f245230454bbee4804df3d6cecc55cff2))
 
 - **date-helper**: Drop moment.js for native dates
-  ([`0533579`](https://github.com/LibreBooking/app/commit/053357954a8b06294c0f558c8eaa8ff91451c870))
+  ([`0533579`](https://github.com/LibreBooking/librebooking/commit/053357954a8b06294c0f558c8eaa8ff91451c870))
 
 - **date-helper.js**: Centralize midnight handling in time-range validation
-  ([`c85fb34`](https://github.com/LibreBooking/app/commit/c85fb34e8ef29d5dcd9676d2c093b27160a74560))
+  ([`c85fb34`](https://github.com/LibreBooking/librebooking/commit/c85fb34e8ef29d5dcd9676d2c093b27160a74560))
 
 - **manage_blackouts**: Use dateHelper for timepickers
-  ([`3fe1f8a`](https://github.com/LibreBooking/app/commit/3fe1f8a3bda3247396e139cc09b9dc3d00d42b24))
+  ([`3fe1f8a`](https://github.com/LibreBooking/librebooking/commit/3fe1f8a3bda3247396e139cc09b9dc3d00d42b24))
 
 - **manage_peak_times**: Use raw times and centralize formatting
-  ([`f099d00`](https://github.com/LibreBooking/app/commit/f099d00c9938b99bdf66326d6d91fc0688af4de7))
+  ([`f099d00`](https://github.com/LibreBooking/librebooking/commit/f099d00c9938b99bdf66326d6d91fc0688af4de7))
 
 - **manage_quotas**: Integrate dateHelper & collapse in UI
-  ([`63b1782`](https://github.com/LibreBooking/app/commit/63b178277830ddc8a159770e083d051a2d89ad12))
+  ([`63b1782`](https://github.com/LibreBooking/librebooking/commit/63b178277830ddc8a159770e083d051a2d89ad12))
 
 - **manage_schedules**: DateHelper for peak pickers & validation
-  ([`348329b`](https://github.com/LibreBooking/app/commit/348329bab3e83aaccf6cc6944044b3d0ea7895ce))
+  ([`348329b`](https://github.com/LibreBooking/librebooking/commit/348329bab3e83aaccf6cc6944044b3d0ea7895ce))
 
 - **search-availability**: Use select pickers for time inputs
-  ([`a87100a`](https://github.com/LibreBooking/app/commit/a87100aa1bd103ffb249f630dd0b35e1aae3997b))
+  ([`a87100a`](https://github.com/LibreBooking/librebooking/commit/a87100aa1bd103ffb249f630dd0b35e1aae3997b))
 
 ### Testing
 
 - Allow unit tests to be run without setup
-  ([`d1221ff`](https://github.com/LibreBooking/app/commit/d1221ff4f0251ee3d3a3a90cb0100e04e4979e3a))
+  ([`d1221ff`](https://github.com/LibreBooking/librebooking/commit/d1221ff4f0251ee3d3a3a90cb0100e04e4979e3a))
 
 - Prevent flaky tests caused by midnight boundary issues
-  ([`c004670`](https://github.com/LibreBooking/app/commit/c004670124e8d947efb02143825de4457460c202))
+  ([`c004670`](https://github.com/LibreBooking/librebooking/commit/c004670124e8d947efb02143825de4457460c202))
 
 - Update AuthenticationWebServiceTest to expect response codes
-  ([`9c690f6`](https://github.com/LibreBooking/app/commit/9c690f65d33b42ceda739136d6bb366b5c5c0ca4))
+  ([`9c690f6`](https://github.com/LibreBooking/librebooking/commit/9c690f65d33b42ceda739136d6bb366b5c5c0ca4))
 
 - **auth**: Add comprehensive tests for authentication plugin configuration loading and validation
-  ([`5522764`](https://github.com/LibreBooking/app/commit/55227647df5e936f88f5baf7f81e398a1c45dfdb))
+  ([`5522764`](https://github.com/LibreBooking/librebooking/commit/55227647df5e936f88f5baf7f81e398a1c45dfdb))
 
 - **config**: Changed expected test values to reflect intended behavior of expecting a default value
-  ([`9f253ef`](https://github.com/LibreBooking/app/commit/9f253ef596940f87034ae449a50ad2016c3b046b))
+  ([`9f253ef`](https://github.com/LibreBooking/librebooking/commit/9f253ef596940f87034ae449a50ad2016c3b046b))
 
 - **timezone**: Replace deprecated US/* timezones with IANA equivalents
-  ([`8e7645b`](https://github.com/LibreBooking/app/commit/8e7645b8bac818a82d2e32b604becf70a6ff8fab))
+  ([`8e7645b`](https://github.com/LibreBooking/librebooking/commit/8e7645b8bac818a82d2e32b604becf70a6ff8fab))
 
 
 ## 4.0.0 - 2025-08-06
@@ -322,30 +322,30 @@
 
 ### What's Changed
 
-- style(manage_resources): don't default collapse CustomAttributes by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/682>
-- fix: EmailMessage.php variable defined after use by @lucs7 in <https://github.com/LibreBooking/app/pull/683>
-- fix: captchas not working by @lucs7 in <https://github.com/LibreBooking/app/pull/684>
-- fix(participation): add missing ParticipationNotification import by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/686>
-- chore: ensure all config variables are in both config files by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/689>
-- fix(reservation): fix the delete reason not submitted when a reservation is not approved. by @belcirelk in <https://github.com/LibreBooking/app/pull/696>
-- fix(reservation): pdf generation is not working in French by @belcirelk in <https://github.com/LibreBooking/app/pull/697>
-- fix(API): stop storing multiple custom attributes of same type for Reources by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/681>
-- chore: Replace jQuery UI datepicker with flatpickr by @labmecanicatec in <https://github.com/LibreBooking/app/pull/756>
-- fix(login): Language selector is not working due to httponly cookie by @belcirelk in <https://github.com/LibreBooking/app/pull/763>
-- fix: allow setting language for non-HTTPS by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/764>
-- chore: remove exec permission from some files by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/765>
-- chore: add text to the "More Resource Actions" drop-down by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/766>
-- refactor: timezone handling and remove jstz library by @labmecanicatec in <https://github.com/LibreBooking/app/pull/769>
-- feat: optional: resource contact may be chosen via a drop-down list of users by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/770>
-- Fix for reminders on cancelled reservations by @cgutteridge in <https://github.com/LibreBooking/app/pull/773>
-- Fix for phpunit tests and additional error check by @lucs7 in <https://github.com/LibreBooking/app/pull/774>
-- fix: error in WebAuthenticationTest and Facebook login by @lucs7 in <https://github.com/LibreBooking/app/pull/781>
+- style(manage_resources): don't default collapse CustomAttributes by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/682>
+- fix: EmailMessage.php variable defined after use by @lucs7 in <https://github.com/LibreBooking/librebooking/pull/683>
+- fix: captchas not working by @lucs7 in <https://github.com/LibreBooking/librebooking/pull/684>
+- fix(participation): add missing ParticipationNotification import by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/686>
+- chore: ensure all config variables are in both config files by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/689>
+- fix(reservation): fix the delete reason not submitted when a reservation is not approved. by @belcirelk in <https://github.com/LibreBooking/librebooking/pull/696>
+- fix(reservation): pdf generation is not working in French by @belcirelk in <https://github.com/LibreBooking/librebooking/pull/697>
+- fix(API): stop storing multiple custom attributes of same type for Reources by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/681>
+- chore: Replace jQuery UI datepicker with flatpickr by @labmecanicatec in <https://github.com/LibreBooking/librebooking/pull/756>
+- fix(login): Language selector is not working due to httponly cookie by @belcirelk in <https://github.com/LibreBooking/librebooking/pull/763>
+- fix: allow setting language for non-HTTPS by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/764>
+- chore: remove exec permission from some files by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/765>
+- chore: add text to the "More Resource Actions" drop-down by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/766>
+- refactor: timezone handling and remove jstz library by @labmecanicatec in <https://github.com/LibreBooking/librebooking/pull/769>
+- feat: optional: resource contact may be chosen via a drop-down list of users by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/770>
+- Fix for reminders on cancelled reservations by @cgutteridge in <https://github.com/LibreBooking/librebooking/pull/773>
+- Fix for phpunit tests and additional error check by @lucs7 in <https://github.com/LibreBooking/librebooking/pull/774>
+- fix: error in WebAuthenticationTest and Facebook login by @lucs7 in <https://github.com/LibreBooking/librebooking/pull/781>
 
 ### New Contributors
 
-- @belcirelk made their first contribution in <https://github.com/LibreBooking/app/pull/696>
+- @belcirelk made their first contribution in <https://github.com/LibreBooking/librebooking/pull/696>
 
-**Full Changelog**: <https://github.com/LibreBooking/app/compare/v3.0.3...v4.0.0>
+**Full Changelog**: <https://github.com/LibreBooking/librebooking/compare/v3.0.3...v4.0.0>
 
 ## 3.0.3 - 2025-07-09
 
@@ -356,17 +356,17 @@
 
 ### What's Changed
 
-- fix(API): add endpoint to get resource types by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/663>
-- remove old docs by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/665>
-- fix(schedule): datepicker conflicts with url validation by @lucs7 in <https://github.com/LibreBooking/app/pull/661>
-- Fix for #671 / Adjusting css to enable datepicker styling by @lucs7 in <https://github.com/LibreBooking/app/pull/673>
-- doc: remove trailing whitespace from *.rst files by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/674>
-- fix(CustomAttribute): handle invalid data by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/662>
-- fix: allow guests to book reservations by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/668>
-- update(docs): update installation documentation: cloning, composer setup, and database config by @labmecanicatec in <https://github.com/LibreBooking/app/pull/675>
-- docs: add link to API docs, use notes, update PHP version by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/676>
+- fix(API): add endpoint to get resource types by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/663>
+- remove old docs by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/665>
+- fix(schedule): datepicker conflicts with url validation by @lucs7 in <https://github.com/LibreBooking/librebooking/pull/661>
+- Fix for #671 / Adjusting css to enable datepicker styling by @lucs7 in <https://github.com/LibreBooking/librebooking/pull/673>
+- doc: remove trailing whitespace from *.rst files by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/674>
+- fix(CustomAttribute): handle invalid data by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/662>
+- fix: allow guests to book reservations by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/668>
+- update(docs): update installation documentation: cloning, composer setup, and database config by @labmecanicatec in <https://github.com/LibreBooking/librebooking/pull/675>
+- docs: add link to API docs, use notes, update PHP version by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/676>
 
-**Full Changelog**: <https://github.com/LibreBooking/app/compare/v3.0.2...v3.0.3>
+**Full Changelog**: <https://github.com/LibreBooking/librebooking/compare/v3.0.2...v3.0.3>
 
 ## 3.0.2 - 2025-07-07
 
@@ -376,21 +376,21 @@
 
 ### What's Changed
 
-- docs: add a `.readthedocs.yml` file by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/647>
-- docs: remove 'beta' designation of the `develop` branch by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/649>
-- docs: fix theme options list by @ClemCordier in <https://github.com/LibreBooking/app/pull/650>
-- Fix date and autogrow issues by @lucs7 in <https://github.com/LibreBooking/app/pull/657>
-- fix: correct datepicker issue introduced in e0cfcbc by @lucs7 in <https://github.com/LibreBooking/app/pull/658>
-- fix: don't attempt to reserve view-only resource by @JohnVillalovos in <https://github.com/LibreBooking/app/pull/656>
+- docs: add a `.readthedocs.yml` file by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/647>
+- docs: remove 'beta' designation of the `develop` branch by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/649>
+- docs: fix theme options list by @ClemCordier in <https://github.com/LibreBooking/librebooking/pull/650>
+- Fix date and autogrow issues by @lucs7 in <https://github.com/LibreBooking/librebooking/pull/657>
+- fix: correct datepicker issue introduced in e0cfcbc by @lucs7 in <https://github.com/LibreBooking/librebooking/pull/658>
+- fix: don't attempt to reserve view-only resource by @JohnVillalovos in <https://github.com/LibreBooking/librebooking/pull/656>
 
-**Full Changelog**: <https://github.com/LibreBooking/app/compare/v3.0.1...v3.0.2>
+**Full Changelog**: <https://github.com/LibreBooking/librebooking/compare/v3.0.1...v3.0.2>
 
 ## 3.0.1 - 2025-06-25
 
 Update the version number in the code base. This wa missed in the v3.0.0
 release.
 
-**Full Changelog**: <https://github.com/LibreBooking/app/compare/v3.0.0...v3.0.1>
+**Full Changelog**: <https://github.com/LibreBooking/librebooking/compare/v3.0.0...v3.0.1>
 
 ## 3.0.0 - 2025-06-24
 
@@ -403,25 +403,25 @@ release.
 - Improvements to the CI system.
 - Thanks to @labmecanicatec and @lucs7 for all their work this release.
 
-**Full Changelog**: <https://github.com/LibreBooking/app/compare/2.8.6.2...v3.0.0>
+**Full Changelog**: <https://github.com/LibreBooking/librebooking/compare/2.8.6.2...v3.0.0>
 
 ## 2.8.6.2 - 2024-08-18
 
-See all the changes at <https://github.com/LibreBooking/app/commits/develop>
+See all the changes at <https://github.com/LibreBooking/librebooking/commits/develop>
 
 ## 2.8.6.1 - 2023-09-26
 
-Mainly Bug fixes, special mention for the ldap plugin, more details at <https://github.com/LibreBooking/app/commits/develop>
+Mainly Bug fixes, special mention for the ldap plugin, more details at <https://github.com/LibreBooking/librebooking/commits/develop>
 
 ## 2.8.6 - 2023-04-18
 
 Librebooking now has PHP8 support
-Many bugs, updates and even new features were added but the list is a bit long so for further details please check the commit history <https://github.com/LibreBooking/app/commits/develop>
+Many bugs, updates and even new features were added but the list is a bit long so for further details please check the commit history <https://github.com/LibreBooking/librebooking/commits/develop>
 
 ## 2.8.5.5 - 2022-02-11
 
 **This version is no longer developed by Twinkle Toes Software (<https://www.bookedscheduler.com>)**
-Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/app](https://github.com/LibreBooking/app)  
+Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/librebooking](https://github.com/LibreBooking/librebooking)  
 Fork this repo, contribute and help keep it alive
 
 Small update to fix a security issue
@@ -429,15 +429,15 @@ Small update to fix a security issue
 ## 2.8.5.4 - 2021-09-03
 
 **This version is no longer developed by Twinkle Toes Software (<https://www.bookedscheduler.com>)**
-Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/app](https://github.com/LibreBooking/app)  
+Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/librebooking](https://github.com/LibreBooking/librebooking)  
 Fork this repo, contribute and help keep it alive
 
-Way too many changes, bugfixes and improvements to list them all here, so please take a look at: [https://github.com/LibreBooking/app/commits/master](https://github.com/LibreBooking/app/commits/master)
+Way too many changes, bugfixes and improvements to list them all here, so please take a look at: [https://github.com/LibreBooking/librebooking/commits/master](https://github.com/LibreBooking/librebooking/commits/master)
 
 ## 2.8.5.3 - 2021-03-10
 
 **This version is no longer developed by Twinkle Toes Software (<https://www.bookedscheduler.com>)**
-Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/app](https://github.com/LibreBooking/app)  
+Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/librebooking](https://github.com/LibreBooking/librebooking)  
 Fork this repo, contribute and help keep it alive
 
 - Added translation: Greek
@@ -447,13 +447,13 @@ Fork this repo, contribute and help keep it alive
 ## 2.8.5.2 - 2021-01-25
 
 **This version is no longer developed by Twinkle Toes Software (<https://www.bookedscheduler.com>)**
-Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/app](<https://github.com/LibreBooking/app>)  
+Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/librebooking](<https://github.com/LibreBooking/librebooking>)  
 Fork this repo, contribute and help keep it alive - Bugfixes
 
 ## 2.8.5.1 - 2020-11-11
 
 **This version is no longer developed by Twinkle Toes Software (<https://www.bookedscheduler.com>)**
-Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/app](<https://github.com/LibreBooking/app>)
+Based on the original open source version of Booked, now available at: [https://github.com/LibreBooking/librebooking](<https://github.com/LibreBooking/librebooking>)
 
 Fork this repo, contribute and help keep it alive - Added intial support for generating pdf's on the reservation page
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 
 # Librebooking
 
-[![GitHub issues](https://img.shields.io/github/issues/LibreBooking/app)](https://github.com/LibreBooking/app/issues)
-[![Last commit](https://img.shields.io/github/last-commit/LibreBooking/app)](https://github.com/LibreBooking/app/commits)
-[![GitHub release](https://img.shields.io/github/v/release/LibreBooking/app?include_prereleases)](https://github.com/LibreBooking/app/releases)
-[![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/LibreBooking/app/blob/develop/LICENSE.md)
+[![GitHub issues](https://img.shields.io/github/issues/LibreBooking/librebooking)](https://github.com/LibreBooking/librebooking/issues)
+[![Last commit](https://img.shields.io/github/last-commit/LibreBooking/librebooking)](https://github.com/LibreBooking/librebooking/commits)
+[![GitHub release](https://img.shields.io/github/v/release/LibreBooking/librebooking?include_prereleases)](https://github.com/LibreBooking/librebooking/releases)
+[![License: GPL v3](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://github.com/LibreBooking/librebooking/blob/develop/LICENSE.md)
 
-[![GitHub stars](https://img.shields.io/github/stars/LibreBooking/app?style=flat)](https://github.com/LibreBooking/app/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/LibreBooking/app?style=flat)](https://github.com/LibreBooking/app/network)
+[![GitHub stars](https://img.shields.io/github/stars/LibreBooking/librebooking?style=flat)](https://github.com/LibreBooking/librebooking/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/LibreBooking/librebooking?style=flat)](https://github.com/LibreBooking/librebooking/network)
 
 [![PHP](https://img.shields.io/badge/PHP-8.2%2B-brightgreen.svg?logo=php)](https://www.php.net/)
 [![MySQL](https://img.shields.io/badge/MySQL-5.5%2B-blue.svg?logo=mysql)](https://www.mysql.com/)
@@ -18,7 +18,7 @@
 [![Docker pulls](https://img.shields.io/docker/pulls/librebooking/librebooking)](https://github.com/LibreBooking/docker)
 
 [![Discord](https://img.shields.io/badge/Discord-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/4TGThPtmX8)
-[![Wiki](https://img.shields.io/badge/Wiki-Available-lightgrey?logo=read-the-docs)](https://github.com/LibreBooking/app/wiki)
+[![Wiki](https://img.shields.io/badge/Wiki-Available-lightgrey?logo=read-the-docs)](https://github.com/LibreBooking/librebooking/wiki)
 
 ⭐ Star us on GitHub — it motivates us a lot!
 
@@ -46,7 +46,7 @@ flexible, mobile-friendly, and extensible interface for organizations to manage
 resource reservations.
 
 The repository for LibreBooking is hosted on GitHub at
-<https://github.com/LibreBooking/app>; the `develop` branch contains the latest
+<https://github.com/LibreBooking/librebooking>; the `develop` branch contains the latest
 code.
 
 LibreBooking is a fork of Booked Scheduler, based on Booked Scheduler's last
@@ -100,7 +100,7 @@ To run LibreBooking from a prebuilt release, your server needs:
 - Git (optional, useful for cloning the repository or managing updates)
 
 For full setup instructions, see
-[INSTALLATION](https://github.com/LibreBooking/app/blob/develop/docs/source/INSTALLATION.rst)
+[INSTALLATION](https://github.com/LibreBooking/librebooking/blob/develop/docs/source/INSTALLATION.rst)
 
 ### Docker Deployment
 
@@ -115,23 +115,22 @@ docker-compose up -d
 ## 💻 Developer Documentation
 
 - See
-  [docs/source/README.md](https://github.com/LibreBooking/app/blob/develop/docs/source/DEVELOPER-README.rst
-)
+  [docs/source/README.md](https://github.com/LibreBooking/librebooking/blob/develop/docs/source/DEVELOPER-README.rst)
   for developer notes.
-- See [docs/source/API.md](https://github.com/LibreBooking/app/blob/develop/docs/source/API.rst)
+- See [docs/source/API.rst](https://github.com/LibreBooking/librebooking/blob/develop/docs/source/API.rst)
   for API notes.
 - See
-  [docs/source/Oauth2-Configuration.md](https://github.com/LibreBooking/app/blob/develop/docs/source/Oauth2-Configuration.rst)
+  [docs/source/Oauth2-Configuration.rst](https://github.com/LibreBooking/librebooking/blob/develop/docs/source/Oauth2-Configuration.rst)
   for Oauth2 configuration.
 - See
-  [docs/source/SAML-Configuration.md](https://github.com/LibreBooking/app/blob/develop/docs/source/SAML-Configuration.rst)
+  [docs/source/SAML-Configuration.rst](https://github.com/LibreBooking/librebooking/blob/develop/docs/source/SAML-Configuration.rst)
   for SAML configuration.
 - Codebase follows PSR-12 standards and GitHub Flow.
 
 ## 🎨 Configuration & Theming
 
 For configuration options, see the
-[Configuration Guide](https://github.com/LibreBooking/app/blob/develop/docs/source/CONFIGURATION.rst).
+[Configuration Guide](https://github.com/LibreBooking/librebooking/blob/develop/docs/source/CONFIGURATION.rst).
 
 Recent configuration highlights:
 
@@ -151,9 +150,9 @@ As of 09-Mar-2023, ReCaptcha integration updated to v3. Generate new keys for yo
 ## 💬 Community & Support
 
 - [Discord](https://discord.gg/4TGThPtmX8)
-- [Wiki](https://github.com/LibreBooking/app/wiki)
-- [Issues](https://github.com/LibreBooking/app/issues)
-- [Discussions](https://github.com/LibreBooking/app/discussions)
+- [Wiki](https://github.com/LibreBooking/librebooking/wiki)
+- [Issues](https://github.com/LibreBooking/librebooking/issues)
+- [Discussions](https://github.com/LibreBooking/librebooking/discussions)
 
 ## 🤝 Contributing
 
@@ -165,7 +164,7 @@ As of 09-Mar-2023, ReCaptcha integration updated to v3. Generate new keys for yo
 ## 💡 Roadmap
 
 _Work in progress – roadmap to be defined._  
-Want to suggest a feature? [Open an issue](https://github.com/LibreBooking/app/issues) or join the [Discord discussion channel](https://discord.gg/4TGThPtmX8).
+Want to suggest a feature? [Open an issue](https://github.com/LibreBooking/librebooking/issues) or join the [Discord discussion channel](https://discord.gg/4TGThPtmX8).
 
 ## 📜 License
 

--- a/docs/source/INSTALLATION.rst
+++ b/docs/source/INSTALLATION.rst
@@ -48,7 +48,7 @@ Alternatively, you can clone the application directly from the official GitHub r
 
 .. code-block:: bash
 
-    git clone https://github.com/LibreBooking/app.git
+    git clone https://github.com/LibreBooking/librebooking.git
 
 After copying or cloning the application to your web server:
 
@@ -56,7 +56,7 @@ Install PHP dependencies using Composer:
 
    .. code-block:: bash
 
-       cd app
+       cd librebooking
        composer install
 
 Copy ``/config/config.dist.php`` to ``/config/config.php`` and adjust
@@ -86,10 +86,10 @@ minimal default settings which should be enough for the application to work.
 Copy ``/config/config.dist.php`` to ``/config/config.php`` and adjust
 the settings for your environment.
 
-For detailed information on all configuration options, see :doc:`BASIC-CONFIGURATION` 
+For detailed information on all configuration options, see :doc:`BASIC-CONFIGURATION`
 for essential settings or :doc:`ADVANCED-CONFIGURATION` for comprehensive options.
 
-The admin email address can be set in the ``config/config.php`` file in the 
+The admin email address can be set in the ``config/config.php`` file in the
 settings array as ``'admin.email' => 'admin@example.com'``
 
 When you later register an account with the admin email address, the user will be given
@@ -170,7 +170,7 @@ Manual Database Setup
   database configuration and set default values.
 | Please edit them to suit your environment before running. The files
   are located in ``librebooking/database_schema/``
-| 
+|
 | The following SQL files are available:
 | - ``create-db.sql`` - Creates the database
 | - ``create-user.sql`` - Creates the database user (optional)
@@ -183,16 +183,16 @@ Manual Database Setup
 
 .. important::
    **Correct Import Order**
-   
+
    The automated installer (Web/install) follows this sequence:
-   
+
    1. ``create-schema.sql`` - Base table structure
    2. All upgrade scripts in ``database_schema/upgrades/`` (in version order)
    3. ``create-data.sql`` - Initial data (depends on upgraded schema)
    4. ``sample-data-utf8.sql`` (optional) - Sample data for testing
-   
-   **Warning:** Simply running create-schema.sql followed by create-data.sql will fail 
-   because create-data.sql expects the fully upgraded schema including all modifications 
+
+   **Warning:** Simply running create-schema.sql followed by create-data.sql will fail
+   because create-data.sql expects the fully upgraded schema including all modifications
    from the upgrade scripts.
 
 | Import the SQL files in the following order (we recommend
@@ -229,7 +229,7 @@ file.
 | Import ``/database_schema/create-schema.sql`` to librebooking (or
   whatever database name was used in the creation process)
 | Import all upgrade scripts from ``/database_schema/upgrades/`` in version order.
-  For each version directory (2.1, 2.2, 2.3, etc.), import first the ``schema.sql`` 
+  For each version directory (2.1, 2.2, 2.3, etc.), import first the ``schema.sql``
   then the ``data.sql`` file if they exist.
 | Import ``/database_schema/create-data.sql`` to librebooking (or
   whatever database name was used in the creation process)
@@ -349,7 +349,7 @@ Quick Start with Docker Compose
             - PGID=1000
             - TZ=America/New_York
             - MYSQL_ROOT_PASSWORD=your_secure_root_password
-        
+
         app:
           image: librebooking/librebooking:develop
           restart: always
@@ -492,7 +492,7 @@ Docker Troubleshooting
   -  Check container has write permissions to volumes
   -  Use named volumes instead of bind mounts for easier management
 
-For more detailed Docker configuration options and advanced setups, see the 
+For more detailed Docker configuration options and advanced setups, see the
 `LibreBooking Docker repository <https://github.com/LibreBooking/docker>`__.
 
 Registering the Administrator Account
@@ -611,8 +611,8 @@ application or database logs. To do this:
    in your configuration file to an appropriate level. For example,
    set ``'logging' => ['level' => 'debug']`` within the settings array.
 
-For detailed information on all logging and other configuration options, 
-see :doc:`BASIC-CONFIGURATION` for essential settings or :doc:`ADVANCED-CONFIGURATION` 
+For detailed information on all logging and other configuration options,
+see :doc:`BASIC-CONFIGURATION` for essential settings or :doc:`ADVANCED-CONFIGURATION`
 for comprehensive options.
 
 

--- a/tpl/Admin/Configuration/manage_configuration.tpl
+++ b/tpl/Admin/Configuration/manage_configuration.tpl
@@ -94,7 +94,7 @@
     {if $IsPageEnabled && $IsConfigFileWritable}
         <div class="card shadow">
             <div class="card-body">
-                {assign var=HelpUrl value="https://github.com/LibreBooking/app/wiki/Administration"}
+                {assign var=HelpUrl value="https://github.com/LibreBooking/librebooking/wiki/Administration"}
                 <h3 class="text-center border-bottom mb-3">{translate key=ConfigurationUpdateHelp args=$HelpUrl}</h3>
                 <div id="updatedMessage" class="alert alert-success" style="display:none;">
                     {translate key=ConfigurationUpdated}
@@ -126,7 +126,7 @@
                                     </div>
                                 </div>
                             {/if}
-                            
+
                             {foreach from=$SectionSettings key=section item=settings}
                                 <div>
                                     <div class="accordion-item shadow mb-2">

--- a/tpl/ResourceDisplay/resource-display-instructions.tpl
+++ b/tpl/ResourceDisplay/resource-display-instructions.tpl
@@ -1,7 +1,7 @@
 {include file='globalheader.tpl' HideNavBar=true}
 <div class="alert alert-danger mt-4">
 	{translate key=ResourceDisplayInstructions}
-	<a href="https://github.com/LibreBooking/app/wiki/Administration" target="blank" class="alert-link"><i
+	<a href="https://github.com/LibreBooking/librebooking/wiki/Administration" target="_blank" class="alert-link"><i
 			class="bi bi-question-circle-fill mx-1"></i>{translate key=Help}</a>
 </div>
 {include file='globalfooter.tpl'}

--- a/tpl/globalfooter.tpl
+++ b/tpl/globalfooter.tpl
@@ -4,7 +4,7 @@
 	</div>
 	<footer class="bg-light border-top text-center pt-2">
 		<div><a class="link-primary" href="{$CompanyUrl}">{$CompanyName}</a></div>
-		<div><a class="link-primary" href="https://github.com/LibreBooking/app">LibreBooking - GPLv3
+		<div><a class="link-primary" href="https://github.com/LibreBooking/librebooking">LibreBooking - GPLv3
 				v{$Version}</a></div>
 	</footer>
 

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -379,7 +379,7 @@
                                         </li>
                                         <li id="navNewVersion" class="new-version">
                                             <a class="dropdown-item"
-                                                href="https://github.com/LibreBooking/app/releases">{translate key=WhatsNew}</a>
+                                                href="https://github.com/LibreBooking/librebooking/releases">{translate key=WhatsNew}</a>
                                         </li>
                                     {/if}
                                 </ul>
@@ -390,11 +390,11 @@
                                 data-bs-toggle="dropdown">{translate key="Help"}</a>
                             <ul class="dropdown-menu  dropdown-menu-end">
                                 <li id="navHelp"><a class="dropdown-item"
-                                        href="https://github.com/LibreBooking/app/wiki">{translate key=Help}</a>
+                                        href="https://github.com/LibreBooking/librebooking/wiki">{translate key=Help}</a>
                                 </li>
                                 {if isset($CanViewAdmin) && $CanViewAdmin}
                                     <li id="navHelpAdmin"><a class="dropdown-item"
-                                            href="https://github.com/LibreBooking/app/wiki/Administration">{translate key=Administration}</a>
+                                            href="https://github.com/LibreBooking/librebooking/wiki/Administration">{translate key=Administration}</a>
                                     </li>
                                 {/if}
                                 <li id="navAbout"><a class="dropdown-item"

--- a/tpl/support-and-credits.tpl
+++ b/tpl/support-and-credits.tpl
@@ -8,7 +8,7 @@
 
                 <h2>Support</h2>
 
-                <p><a class="link-primary" href="https://github.com/LibreBooking/app">LibreBooking Support</a></p>
+                <p><a class="link-primary" href="https://github.com/LibreBooking/librebooking">LibreBooking Support</a></p>
 
                 <p><a class="link-primary" href="https://discord.gg/4TGThPtmX8">LibreBooking Community discussion channel
                         on Discord</a></p>
@@ -16,7 +16,7 @@
                 <h2>Credits</h2>
 
                 <p>see <a class="link-primary"
-                        href="https://github.com/LibreBooking/app/blob/master/CONTRIBUTORS.md">CONTRIBUTORS.md</a>
+                        href="https://github.com/LibreBooking/librebooking/blob/develop/CONTRIBUTORS.md">CONTRIBUTORS.md</a>
                 </p>
 
                 <h2>License</h2>


### PR DESCRIPTION
Update the documentation and other files to reflect the new repository location at https://github.com/LibreBooking/librebooking