### PR TITLE
fix(auth): repair MoodleAdv config access and add regression coverage

### DIFF
--- a/plugins/Authentication/MoodleAdv/MoodleAdvOptions.php
+++ b/plugins/Authentication/MoodleAdv/MoodleAdvOptions.php
@@ -60,7 +60,6 @@ class MoodleAdvOptions
 
     private function GetConfig($configDef, $converter = null)
     {
-        $keyName = is_array($configDef) ? $configDef['key'] : $configDef;
-        return Configuration::Instance()->File(MoodleAdvConfigKeys::CONFIG_ID)->GetKey($keyName, $converter);
+        return Configuration::Instance()->File(MoodleAdvConfigKeys::CONFIG_ID)->GetKey($configDef, $converter);
     }
 }

--- a/tests/Plugins/Authentication/MoodleAdv/MoodleAdvOptionsTest.php
+++ b/tests/Plugins/Authentication/MoodleAdv/MoodleAdvOptionsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+require_once(ROOT_DIR . 'plugins/Authentication/MoodleAdv/namespace.php');
+
+class MoodleAdvOptionsTest extends TestBase
+{
+    public function testReadsConfigValuesFromConfigDefinitions()
+    {
+        $pluginConfig = new FakeConfigFile();
+        $pluginConfig->SetKey(MoodleAdvConfigKeys::DB_HOST, 'db.example.internal');
+        $pluginConfig->SetKey(MoodleAdvConfigKeys::DB_NAME, 'moodle_prod');
+        $pluginConfig->SetKey(MoodleAdvConfigKeys::DB_USER, 'moodle_user');
+        $pluginConfig->SetKey(MoodleAdvConfigKeys::DB_PASS, 'secret');
+        $pluginConfig->SetKey(MoodleAdvConfigKeys::DB_PREFIX, 'mdl_');
+        $pluginConfig->SetKey(MoodleAdvConfigKeys::AUTH_METHOD, 'roles');
+        $pluginConfig->SetKey(MoodleAdvConfigKeys::ROLES, '1,2');
+        $pluginConfig->SetKey(MoodleAdvConfigKeys::FIELD, '10');
+        $this->fakeConfig->SetFile(MoodleAdvConfigKeys::CONFIG_ID, $pluginConfig);
+
+        $options = new TestMoodleAdvOptions();
+
+        $this->assertEquals('db.example.internal', $options->GetDbHost());
+        $this->assertEquals('moodle_prod', $options->GetDbName());
+        $this->assertEquals('moodle_user', $options->GetDbUser());
+        $this->assertEquals('secret', $options->GetDbPass());
+        $this->assertEquals('mdl_', $options->GetTablePrefix());
+        $this->assertEquals('roles', $options->GetAuthMethod());
+        $this->assertEquals(['1', '2'], $options->GetRoles());
+        $this->assertEquals('10', $options->GetField());
+    }
+}
+
+class TestMoodleAdvOptions extends MoodleAdvOptions
+{
+    public function __construct()
+    {
+        // Intentionally bypass parent constructor to avoid file I/O in unit tests.
+    }
+}


### PR DESCRIPTION
`MoodleAdvOptions::GetConfig now passes full config definitions to ConfigurationFile::GetKey instead of raw string keys. GetKey() requires a config definition and will fail if passing a string, as was done before.

Add MoodleAdvOptionsTest to verify DB/auth-related getters read values correctly from plugin config definitions (including roles parsing).`