### PR TITLE
refactor(ldap)!: switch LDAP server config from host/port to uri

### DIFF
--- a/docs/source/LDAP-Authentication.rst
+++ b/docs/source/LDAP-Authentication.rst
@@ -52,7 +52,7 @@ options with detailed comments explaining each setting. You can also view and
 modify these settings through the web admin interface at **Application
 Management > Configuration**. Key settings include:
 
-- **host**: LDAP server URL(s)
+- **uri**: LDAP URI string. For multiple servers, use a space-separated list of URIs.
 - **binddn/bindpw**: Service account credentials for directory searches
 - **basedn**: Base DN where users are located
 - **user.id.attribute**: LDAP attribute for username lookup (typically ``uid``)
@@ -62,14 +62,46 @@ Management > Configuration**. Key settings include:
 
 .. important::
 
-   The ``host`` value must include the LDAP scheme, for example
+   The ``uri`` value must include the LDAP scheme, for example
    ``ldap://ldap.example.com`` or ``ldaps://ldap.example.com``.
    A bare hostname such as ``ldap.example.com`` is not enough.
 
+URI examples:
+
+.. code-block:: php
+
+   // single LDAP server (unencrypted LDAP, explicit port)
+   'uri' => 'ldap://ldap1.example.com:389',
+
+   // single LDAP server (unencrypted LDAP, default port 389)
+   'uri' => 'ldap://ldap1.example.com',
+
+   // single LDAP server over LDAPS (TLS, explicit port)
+   'uri' => 'ldaps://ldap1.example.com:636',
+
+   // single LDAP server over LDAPS (TLS, default port 636)
+   'uri' => 'ldaps://ldap1.example.com',
+
+   // multiple LDAP servers (space-separated URIs in one string)
+   'uri' => 'ldap://ldap1.example.com:389 ldap://ldap2.example.com:389',
+
+   // multiple LDAPS servers
+   'uri' => 'ldaps://ldap1.example.com:636 ldaps://ldap2.example.com:636',
+
+Port defaults:
+
+- ``ldap://`` uses port ``389`` by default when no port is specified.
+- ``ldaps://`` uses port ``636`` by default when no port is specified.
+
+Breaking change:
+
+- ``host`` and ``port`` are no longer supported.
+- Configure LDAP endpoints only through ``uri``.
+
 Alternatively, configure the plugin through the web admin interface at
 **Application Configuration** (``/Web/admin/manage_configuration.php``) and
-select **Authentification-Ldap**.
-Refer to ``/plugins/Authentication/Ldap/Ldap.config.dist.php`` for complete
+select **Authentication-Ldap**. Refer to
+``/plugins/Authentication/Ldap/Ldap.config.dist.php`` for complete
 documentation of all options.
 
 Troubleshooting
@@ -89,7 +121,7 @@ Common Issues
 ~~~~~~~~~~~~~
 
 **Connection failures**
-  - Verify server hostname and port accessibility
+  - Verify LDAP URI hostname and port accessibility
   - Check firewall rules
   - Test with ``telnet ldap.example.com 389``
 

--- a/plugins/Authentication/Ldap/Ldap.config.dist.php
+++ b/plugins/Authentication/Ldap/Ldap.config.dist.php
@@ -6,11 +6,16 @@
 return [
     'settings' => [
         'ldap' => [
-            // comma separated list of ldap servers such as ldap://mydomain1,ldap://localhost
-            'host' => 'ldap://localhost',
-
-            // default ldap port 389 or 636 for ssl.
-            'port' => 389,
+            // LDAP URI(s). For multiple servers, separate each URI with spaces.
+            // If no port is specified, defaults are: ldap:// = 389, ldaps:// = 636.
+            // examples:
+            //   'ldap://ldap1.example.com'
+            //   'ldap://ldap1.example.com:389'
+            //   'ldaps://ldap1.example.com'
+            //   'ldaps://ldap1.example.com:636'
+            //   'ldap://ldap1.example.com:389 ldap://ldap2.example.com:389'
+            //   'ldaps://ldap1.example.com:636 ldaps://ldap2.example.com:636'
+            'uri' => 'ldap://localhost:389',
 
             // LDAP protocol version
             'version' => 3,

--- a/plugins/Authentication/Ldap/Ldap.php
+++ b/plugins/Authentication/Ldap/Ldap.php
@@ -108,7 +108,13 @@ class Ldap extends Authentication implements IAuthentication
         $this->password = $password;
 
         $username = $this->CleanUsername($username);
-        $connected = $this->ldap->Connect();
+
+        try {
+            $connected = $this->ldap->Connect();
+        } catch (RuntimeException $e) {
+            Log::Error('LDAP configuration error: %s', $e->getMessage());
+            throw $e;
+        }
 
         if (!$connected) {
             throw new Exception('Could not connect to LDAP server. Please check your LDAP configuration settings');

--- a/plugins/Authentication/Ldap/LdapConfigKeys.php
+++ b/plugins/Authentication/Ldap/LdapConfigKeys.php
@@ -6,21 +6,12 @@ class LdapConfigKeys extends PluginConfigKeys
 {
     public const CONFIG_ID = 'ldap';
 
-    public const HOST = [
-        'key' => 'host',
+    public const URI = [
+        'key' => 'uri',
         'type' => 'string',
         'default' => '',
-        'label' => 'LDAP Host',
-        'description' => 'Hostname or IP address of LDAP server. Should start with ldap:// or ldaps://',
-        'section' => 'ldap'
-    ];
-
-    public const PORT = [
-        'key' => 'port',
-        'type' => 'integer',
-        'default' => 389,
-        'label' => 'LDAP Port',
-        'description' => 'Port of LDAP server (usually 389 or 636 for SSL)',
+        'label' => 'LDAP server URI(s)',
+        'description' => 'LDAP server URI(s). Use ldap:// or ldaps://. For multiple servers, separate URIs with spaces.',
         'section' => 'ldap'
     ];
 

--- a/plugins/Authentication/Ldap/LdapOptions.php
+++ b/plugins/Authentication/Ldap/LdapOptions.php
@@ -5,6 +5,10 @@ require_once(ROOT_DIR . '/lib/Config/namespace.php');
 class LdapOptions
 {
     private $_options = [];
+    /**
+     * @var array<string, mixed>
+     */
+    private $rawLdapSettings = [];
 
     public function __construct()
     {
@@ -13,8 +17,6 @@ class LdapOptions
             $configPath = dirname(__FILE__) . '/Ldap.config.dist.php';
         }
 
-        require_once($configPath);
-
         Configuration::Instance()->Register(
             $configPath,
             '',
@@ -22,13 +24,15 @@ class LdapOptions
             false,
             LdapConfigKeys::class
         );
+
+        $allValues = Configuration::Instance()->File(LdapConfigKeys::CONFIG_ID)->GetValues();
+        $this->rawLdapSettings = $allValues['ldap'] ?? [];
     }
 
     public function Ldap2Config()
     {
-        $hosts = $this->GetHosts();
+        $hosts = $this->GetUris();
         $this->SetOption('host', $hosts);
-        $this->SetOption('port', $this->GetConfig(LdapConfigKeys::PORT, new IntConverter()));
         $this->SetOption('starttls', $this->GetConfig(LdapConfigKeys::STARTTLS, new BooleanConverter()));
         $this->SetOption('version', $this->GetConfig(LdapConfigKeys::VERSION, new IntConverter()));
         $this->SetOption('binddn', $this->GetConfig(LdapConfigKeys::BINDDN));
@@ -47,7 +51,7 @@ class LdapOptions
 
     public function Controllers()
     {
-        return $this->GetHosts();
+        return $this->GetUris();
     }
 
     private function SetOption($key, $value)
@@ -64,15 +68,35 @@ class LdapOptions
         return Configuration::Instance()->File(LdapConfigKeys::CONFIG_ID)->GetKey($configDef, $converter);
     }
 
-    private function GetHosts()
+    private function GetUris()
     {
-        $hosts = explode(',', $this->GetConfig(LdapConfigKeys::HOST));
+        $this->AssertLegacyHostPortNotConfigured();
 
-        for ($i = 0; $i < count($hosts); $i++) {
-            $hosts[$i] = trim($hosts[$i]);
+        $uriConfig = trim($this->GetConfig(LdapConfigKeys::URI));
+        if (empty($uriConfig)) {
+            throw new RuntimeException("LDAP setting 'uri' is required and must contain at least one ldap:// or ldaps:// URI.");
         }
 
-        return $hosts;
+        $uris = preg_split('/\s+/', $uriConfig) ?: [];
+        foreach ($uris as $uri) {
+            $scheme = parse_url($uri, PHP_URL_SCHEME);
+            $host = parse_url($uri, PHP_URL_HOST);
+
+            if (!in_array($scheme, ['ldap', 'ldaps'], true) || empty($host)) {
+                throw new RuntimeException(
+                    sprintf("Invalid LDAP URI '%s'. Use ldap:// or ldaps:// with a hostname. For multiple servers, separate URIs with spaces.", $uri)
+                );
+            }
+        }
+
+        return $uris;
+    }
+
+    private function AssertLegacyHostPortNotConfigured()
+    {
+        if (array_key_exists('host', $this->rawLdapSettings) || array_key_exists('port', $this->rawLdapSettings)) {
+            throw new RuntimeException("LDAP settings 'host' and 'port' have been removed. Use only the 'uri' setting.");
+        }
     }
 
     public function BaseDn()

--- a/tests/Plugins/Authentication/Ldap/LdapTest.php
+++ b/tests/Plugins/Authentication/Ldap/LdapTest.php
@@ -98,6 +98,19 @@ class LdapTest extends TestBase
         $this->assertTrue($this->fakeLdap->_AuthenticateCalled);
     }
 
+    public function testValidateRethrowsRuntimeExceptionFromConnect()
+    {
+        $exception = new RuntimeException("LDAP settings 'host' and 'port' have been removed. Use only the 'uri' setting.");
+        $this->fakeLdap->_ConnectException = $exception;
+
+        $auth = new Ldap($this->fakeAuth, $this->fakeLdap, $this->fakeLdapOptions);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("LDAP settings 'host' and 'port' have been removed");
+
+        $auth->Validate($this->username, $this->password);
+    }
+
     public function testDoesNotTryToLoadUserDetailsIfNotValid()
     {
         $this->fakeLdap->_ExpectedAuthenticate = false;
@@ -186,8 +199,7 @@ class LdapTest extends TestBase
 
     public function testConstructsOptionsCorrectly()
     {
-        $hosts = 'localhost, localhost.2';
-        $port = '389';
+        $uris = 'ldap://localhost:389 ldap://localhost.2:389';
         $binddn = 'cn=admin,ou=users,dc=example,dc=org';
         $password = 'pw';
         $base = 'dc=example,dc=org';
@@ -195,8 +207,7 @@ class LdapTest extends TestBase
         $version = '3';
 
         $configFile = new FakeConfigFile();
-        $configFile->SetKey(LdapConfigKeys::HOST, $hosts);
-        $configFile->SetKey(LdapConfigKeys::PORT, $port);
+        $configFile->SetKey(LdapConfigKeys::URI, $uris);
         $configFile->SetKey(LdapConfigKeys::BINDDN, $binddn);
         $configFile->SetKey(LdapConfigKeys::BINDPW, $password);
         $configFile->SetKey(LdapConfigKeys::BASEDN, $base);
@@ -209,8 +220,7 @@ class LdapTest extends TestBase
         $options = $ldapOptions->Ldap2Config();
 
         $this->assertNotNull($this->fakeConfig->_RegisteredFiles[LdapConfigKeys::CONFIG_ID]);
-        $this->assertEquals('localhost', $options['host'][0], 'domain_controllers must be an array');
-        $this->assertEquals(intval($port), $options['port'], 'port should be int');
+        $this->assertEquals('ldap://localhost:389', $options['host'][0], 'controllers must be an array of URIs');
         $this->assertEquals($binddn, $options['binddn']);
         $this->assertEquals($password, $options['bindpw']);
         $this->assertEquals($base, $options['basedn']);
@@ -220,15 +230,51 @@ class LdapTest extends TestBase
 
     public function testGetAllHosts()
     {
-        $controllers = 'localhost, localhost.2';
+        $controllers = 'ldap://localhost:389 ldap://localhost.2:389';
 
         $configFile = new FakeConfigFile();
-        $configFile->SetKey(LdapConfigKeys::HOST, $controllers);
+        $configFile->SetKey(LdapConfigKeys::URI, $controllers);
         $this->fakeConfig->SetFile(LdapConfigKeys::CONFIG_ID, $configFile);
 
         $options = new LdapOptions();
 
-        $this->assertEquals(['localhost', 'localhost.2'], $options->Controllers(), 'comma separated values should become array');
+        $this->assertEquals(['ldap://localhost:389', 'ldap://localhost.2:389'], $options->Controllers(), 'space separated uris should become array');
+    }
+
+    public function testThrowsIfLegacyHostIsConfigured()
+    {
+        $configFile = new FakeConfigFile();
+        $configFile->SetKey([
+            'key' => 'host',
+            'section' => 'ldap',
+            'type' => 'string',
+        ], 'ldap://localhost');
+        $this->fakeConfig->SetFile(LdapConfigKeys::CONFIG_ID, $configFile);
+
+        $options = new LdapOptions();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("LDAP settings 'host' and 'port' have been removed");
+
+        $options->Ldap2Config();
+    }
+
+    public function testThrowsIfLegacyPortIsConfigured()
+    {
+        $configFile = new FakeConfigFile();
+        $configFile->SetKey([
+            'key' => 'port',
+            'section' => 'ldap',
+            'type' => 'string',
+        ], '389');
+        $this->fakeConfig->SetFile(LdapConfigKeys::CONFIG_ID, $configFile);
+
+        $options = new LdapOptions();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("LDAP settings 'host' and 'port' have been removed");
+
+        $options->Ldap2Config();
     }
 
     public function testUserHandlesArraysAsAttribute()
@@ -345,6 +391,10 @@ class LdapIntegrationTest extends TestBase
 
 class FakeLdapOptions extends LdapOptions
 {
+    public function __construct()
+    {
+    }
+
     public $_RetryAgainstDatabase = false;
 
     public function RetryAgainstDatabase()
@@ -391,9 +441,14 @@ class FakeLdapWrapper extends Ldap2Wrapper
 
     public $_ExpectedLdapUser;
 
+    public ?\RuntimeException $_ConnectException = null;
+
     public function Connect()
     {
         $this->_ConnectCalled = true;
+        if ($this->_ConnectException !== null) {
+            throw $this->_ConnectException;
+        }
         return $this->_ExpectedConnect;
     }
 

--- a/tests/fakes/FakeConfig.php
+++ b/tests/fakes/FakeConfig.php
@@ -141,6 +141,11 @@ class FakeConfigFile extends ConfigurationFile implements IConfigurationFile
         }
     }
 
+    public function GetValues(): array
+    {
+        return $this->_values;
+    }
+
     public function EnableSubscription()
     {
     }


### PR DESCRIPTION
To work better with PHP's `ldap_connect()` function, we have switched to
requiring a URI to specify the LDAP server(s).

This allows specifying multiple LDAP servers, if desired.

BREAKING CHANGE: LDAP plugin configuration now requires `uri` and no
longer supports `host` or `port`. Migrate to: `'uri' =>
'ldap://host:389'` or `'uri' => 'ldaps://host:636'` For multiple
servers, provide a space-separated URI string.
