### PR TITLE
feat: provide a helpful error message if no DB access

### DIFF
--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -57,6 +57,8 @@ class de_de extends en_gb
         $strings['Error'] = 'Fehler';
         $strings['ReturnToPreviousPage'] = 'Zurück zur vorigen Seite';
         $strings['UnknownError'] = 'Unbekannter Fehler';
+        $strings['DatabaseConnectionError'] = 'Verbindung zum Datenbankserver konnte nicht hergestellt werden.<br/>Bitten Sie den Website-Administrator, Host, Benutzername und Passwort der Datenbank in <code>config/config.php</code> zu prüfen.';
+        $strings['DatabaseNotFoundError'] = 'Die konfigurierte Datenbank konnte nicht ausgewählt werden.<br/>Bitten Sie den Website-Administrator, den Datenbanknamen in <code>config/config.php</code> zu prüfen und zu bestätigen, dass die Datenbank erstellt/initialisiert wurde.';
         $strings['InsufficientPermissionsError'] = 'Sie haben keinen Zugriff auf diese Ressource.';
         $strings['MissingReservationResourceError'] = 'Keine Ressource ausgewählt';
         $strings['MissingReservationScheduleError'] = 'Kein Terminplan ausgewählt';

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -94,6 +94,8 @@ class en_us extends Language
         $strings['Error'] = 'Error';
         $strings['ReturnToPreviousPage'] = 'Return to the last page that you were on';
         $strings['UnknownError'] = 'Unknown Error';
+        $strings['DatabaseConnectionError'] = 'Unable to connect to the database server.<br/>Ask the website administrator to verify the database host, username, and password in <code>config/config.php</code>.';
+        $strings['DatabaseNotFoundError'] = 'Unable to select the configured database.<br/>Ask the website administrator to verify the database name in <code>config/config.php</code> and confirm the database has been created/initialized.';
         $strings['InsufficientPermissionsError'] = 'You do not have permission to access this resource';
         $strings['MissingReservationResourceError'] = 'A resource was not selected';
         $strings['MissingReservationScheduleError'] = 'A schedule was not selected';

--- a/lang/es.php
+++ b/lang/es.php
@@ -59,6 +59,8 @@ class es extends en_gb
         $strings['Error'] = 'Error';
         $strings['ReturnToPreviousPage'] = 'Volver a la página anterior';
         $strings['UnknownError'] = 'Error desconocido';
+        $strings['DatabaseConnectionError'] = 'No se pudo conectar al servidor de base de datos.<br/>Pide al administrador del sitio web que verifique el host, usuario y contraseña de la base de datos en <code>config/config.php</code>.';
+        $strings['DatabaseNotFoundError'] = 'No se pudo seleccionar la base de datos configurada.<br/>Pide al administrador del sitio web que verifique el nombre de la base de datos en <code>config/config.php</code> y confirme que la base de datos ha sido creada/inicializada.';
         $strings['InsufficientPermissionsError'] = 'No tienes permiso para acceder a este recurso';
         $strings['MissingReservationResourceError'] = 'No se ha seleccionado un recurso';
         $strings['MissingReservationScheduleError'] = 'No se ha seleccionado una planificación';

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -95,6 +95,8 @@ class ja_jp extends en_gb
         $strings['Error'] = 'エラー';
         $strings['ReturnToPreviousPage'] = '直近のページへ戻る';
         $strings['UnknownError'] = '不明なエラー';
+        $strings['DatabaseConnectionError'] = 'データベースサーバーに接続できませんでした。<br/>Webサイト管理者に、<code>config/config.php</code> のデータベースのホスト名・ユーザー名・パスワード設定を確認するよう依頼してください。';
+        $strings['DatabaseNotFoundError'] = '設定されたデータベースを選択できませんでした。<br/>Webサイト管理者に、<code>config/config.php</code> のデータベース名を確認し、データベースが作成／初期化済みであることを確認するよう依頼してください。';
         $strings['InsufficientPermissionsError'] = 'このリソースを操作する権限がありません';
         $strings['MissingReservationResourceError'] = 'リソースが選択されていません';
         $strings['MissingReservationScheduleError'] = 'スケジュールが選択されていません';

--- a/lib/Common/ErrorMessages.php
+++ b/lib/Common/ErrorMessages.php
@@ -8,6 +8,8 @@ class ErrorMessages
     public const MISSING_SCHEDULE = 3;
     public const RESERVATION_NOT_FOUND = 4;
     public const RESERVATION_NOT_AVAILABLE = 5;
+    public const DATABASE_CONNECTION = 6;
+    public const DATABASE_NOT_FOUND = 7;
 
     private $_resourceKeys = [];
     private static $_instance;
@@ -19,6 +21,8 @@ class ErrorMessages
         $this->SetKey(ErrorMessages::MISSING_SCHEDULE, 'MissingReservationScheduleError');
         $this->SetKey(ErrorMessages::RESERVATION_NOT_FOUND, 'ReservationNotFoundError');
         $this->SetKey(ErrorMessages::RESERVATION_NOT_AVAILABLE, 'ReservationNotAvailable');
+        $this->SetKey(ErrorMessages::DATABASE_CONNECTION, 'DatabaseConnectionError');
+        $this->SetKey(ErrorMessages::DATABASE_NOT_FOUND, 'DatabaseNotFoundError');
     }
 
     /**

--- a/lib/Common/Logging/ExceptionHandler.php
+++ b/lib/Common/Logging/ExceptionHandler.php
@@ -42,7 +42,14 @@ class WebExceptionHandler extends ExceptionHandler
         ob_start();
         debug_print_backtrace();
         error_log(ob_get_clean());
-        call_user_func($this->callback);
+        $errorMessageId = ErrorMessages::UNKNOWN_ERROR;
+        if (is_a($exception, 'DatabaseConnectionException')) {
+            $errorMessageId = ErrorMessages::DATABASE_CONNECTION;
+        } elseif (is_a($exception, 'DatabaseNotFoundException')) {
+            $errorMessageId = ErrorMessages::DATABASE_NOT_FOUND;
+        }
+
+        call_user_func($this->callback, $errorMessageId);
     }
 }
 

--- a/lib/Database/DatabaseExceptions.php
+++ b/lib/Database/DatabaseExceptions.php
@@ -1,0 +1,13 @@
+<?php
+
+class DatabaseException extends Exception
+{
+}
+
+class DatabaseConnectionException extends DatabaseException
+{
+}
+
+class DatabaseNotFoundException extends DatabaseException
+{
+}

--- a/lib/Database/MySQL/MySqlConnection.php
+++ b/lib/Database/MySQL/MySqlConnection.php
@@ -43,14 +43,14 @@ class MySqlConnection implements IDbConnection
         if (!$this->_db) {
             $connectError = mysqli_connect_error();
             Log::Error("Error connecting to database\nCheck your database settings in the config file\n%s", $connectError);
-            throw new Exception("Error connecting to database\nError: " . $connectError);
+            throw new DatabaseConnectionException("Error connecting to database\nError: " . $connectError);
         }
 
         $selected = mysqli_select_db($this->_db, $this->_dbName);
 
         if (!$selected) {
             Log::Error("Error selecting database '%s'\nCheck your database settings in the config file\n%s", $this->_dbName, mysqli_error($this->_db));
-            throw new Exception("Error selecting database\nError: " . mysqli_error($this->_db));
+            throw new DatabaseNotFoundException("Error selecting database\nError: " . mysqli_error($this->_db));
         }
         mysqli_set_charset($this->_db, 'utf8mb4');
 

--- a/lib/Database/namespace.php
+++ b/lib/Database/namespace.php
@@ -5,6 +5,7 @@ require_once(ROOT_DIR . 'lib/Database/ISqlCommand.php');
 require_once(ROOT_DIR . 'lib/Database/IReader.php');
 require_once(ROOT_DIR . 'lib/Database/Parameter.php');
 require_once(ROOT_DIR . 'lib/Database/Parameters.php');
+require_once(ROOT_DIR . 'lib/Database/DatabaseExceptions.php');
 require_once(ROOT_DIR . 'lib/Database/SqlCommand.php');
 require_once(ROOT_DIR . 'lib/Database/Database.php');
 require_once(ROOT_DIR . 'lib/Database/DatabaseFactory.php');


### PR DESCRIPTION
If unable to access the database provide a helpful error message.

Now the error message will say:
  Unable to connect to the database. Ask the website administrator to
  verify that the database has been created/initialized. They should
  also verify that the `config/config.php` database configuration is
  correct.

Previously it said:
  Unknown Error