### PR TITLE
docs(logging): correct LB_LOGGING_* names

### DIFF
--- a/docs/source/BASIC-CONFIGURATION.rst
+++ b/docs/source/BASIC-CONFIGURATION.rst
@@ -431,13 +431,13 @@ Docker Environment Variables
 ``LB_ENV``
   Environment mode: ``production`` (default) or ``dev``
 
-``LB_LOG_FOLDER``
+``LB_LOGGING_FOLDER``
   Log directory (default: ``/var/log/librebooking``)
 
-``LB_LOG_LEVEL``
+``LB_LOGGING_LEVEL``
   Logging level: ``none`` (default), ``debug``, ``error``
 
-``LB_LOG_SQL``
+``LB_LOGGING_SQL``
   Enable SQL logging: ``false`` (default), ``true``
 
 ``LB_CRON_ENABLED``

--- a/docs/source/INSTALLATION.rst
+++ b/docs/source/INSTALLATION.rst
@@ -477,13 +477,13 @@ Docker Environment Variables
 ``LB_ENV``
   Environment mode: ``production`` (default) or ``dev``
 
-``LB_LOG_FOLDER``
+``LB_LOGGING_FOLDER``
   Log directory (default: ``/var/log/librebooking``)
 
-``LB_LOG_LEVEL``
+``LB_LOGGING_LEVEL``
   Logging level: ``none`` (default), ``debug``, ``error``
 
-``LB_LOG_SQL``
+``LB_LOGGING_SQL``
   Enable SQL logging: ``false`` (default), ``true``
 
 ``LB_CRON_ENABLED``


### PR DESCRIPTION
Was `LB_LOG_*` but should be `LB_LOGGING_*`