### PR TITLE
chore: have 'php-cs-fixer' be composer installed

### DIFF
--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -135,7 +135,7 @@ jobs:
       # - name: Check coding-standard
       #   # Allow the previous check to fail but not abort
       #   if: always()
-      #   run: composer phpcs
+      #   run: composer phpcsfixer:lint
 
   analyse-php:
     runs-on: ubuntu-latest

--- a/.phive/phars.xml
+++ b/.phive/phars.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phive xmlns="https://phar.io/phive">
   <phar name="phing" version="^3.0.0-RC3" installed="3.0.0-RC3" location="./tools/phing" copy="true"/>
-  <phar name="phpunit" version="^9.5.9" installed="9.5.9" location="./tools/phpunit" copy="true"/>
   <phar name="phpdocumentor" version="^3.1.2" installed="3.1.2" location="./tools/phpdocumentor" copy="true"/>
-  <phar name="php-cs-fixer" version="^3.1.0" installed="3.1.0" location="./tools/php-cs-fixer" copy="true"/>
 </phive>

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -20,9 +20,9 @@ $config = new PhpCsFixer\Config();
 // rules: https://cs.symfony.com/doc/rules/index.html
 return $config
     ->setCacheFile(PHP_CS_FIXER_CACHE_FILE)
-    ->setRiskyAllowed(true)
+    ->setRiskyAllowed(false)
     ->setRules([
-        '@Symfony' => true,
+        // '@Symfony' => true,
         '@PSR12' => true, // https://www.php-fig.org/psr/psr-12/
         'array_syntax' => ['syntax' => 'short'],
         'array_indentation' => true,

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "license": "GPL-3.0-only",
     "autoload": {},
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.89",
         "squizlabs/php_codesniffer": "^3.7.1",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "phpunit/phpunit": "^11.3",
@@ -35,14 +36,14 @@
     "scripts": {
         "install-tools": "phive install --trust-gpg-keys",
         "build": "./tools/phing",
-        "fix": "./tools/php-cs-fixer fix -v",
-        "lint": "./tools/php-cs-fixer fix -vv --dry-run",
+        "phpcsfixer:fix": "./vendor/bin/php-cs-fixer fix -v",
+        "phpcsfixer:lint": "./vendor/bin/php-cs-fixer fix -vv --dry-run",
         "phpunit": "./vendor/bin/phpunit",
         "phpstan": "./vendor/bin/phpstan analyse",
         "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline",
         "test": [
             "@phpunit",
-            "@lint"
+            "@phpcsfixer:lint"
         ],
         "sniffer:php8": "phpcs -p ./ --standard=vendor/phpcompatibility/php-compatibility/PHPCompatibility --report-full=./php8-report.log --ignore=./vendor/*,./tools/*,./.git/*,./tpl_c/*,./build/*,./.phpdoc/*,./var/*,./Web/scripts/*,./Web/css/* --runtime-set testVersion 8.0",
         "preflight": "php lib/preflight.php"

--- a/docs/source/DEVELOPER-README.rst
+++ b/docs/source/DEVELOPER-README.rst
@@ -68,8 +68,11 @@ Tools
 | For phive to work properly you also need to install
   `gnupgp <https://www.gnupg.org/download/index.html#binary>`__
 
-Simply run ``composer install-tools`` in the root of the project and all
-tools will be available inside the ``/tools`` directory.
+Run ``composer install-tools`` in the root of the project to install
+Phive-managed tools into the ``/tools`` directory.
+
+Run ``composer install`` to install Composer-managed tools into
+``/vendor/bin`` (for example ``php-cs-fixer``).
 
 `Phing <https://www.phing.info/#docs>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -95,7 +98,7 @@ will be generated in ``/.phpdoc/build``.
 `PHP-CS-Fixer <https://github.com/FriendsOfPhp/PHP-CS-Fixer#usage>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-| ``composer lint`` and ``composer fix``
+| ``composer phpcsfixer:lint`` and ``composer phpcsfixer:fix``
 | lints (just warnings) and fixes (changes files) code formating to
   [PSR-12]
 


### PR DESCRIPTION
Previously 'php-cs-fixer' would be installed by phive.

NOTE: 'php-cs-fixer' does not pass on the project yet as there are many issues.