### PR TITLE
chore(phpstan): add comments to `phpstan.neon`

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,6 +16,7 @@ parameters:
         - lang
         - lib
         - phing-tasks
+        # Keep `plugins` in paths so PHPStan can scan symbols used via dynamic plugin loading.
         - plugins
         - tests
     excludePaths:
@@ -24,6 +25,9 @@ parameters:
             - Web/scripts/
             - build/ (?)
             - lib/external/
+            # Do not report diagnostics inside `plugins`: The
+            # legacy/third-party code is noisy. This keeps analysis focused on
+            # core app code while still allowing symbol discovery.
             - plugins/
             - tpl_c/ (?)
             - vendor/


### PR DESCRIPTION
Explain why we scan the `plugins\` directory but don't analyze it.