### PR TITLE
style(data-cleanup): enhance admin interface with responsive card design

### DIFF
--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -683,6 +683,7 @@ class de_de extends en_gb
         $strings['DeleteBlackoutsBefore'] = 'Lösche Sperrzeiten älter als';
         $strings['DeletedReservations'] = 'Gelöschte Reservierungen';
         $strings['DeleteReservationsBefore'] = 'Lösche Reservierungen älter als';
+        $strings['PermanentlyPurgeAllDeletedReservations'] = 'Alle gelöschten Reservierungen endgültig löschen';
         $strings['SwitchToACustomLayout'] = 'Layout zu einem angepassten Layout ändern';
         $strings['SwitchToAStandardLayout'] = 'Layout zu einem Standardlayout ändern';
         $strings['ThisScheduleUsesACustomLayout'] = 'Dieser Terminplan nutzt ein angepasstes Layout';

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -723,6 +723,7 @@ class en_us extends Language
         $strings['DeleteBlackoutsBefore'] = 'Delete blackout times before';
         $strings['DeletedReservations'] = 'Deleted Reservations';
         $strings['DeleteReservationsBefore'] = 'Delete reservations before';
+        $strings['PermanentlyPurgeAllDeletedReservations'] = 'Permanently purge all deleted reservations';
         $strings['SwitchToACustomLayout'] = 'Switch to a custom layout';
         $strings['SwitchToAStandardLayout'] = 'Switch to a standard layout';
         $strings['ThisScheduleUsesACustomLayout'] = 'This schedule uses a custom layout';

--- a/lang/es.php
+++ b/lang/es.php
@@ -688,6 +688,7 @@ class es extends en_gb
         $strings['DeleteBlackoutsBefore'] = 'Borrar agenda de no disponibilidad antes de';
         $strings['DeletedReservations'] = 'Reservas Borradas';
         $strings['DeleteReservationsBefore'] = 'Borrar reservas anteriores a';
+        $strings['PermanentlyPurgeAllDeletedReservations'] = 'Purgar permanentemente todas las reservas eliminadas';
         $strings['SwitchToACustomLayout'] = 'Cambiar a un diseño personalizado';
         $strings['SwitchToAStandardLayout'] = 'Cambiar a un diseño estándar';
         $strings['ThisScheduleUsesACustomLayout'] = 'Este horario usa un diseño personalizado';

--- a/tpl/Admin/Configuration/data_cleanup.tpl
+++ b/tpl/Admin/Configuration/data_cleanup.tpl
@@ -6,55 +6,116 @@
         <div class="card-body">
             <h1 class="border-bottom mb-3">{translate key=DataCleanup}</h1>
 
-            <div class="mb-3 p-3 border rounded bg-light">
-                <h5><span class="badge bg-primary">{$ReservationCount} {translate key=Reservations}</span></h5>
-                <div class="input-group input-group-sm">
-                    <label class="input-group-text fw-bold"
-                        for="reservationDeleteDate">{translate key=DeleteReservationsBefore}</label>
-                    <input type="date" id="reservationDeleteDate" class="form-control dateinput"
-                        value="{formatdate date=$DeleteDate format='Y-m-d'}" />
-                    <input type="hidden" id="formattedReservationDeleteDate"
-                        value="{formatdate date=$DeleteDate key=system}" />
-                    {delete_button id='deleteReservations'}
+            <!-- Reservations Item -->
+            <div class="cleanup-item p-3 border-bottom">
+                <div class="row g-2 align-items-center">
+                    <div class="col-12 col-md-7">
+                        <div class="d-flex align-items-start">
+                            <i class="bi bi-calendar-check fs-5 link-primary mt-1 me-2"></i>
+                            <div>
+                                <h6 class="mb-0 d-inline">{translate key=Reservations}
+                                    <span class="badge bg-primary ms-2">{$ReservationCount}</span>
+                                </h6>
+                                <div class="text-muted small">{translate key=DeleteReservationsBefore}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-5">
+                        <div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center gap-2">
+                            <div class="flex-grow-1">
+                                <input type="date" id="reservationDeleteDate" class="form-control form-control-sm"
+                                    value="{formatdate date=$DeleteDate format='Y-m-d'}" />
+                                <input type="hidden" id="formattedReservationDeleteDate"
+                                    value="{formatdate date=$DeleteDate key=system}" />
+                            </div>
+                            <div style="min-width: 120px;">
+                                {delete_button id='deleteReservations' class='btn-sm w-100'}
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 
-            <div class="mb-3 p-3 border rounded bg-light clearfix">
-                <h5><span class="badge bg-primary">{$DeletedReservationCount} {translate key=DeletedReservations}</span>
-                </h5>
-                <div class="form-group">
-
+            <!-- Purge Deleted Reservations -->
+            <div class="cleanup-item p-3 border-bottom">
+                <div class="row g-2 align-items-center">
+                    <div class="col-12 col-md-7">
+                        <div class="d-flex align-items-start">
+                            <i class="bi bi-trash fs-5 text-warning mt-1 me-2"></i>
+                            <div>
+                                <h6 class="mb-0 d-inline">{translate key=DeletedReservations}
+                                    <span class="badge bg-warning text-dark ms-2">{$DeletedReservationCount}</span>
+                                </h6>
+                                <div class="text-muted small">{translate key=PermanentlyPurgeAllDeletedReservations}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-5 text-md-end">
+                        <button id="purgeReservations" type="button" class="btn btn-sm btn-warning w-100 w-md-auto">
+                            <i class="bi bi-eraser me-1"></i>{translate key=Purge}
+                        </button>
+                    </div>
                 </div>
-                {delete_button id='purgeReservations' key=Purge class='btn-sm float-end'}
             </div>
 
-            <div class="mb-3 p-3 border rounded bg-light">
-                <h5><span class="badge bg-primary">{$BlackoutsCount} {translate key=ManageBlackouts}</span></h5>
-
-                <div class="input-group input-group-sm">
-                    <label class="input-group-text fw-bold"
-                        for="blackoutDeleteDate">{translate key=DeleteBlackoutsBefore}</label>
-                    <input type="date" id="blackoutDeleteDate" class="form-control input-sm inline-block dateinput"
-                        value="{formatdate date=$DeleteDate format='Y-m-d'}" />
-                    <input type="hidden" id="formattedBlackoutDeleteDate"
-                        value="{formatdate date=$DeleteDate key=system}" />
-                    {delete_button id='deleteBlackouts'}
+            <!-- Blackouts Item -->
+            <div class="cleanup-item p-3 border-bottom">
+                <div class="row g-2 align-items-center">
+                    <div class="col-12 col-md-7">
+                        <div class="d-flex align-items-start">
+                            <i class="bi bi-clock-history fs-5 link-primary mt-1 me-2"></i>
+                            <div>
+                                <h6 class="mb-0 d-inline">{translate key=ManageBlackouts}
+                                    <span class="badge bg-primary ms-2">{$BlackoutsCount}</span>
+                                </h6>
+                                <div class="text-muted small">{translate key=DeleteBlackoutsBefore}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-5">
+                        <div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center gap-2">
+                            <div class="flex-grow-1">
+                                <input type="date" id="blackoutDeleteDate" class="form-control form-control-sm"
+                                    value="{formatdate date=$DeleteDate format='Y-m-d'}" />
+                                <input type="hidden" id="formattedBlackoutDeleteDate"
+                                    value="{formatdate date=$DeleteDate key=system}" />
+                            </div>
+                            <div style="min-width: 120px;">
+                                {delete_button id='deleteBlackouts' class='btn-sm w-100'}
+                            </div>
+                        </div>
+                    </div>
                 </div>
-
-
             </div>
 
-            <div class="mb-3 p-3 border rounded bg-light">
-                <h5><span class="badge bg-primary">{$UserCount} {translate key=Users}</span></h5>
-
-                <div class="input-group input-group-sm">
-                    <label class="input-group-text fw-bold"
-                        for="userDeleteDate">{translate key=PermanentlyDeleteUsers}</label>
-                    <input type="date" id="userDeleteDate" class="form-control input-sm inline-block dateinput"
-                        value="{formatdate date=$DeleteDate format='Y-m-d'}" />
-                    <input type="hidden" id="formattedUserDeleteDate"
-                        value="{formatdate date=$DeleteDate key=system}" />
-                    {delete_button id='deleteUsers'}
+            <!-- Users Item -->
+            <div class="cleanup-item p-3">
+                <div class="row g-2 align-items-center">
+                    <div class="col-12 col-md-7">
+                        <div class="d-flex align-items-start">
+                            <i class="bi bi-person-x fs-5 link-primary mt-1 me-2"></i>
+                            <div>
+                                <h6 class="mb-0 d-inline">{translate key=Users}
+                                    <span class="badge bg-primary ms-2">{$UserCount}</span>
+                                </h6>
+                                <div class="text-muted small">{translate key=PermanentlyDeleteUsers}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-md-5">
+                        <div class="d-flex flex-column flex-md-row align-items-stretch align-items-md-center gap-2">
+                            <div class="flex-grow-1">
+                                <input type="date" id="userDeleteDate" class="form-control form-control-sm"
+                                    value="{formatdate date=$DeleteDate format='Y-m-d'}" />
+                                <input type="hidden" id="formattedUserDeleteDate"
+                                    value="{formatdate date=$DeleteDate key=system}" />
+                            </div>
+                            <div style="min-width: 120px;">
+                                {delete_button id='deleteUsers' class='btn-sm w-100'}
+                            </div>
+                        </div>
+                    </div>
                 </div>
 
             </div>


### PR DESCRIPTION
Rework the Data Cleanup admin template to a responsive, card-style layout with improved Bootstrap classes, icons, and button styling (reservation, deleted reservations, blackouts, users). Add a dedicated purge button for permanently removing deleted reservations and update date input classes and delete_button usages. Also add the new translation key PermanentlyPurgeAllDeletedReservations in en_us, de_de and es language files. No business logic changes—purely UI/translation updates.
<img width="754" height="406" alt="image" src="https://github.com/user-attachments/assets/ea9550a6-ad96-42d4-a09f-835d0fade0d9" />
