### PR TITLE
docs(config): clarify prevent.participation setting description

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -296,7 +296,7 @@ return [
         ##########################################
 
         'reservation' => [
-            # Prevent participants from being added to reservations (true/false)
+            # Disable reservation participation/invitations and hide participant/invitee lists in the reservation UI (true/false)
             'prevent.participation' => false,
 
             # Disable recurring reservations (true/false)

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -307,7 +307,8 @@ Reservation Behavior
    ],
 
 **reservation.prevent.participation**
-  Disable the ability to add participants to reservations.
+  Disable reservation participation/invitations and hide participant/invitee
+  lists in the reservation UI.
 
 **reservation.prevent.recurrence**
   Disable recurring/repeating reservations.

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -691,8 +691,8 @@ class ConfigKeys
         'key' => 'reservation.prevent.participation',
         'type' => 'boolean',
         'default' => false,
-        'label' => 'Prevent Participation',
-        'description' => 'Prevent users from participating in reservations',
+        'label' => 'Disable Participation & Invitations',
+        'description' => 'Disable reservation participation/invitations and hide participant/invitee lists in the reservation UI',
         'section' => 'reservation'
     ];
     public const RESERVATION_PREVENT_RECURRENCE = [


### PR DESCRIPTION
The old description only mentioned preventing participants from being added. The setting actually disables both participation and invitations, and hides participant/invitee lists throughout the reservation UI.

Update the description for config.dist.php, ADVANCED-CONFIGURATION.rst, and ConfigKeys.php.