### PR TITLE
feat: Generate a helpful web page if missing composer

### DIFF
--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -1,9 +1,7 @@
 <?php
 
-// debugging tools / libs
-if (file_exists(ROOT_DIR . 'vendor/autoload.php')) {
-    require ROOT_DIR . 'vendor/autoload.php';
-}
+require_once(ROOT_DIR . 'lib/ComposerDependenciesGuard.php');
+EnsureComposerDependenciesInstalledForRequest();
 
 require_once(ROOT_DIR . 'Pages/IPage.php');
 require_once(ROOT_DIR . 'Pages/Pages.php');

--- a/Web/Services/index.php
+++ b/Web/Services/index.php
@@ -2,6 +2,9 @@
 
 define('ROOT_DIR', '../../');
 
+require_once(ROOT_DIR . 'lib/ComposerDependenciesGuard.php');
+EnsureComposerDependenciesInstalledForRequest();
+
 require_once(ROOT_DIR . 'lib/WebService/namespace.php');
 require_once(ROOT_DIR . 'lib/WebService/Slim/namespace.php');
 

--- a/lib/ComposerDependenciesGuard.php
+++ b/lib/ComposerDependenciesGuard.php
@@ -1,0 +1,96 @@
+<?php
+
+function EnsureComposerDependenciesInstalledForRequest(): void
+{
+    $autoloadPath = ROOT_DIR . 'vendor/autoload.php';
+    if (file_exists($autoloadPath)) {
+        require_once $autoloadPath;
+        return;
+    }
+
+    $requestUri = $_SERVER['REQUEST_URI'] ?? '';
+    $scriptName = $_SERVER['SCRIPT_NAME'] ?? '';
+    $phpSelf = $_SERVER['PHP_SELF'] ?? '';
+
+    $accept = $_SERVER['HTTP_ACCEPT'] ?? '';
+
+    $isApiRequest = str_contains($scriptName, '/Web/Services/')
+        || str_contains($phpSelf, '/Web/Services/')
+        || str_contains($requestUri, '/Web/Services/')
+        || stripos($accept, 'application/json') !== false;
+
+    if ($isApiRequest) {
+        if (!headers_sent()) {
+            header('Content-Type: application/json; charset=utf-8', true, 503);
+        }
+        echo json_encode(
+            [
+                'error' => 'dependencies_missing',
+                'message' => 'Application dependencies are not installed. Run "composer install" in the project root.',
+            ],
+            JSON_UNESCAPED_SLASHES
+        );
+        exit;
+    }
+
+    if (!headers_sent()) {
+        header('Content-Type: text/html; charset=utf-8', true, 503);
+    }
+
+    echo <<<'HTML'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LibreBooking Setup Required</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+            background: #f7f7f7;
+            color: #1f2937;
+            margin: 0;
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 780px;
+            margin: 3rem auto;
+            background: #ffffff;
+            border: 1px solid #e5e7eb;
+            border-radius: 10px;
+            padding: 2rem;
+            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.06);
+        }
+
+        h1 {
+            margin-top: 0;
+            color: #991b1b;
+            font-size: 1.6rem;
+        }
+
+        code {
+            background: #f3f4f6;
+            border: 1px solid #e5e7eb;
+            border-radius: 6px;
+            padding: 0.25rem 0.4rem;
+            font-size: 0.95rem;
+        }
+
+        p {
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Application setup is incomplete</h1>
+        <p>Composer dependencies are missing, so LibreBooking cannot start yet.</p>
+        <p>From the project root, run <code>composer install</code>, then reload this page.</p>
+    </div>
+</body>
+</html>
+HTML;
+
+    exit;
+}


### PR DESCRIPTION
If `composer install` has not been setup yet, causing `vendor/autoload.php` to not be created, generate a helpful error message on the web page.

Before the server would just generate a 500 message with no details.