### PR TITLE
feat: display friendly error messages for LDAP authentication failures

### DIFF
--- a/Pages/LoginPage.php
+++ b/Pages/LoginPage.php
@@ -47,6 +47,7 @@ interface ILoginPage extends IPage, ILoginBasePage
     public function SetResumeUrl($value);
 
     public function SetShowLoginError();
+    public function SetLoginErrorMessage(?string $message): void;
 
     /**
      * @param $languageCode string
@@ -133,6 +134,7 @@ class LoginPage extends Page implements ILoginPage
         if ($resumeUrl !== NULL) $resumeUrl = str_replace('&amp;&amp;', '&amp;', $resumeUrl);
         $this->Set('ResumeUrl', $resumeUrl);
         $this->Set('ShowLoginError', false);
+        $this->Set('LoginErrorMessage', null);
         $this->Set('Languages', Resources::GetInstance()->AvailableLanguages);
 
         $this->SetFacebookErrorMessage();
@@ -248,6 +250,11 @@ class LoginPage extends Page implements ILoginPage
     public function SetShowLoginError()
     {
         $this->Set('ShowLoginError', true);
+    }
+
+    public function SetLoginErrorMessage(?string $message): void
+    {
+        $this->Set('LoginErrorMessage', $message);
     }
 
     public function GetRequestedLanguage()

--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -152,8 +152,17 @@ class LoginPresenter
         }
 
         $id = $this->_page->GetEmailAddress();
+        $isValid = false;
+        try {
+            $isValid = $this->authentication->Validate($id, $this->_page->GetPassword());
+        } catch (Throwable $ex) {
+            Log::Error('Authentication failure for user %s: %s', $id, $ex->getMessage());
+            $this->_page->SetLoginErrorMessage(message: $this->GetLdapErrorMessage(ex: $ex));
+            $this->_page->SetShowLoginError();
+            return;
+        }
 
-        if ($this->authentication->Validate($id, $this->_page->GetPassword())) {
+        if ($isValid) {
             $context = new WebLoginContext(new LoginData($this->_page->GetPersistLogin(), $this->_page->GetSelectedLanguage()));
             $this->authentication->Login($id, $context);
             $this->_Redirect();
@@ -162,6 +171,31 @@ class LoginPresenter
             $this->authentication->HandleLoginFailure($this->_page);
             $this->_page->SetShowLoginError();
         }
+    }
+
+    /**
+     * Returns a user-facing message for known LDAP failures, or null for generic auth failures.
+     *
+     * @param Throwable $ex
+     * @return string|null
+     */
+    private function GetLdapErrorMessage(Throwable $ex): ?string
+    {
+        $message = $ex->getMessage();
+        $resources = Resources::GetInstance();
+
+        if (str_contains($message, 'Could not connect to LDAP server') || str_contains($message, "Can't contact LDAP server")) {
+            return $resources->GetString(key: 'LdapConnectionErrorMessage');
+        }
+
+        $isMissingLdapLibrary = str_contains($message, 'pear/net_ldap2')
+            || preg_match('/Class\\s+"?Net_LDAP2"?\\s+not found/i', $message) === 1;
+
+        if ($isMissingLdapLibrary) {
+            return $resources->GetString(key: 'LdapDependencyMissingMessage');
+        }
+
+        return null;
     }
 
     public function postLogout()

--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -799,6 +799,8 @@ class de_de extends en_gb
 
         // Errors
         $strings['LoginError'] = 'Benutzername oder Passwort falsch';
+        $strings['LdapConnectionErrorMessage'] = 'Es konnte keine Verbindung zum LDAP-Server hergestellt werden. Bitte kontaktieren Sie Ihren Administrator.';
+        $strings['LdapDependencyMissingMessage'] = 'Die LDAP-Authentifizierung ist nicht verfügbar, da pear/net_ldap2 fehlt. Installieren Sie es mit: composer require pear/net_ldap2';
         $strings['ReservationFailed'] = 'Ihre Reservierung konnte nicht angelegt werden';
         $strings['MinNoticeError'] = 'Diese Reservierung benötigt eine Vorankündigung. Der früheste zu reservierende Zeitpunkt ist %s.';
         $strings['MinNoticeErrorUpdate'] = 'Ändern dieser Reservierung benötigt eine Vorankündigung. Reservierungen vor %s dürfen nicht verändert werden.';

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -843,6 +843,8 @@ class en_us extends Language
 
         // Errors
         $strings['LoginError'] = 'We could not match your username or password';
+        $strings['LdapConnectionErrorMessage'] = 'Could not connect to the LDAP server. Please contact your administrator.';
+        $strings['LdapDependencyMissingMessage'] = 'LDAP authentication is not available because pear/net_ldap2 is missing. Install it with: composer require pear/net_ldap2';
         $strings['ReservationFailed'] = 'Your reservation could not be made';
         $strings['MinNoticeError'] = 'This reservation requires advance notice. The earliest date and time that can be reserved is %s.';
         $strings['MinNoticeErrorUpdate'] = 'Changing this reservation requires advance notice. Reservations before %s are not allowed to be changed.';

--- a/lang/es.php
+++ b/lang/es.php
@@ -808,6 +808,8 @@ class es extends en_gb
 
         // Errors
         $strings['LoginError'] = 'No se ha encontrado una correspondencia para tu Nombre de Usuario (Identificador) y contraseña';
+        $strings['LdapConnectionErrorMessage'] = 'No se pudo conectar al servidor LDAP. Por favor, contacte con su administrador.';
+        $strings['LdapDependencyMissingMessage'] = 'La autenticación LDAP no está disponible porque falta pear/net_ldap2. Instálelo con: composer require pear/net_ldap2';
         $strings['ReservationFailed'] = 'Tu reserva no se ha podido realizar';
         $strings['MinNoticeError'] = 'Esta reserva se debe realizar por anticipado.  La fecha más temprana que puede ser reservada %s.';
         $strings['MinNoticeErrorUpdate'] = 'Cambiar esta reserva requiere aviso previo. Las reservas antes del %s no se pueden cambiar.';

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -815,6 +815,8 @@ class ja_jp extends en_gb
 
         // Errors
         $strings['LoginError'] = 'ユーザー名またはパスワードが一致しません';
+        $strings['LdapConnectionErrorMessage'] = 'LDAPサーバーに接続できませんでした。管理者にお問い合わせください。';
+        $strings['LdapDependencyMissingMessage'] = 'pear/net_ldap2 が見つからないため、LDAP 認証は利用できません。次のコマンドでインストールしてください: composer require pear/net_ldap2';
         $strings['ReservationFailed'] = '予約できませんでした';
         $strings['MinNoticeError'] = 'このリソースが今から予約できるのは %s 以降です。';
         $strings['MinNoticeErrorUpdate'] = 'この予約を変更するには事前の通知が必要です。 %s 以前の予約は変更できません。';

--- a/tests/Presenters/LoginPresenterTest.php
+++ b/tests/Presenters/LoginPresenterTest.php
@@ -141,6 +141,59 @@ class LoginPresenterTest extends TestBase
 
         $this->assertEquals("", $this->page->_LastRedirect, "Does not redirect if auth fails");
         $this->assertTrue($this->page->_ShowLoginError, "Should show login error if auth fails");
+        $this->assertNull($this->page->_LoginErrorMessage);
+    }
+
+    public function testLdapDependencyErrorIsDisplayedIfAuthenticationThrowsRuntimeException()
+    {
+        $this->auth->_ValidateException = new RuntimeException('The LDAP plugin requires pear/net_ldap2. Install it with: composer require pear/net_ldap2');
+
+        $this->presenter->Login();
+
+        $this->assertTrue($this->page->_ShowLoginError, 'Should show login error when validation throws');
+        $this->assertEquals(
+            'LdapDependencyMissingMessage',
+            $this->page->_LoginErrorMessage
+        );
+        $this->assertNull($this->auth->_LastLoginContext, 'Should not call login when validation throws');
+    }
+
+    public function testNetLdap2ClassErrorIsDisplayedAsMissingDependencyMessage()
+    {
+        $this->auth->_ValidateException = new Exception('Class "Net_LDAP2" not found');
+
+        $this->presenter->Login();
+
+        $this->assertTrue($this->page->_ShowLoginError);
+        $this->assertEquals(
+            'LdapDependencyMissingMessage',
+            $this->page->_LoginErrorMessage
+        );
+    }
+
+    public function testLdapConnectionErrorContainingNetLdap2DoesNotLookLikeMissingDependency()
+    {
+        $this->auth->_ValidateException = new Exception(
+            "Could not connect to LDAP server. Check your settings in Ldap.config.php : Bind failed: Can't contact LDAP server: Unknown Net_LDAP2 Error (-1)"
+        );
+
+        $this->presenter->Login();
+
+        $this->assertTrue($this->page->_ShowLoginError);
+        $this->assertEquals(
+            'LdapConnectionErrorMessage',
+            $this->page->_LoginErrorMessage
+        );
+    }
+
+    public function testNonLdapExceptionFallsBackToGenericLoginErrorPath()
+    {
+        $this->auth->_ValidateException = new Exception('Some unexpected auth error');
+
+        $this->presenter->Login();
+
+        $this->assertTrue($this->page->_ShowLoginError);
+        $this->assertNull($this->page->_LoginErrorMessage);
     }
 
     public function testAutoLoginIfCookieIsSet()
@@ -213,6 +266,7 @@ class FakeLoginPage extends FakePageBase implements ILoginPage
     public $_UseLogonName = false;
     public $_ResumeUrl = "";
     public $_ShowLoginError = false;
+    public $_LoginErrorMessage = null;
     public $_requestedLanguage;
     public $_selectedLanguage;
     public $_CurrentCode = '';
@@ -315,6 +369,11 @@ class FakeLoginPage extends FakePageBase implements ILoginPage
     public function SetShowLoginError()
     {
         $this->_ShowLoginError = true;
+    }
+
+    public function SetLoginErrorMessage(?string $message): void
+    {
+        $this->_LoginErrorMessage = $message;
     }
 
     public function GetRequestedLanguage()

--- a/tests/fakes/FakeWebAuthentication.php
+++ b/tests/fakes/FakeWebAuthentication.php
@@ -171,6 +171,7 @@ class FakeWebAuthentication implements IWebAuthentication
     public $_LoginCalled = false;
 
     public $_ValidateResult = false;
+    public $_ValidateException = null;
 
     public $_ShowUsernamePrompt = false;
     public $_ShowPasswordPrompt = false;
@@ -186,6 +187,10 @@ class FakeWebAuthentication implements IWebAuthentication
     {
         $this->_LastLogin = $username;
         $this->_LastPassword = $password;
+
+        if ($this->_ValidateException instanceof Throwable) {
+            throw $this->_ValidateException;
+        }
 
         return $this->_ValidateResult;
     }

--- a/tpl/login.tpl
+++ b/tpl/login.tpl
@@ -32,7 +32,11 @@
 
                         {if $ShowLoginError}
                             <div id="loginError" class="alert alert-danger">
-                                {translate key='LoginError'}
+                                {if !empty($LoginErrorMessage)}
+                                    {$LoginErrorMessage}
+                                {else}
+                                    {translate key='LoginError'}
+                                {/if}
                             </div>
                         {/if}
 


### PR DESCRIPTION
Wrap authentication validation in try/catch to handle LDAP-related exceptions (missing pear/net_ldap2 library, unreachable LDAP server) and display (hopefully) user-friendly error messages on the login page instead of a generic error or unhandled exception.

This doesn't change the message seen if the issue is a wrong username/password.