### PR TITLE
fix(shibboleth): use correct config key names

### DIFF
--- a/plugins/Authentication/Shibboleth/ShibbolethOptions.php
+++ b/plugins/Authentication/Shibboleth/ShibbolethOptions.php
@@ -55,12 +55,12 @@ class ShibbolethOptions
     protected function InitShibbolethOptions()
     {
         $this->_options = [];
-        $this->SetOption('shibboleth.username', $this->GetConfig(ShibbolethConfigKeys::USERNAME));
-        $this->SetOption('shibboleth.firstname', $this->GetConfig(ShibbolethConfigKeys::FIRSTNAME));
-        $this->SetOption('shibboleth.lastname', $this->GetConfig(ShibbolethConfigKeys::LASTNAME));
-        $this->SetOption('shibboleth.email', $this->GetConfig(ShibbolethConfigKeys::EMAIL));
-        $this->SetOption('shibboleth.phone', $this->GetConfig(ShibbolethConfigKeys::PHONE));
-        $this->SetOption('shibboleth.organization', $this->GetConfig(ShibbolethConfigKeys::ORGANIZATION));
+        $this->SetOption(ShibbolethConfigKeys::USERNAME['key'], $this->GetConfig(ShibbolethConfigKeys::USERNAME));
+        $this->SetOption(ShibbolethConfigKeys::FIRSTNAME['key'], $this->GetConfig(ShibbolethConfigKeys::FIRSTNAME));
+        $this->SetOption(ShibbolethConfigKeys::LASTNAME['key'], $this->GetConfig(ShibbolethConfigKeys::LASTNAME));
+        $this->SetOption(ShibbolethConfigKeys::EMAIL['key'], $this->GetConfig(ShibbolethConfigKeys::EMAIL));
+        $this->SetOption(ShibbolethConfigKeys::PHONE['key'], $this->GetConfig(ShibbolethConfigKeys::PHONE));
+        $this->SetOption(ShibbolethConfigKeys::ORGANIZATION['key'], $this->GetConfig(ShibbolethConfigKeys::ORGANIZATION));
     }
 
     /**

--- a/tests/Plugins/Authentication/Shibboleth/ShibbolethUserTest.php
+++ b/tests/Plugins/Authentication/Shibboleth/ShibbolethUserTest.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once(ROOT_DIR . 'plugins/Authentication/Shibboleth/namespace.php');
+
+class ShibbolethUserTest extends TestBase
+{
+    public function testMapsValuesFromConfiguredServerAttributeKeys()
+    {
+        $options = new TestShibbolethOptions();
+
+        $user = new ShibbolethUser([
+            'REMOTE_USER' => 'jdoe',
+            'givenName' => 'John',
+            'sn' => 'Doe',
+            'mail' => 'jdoe@example.com',
+            'telephone' => '555-1234',
+            'ou' => 'Engineering',
+        ], $options);
+
+        $this->assertEquals('jdoe', $user->GetUsername());
+        $this->assertEquals('John', $user->GetFirstName());
+        $this->assertEquals('Doe', $user->GetLastName());
+        $this->assertEquals('jdoe@example.com', $user->GetEmailAddress());
+        $this->assertEquals('555-1234', $user->GetPhone());
+        $this->assertEquals('Engineering', $user->GetOrganization());
+    }
+}
+
+class TestShibbolethOptions extends ShibbolethOptions
+{
+    public function __construct()
+    {
+        // Intentionally bypass parent constructor to avoid file I/O in unit tests.
+    }
+
+    protected function GetConfig($configDef, $converter = null)
+    {
+        return $configDef['default'] ?? null;
+    }
+}


### PR DESCRIPTION
Previously the config file was restructured from flat keys ('shibboleth.username') to nested keys ('shibboleth' => ['username' => ...]), and ShibbolethConfigKeys constants were updated accordingly ('key' => 'username'). But ShibbolethOptions::InitShibbolethOptions() still used the old hardcoded 'shibboleth.username' strings when calling SetOption().

Closes: #1004