### PR TITLE
chore(phpstan): enable level 2 on tests with phpstan-phpunit extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "squizlabs/php_codesniffer": "^3.7.1",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "phpunit/phpunit": "^11.3",
-        "phpstan/phpstan": "^2.1"
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-phpunit": "^2.0"
     },
     "require": {
         "php": ">=8.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb7c0cc85feb0abaf8d0988e999da59d",
+    "content-hash": "a78b6a5501e312c9009c75cd426d0aa2",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5540,6 +5540,62 @@
                 }
             ],
             "time": "2026-02-11T14:48:56+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "2.0.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.32"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.16"
+            },
+            "time": "2026-02-14T09:05:21+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/lib/Application/Schedule/ResourceService.php
+++ b/lib/Application/Schedule/ResourceService.php
@@ -44,12 +44,12 @@ interface IResourceService
     public function GetResourceTypes();
 
     /**
-     * @return Attribute[]
+     * @return LBAttribute[]
      */
     public function GetResourceAttributes();
 
     /**
-     * @return Attribute[]
+     * @return LBAttribute[]
      */
     public function GetResourceTypeAttributes();
 
@@ -222,7 +222,7 @@ class ResourceService implements IResourceService
     }
 
     /**
-     * @return Attribute[]
+     * @return LBAttribute[]
      */
     public function GetResourceAttributes()
     {
@@ -236,7 +236,7 @@ class ResourceService implements IResourceService
     }
 
     /**
-     * @return Attribute[]
+     * @return LBAttribute[]
      */
     public function GetResourceTypeAttributes()
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+
 parameters:
     level: 2
     errorFormat: prettyJson
@@ -16,6 +19,7 @@ parameters:
         - phing-tasks
         # Keep `plugins` in paths so PHPStan can scan symbols used via dynamic plugin loading.
         - plugins
+        - tests
     excludePaths:
         analyse:
             - Web/css/

--- a/tests/Application/Attributes/AttributeServiceTest.php
+++ b/tests/Application/Attributes/AttributeServiceTest.php
@@ -175,7 +175,7 @@ class AttributeServiceTest extends TestBase
 
         $this->attributeRepository->_CustomAttributes = [$unrestricted, $forUser, $notForUser, $forResource1, $resource2IsNotAllowed, $forOtherResource, $forResourceType1, $forOtherResourceType];
 
-        /** @var Attribute[] $attributes */
+        /** @var LBAttribute[] $attributes */
         $attributes = $this->attributeService->GetReservationAttributes($this->fakeUser, new ReservationView(), $requestedUserId, [$resourceId1, $resourceId2, $resourceId3]);
 
         $this->assertEquals(4, count($attributes));

--- a/tests/Application/Authentication/PasswordMigrationTest.php
+++ b/tests/Application/Authentication/PasswordMigrationTest.php
@@ -56,6 +56,7 @@ class PasswordMigrationTest extends TestBase
 
         $migration = new PasswordMigration();
         $password = $migration->Create($this->plaintext, $oldpassword, $newpassword);
+        $this->assertInstanceOf(Password::class, $password);
         $password->Encryption = $fakeEncryption;
 
         $isValid = $password->Validate('');

--- a/tests/Application/Authentication/RegistrationTest.php
+++ b/tests/Application/Authentication/RegistrationTest.php
@@ -14,10 +14,7 @@ class RegistrationTest extends TestBase
      */
     private $fakeEncryption;
 
-    /**
-     * @var IUserRepository
-     */
-    private $userRepository;
+    private IUserRepository&\PHPUnit\Framework\MockObject\MockObject $userRepository;
 
     /**
      * @var FakeGroupViewRepository

--- a/tests/Application/Authentication/WebServiceAuthenticationTest.php
+++ b/tests/Application/Authentication/WebServiceAuthenticationTest.php
@@ -17,10 +17,7 @@ class WebServiceAuthenticationTest extends TestBase
     private $username = 'LoGInName';
     private $password = 'password';
 
-    /**
-     * @var IUserSessionRepository
-     */
-    private $userSessionRepository;
+    private IUserSessionRepository&\PHPUnit\Framework\MockObject\MockObject $userSessionRepository;
 
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ReservationStartTimeRuleTest.php
+++ b/tests/Application/Reservation/ReservationStartTimeRuleTest.php
@@ -5,15 +5,9 @@ require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
 class ReservationStartTimeRuleTest extends TestBase
 {
-    /**
-     * @var IScheduleRepository
-     */
-    private $scheduleRepository;
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
 
-    /**
-     * @var IScheduleLayout
-     */
-    private $layout;
+    private IScheduleLayout&\PHPUnit\Framework\MockObject\MockObject $layout;
 
     public function setUp(): void
     {

--- a/tests/Application/Reservation/ResourceCrossDayRuleTest.php
+++ b/tests/Application/Reservation/ResourceCrossDayRuleTest.php
@@ -5,10 +5,7 @@ require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
 class ResourceCrossDayRuleTest extends TestBase
 {
-    /**
-     * @var IScheduleRepository
-     */
-    private $scheduleRepository;
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
 
     /**
      * @var Schedule

--- a/tests/Application/Reservation/SchedulePeriodRuleTest.php
+++ b/tests/Application/Reservation/SchedulePeriodRuleTest.php
@@ -5,15 +5,9 @@ require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
 class SchedulePeriodRuleTest extends TestBase
 {
-    /**
-     * @var IScheduleRepository
-     */
-    private $scheduleRepository;
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
 
-    /**
-     * @var IScheduleLayout
-     */
-    private $layout;
+    private IScheduleLayout&\PHPUnit\Framework\MockObject\MockObject $layout;
 
     /**
      * @var SchedulePeriodRule

--- a/tests/Application/Schedule/ResourceServiceTest.php
+++ b/tests/Application/Schedule/ResourceServiceTest.php
@@ -4,35 +4,20 @@ require_once(ROOT_DIR . 'lib/Application/Schedule/ResourceService.php');
 
 class ResourceServiceTest extends TestBase
 {
-    /**
-     * @var IPermissionService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $permissionService;
+    private IPermissionService&\PHPUnit\Framework\MockObject\MockObject $permissionService;
 
-    /**
-     * @var IResourceRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $resourceRepository;
+    private IResourceRepository&\PHPUnit\Framework\MockObject\MockObject $resourceRepository;
 
-    /**
-     * @var IAttributeService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $attributeService;
+    private IAttributeService&\PHPUnit\Framework\MockObject\MockObject $attributeService;
 
-    /**
-     * @var IUserRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $userRepository;
+    private IUserRepository&\PHPUnit\Framework\MockObject\MockObject $userRepository;
 
     /**
      * @var ResourceService
      */
     private $resourceService;
 
-    /**
-     * @var IAccessoryRepository
-     */
-    private $accessoryRepository;
+    private IAccessoryRepository&\PHPUnit\Framework\MockObject\MockObject $accessoryRepository;
 
     public function setUp(): void
     {

--- a/tests/Application/Schedule/ScheduleReservationListTest.php
+++ b/tests/Application/Schedule/ScheduleReservationListTest.php
@@ -309,7 +309,7 @@ class ScheduleReservationListTest extends TestBase
         $this->assertEquals($slot9, $slots[8]);
         $this->assertEquals($slot10, $slots[9]);
         $this->assertEquals($slot11, $slots[10]);
-        $this->assertEquals($slot12, $slots[11], $slot12 . ' ' . $slots[11]);
+        $this->assertEquals($slot12, $slots[11]);
     }
 
     public function testReservationStartingBeforeLayoutPeriodAndEndingAfterLayoutPeriodIsCreatedProperly()

--- a/tests/Application/Schedule/SlotLabelFactoryTest.php
+++ b/tests/Application/Schedule/SlotLabelFactoryTest.php
@@ -121,7 +121,7 @@ class SlotLabelFactoryTest extends TestBase
 
         $label = $factory->Format($this->reservation);
 
-        $fullName = $this->reservation->GetUserName()->__toString();
+        $fullName = $this->reservation->GetUserName();
 
         $this->assertStringNotContainsString($fullName, $label);
     }
@@ -141,7 +141,7 @@ class SlotLabelFactoryTest extends TestBase
 
         $label = $factory->Format($this->reservation);
 
-        $fullName = $this->reservation->GetUserName()->__toString();
+        $fullName = $this->reservation->GetUserName();
 
         $this->assertStringContainsString($fullName, $label);
     }

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -9,25 +9,16 @@ class ManageUsersServiceTest extends TestBase
      */
     private $service;
 
-    /**
-     * @var IRegistration
-     */
-    private $registration;
+    private IRegistration&\PHPUnit\Framework\MockObject\MockObject $registration;
 
     /**
      * @var FakeUserRepository
      */
     private $userRepo;
 
-    /**
-     * @var IGroupRepository
-     */
-    private $groupRepo;
+    private IGroupRepository&\PHPUnit\Framework\MockObject\MockObject $groupRepo;
 
-    /**
-     * @var IUserViewRepository
-     */
-    private $userViewRepo;
+    private IUserViewRepository&\PHPUnit\Framework\MockObject\MockObject $userViewRepo;
 
     /**
      * @var FakePasswordEncryption

--- a/tests/Domain/Reservation/ExistingReservationTest.php
+++ b/tests/Domain/Reservation/ExistingReservationTest.php
@@ -1153,7 +1153,7 @@ class ExistingReservationTest extends TestBase
             }
 
             if (is_a($e, 'InstanceUpdatedEvent')) {
-                /** @var InstanceAddedEvent $e */
+                /** @var InstanceUpdatedEvent $e */
                 $updatedReferenceNumbers[] = $e->Instance()->ReferenceNumber();
             }
         }

--- a/tests/Domain/Reservation/QuotaTest.php
+++ b/tests/Domain/Reservation/QuotaTest.php
@@ -14,10 +14,7 @@ class QuotaTest extends TestBase
      */
     public $schedule;
 
-    /**
-     * @var IReservationViewRepository
-     */
-    public $reservationViewRepository;
+    public IReservationViewRepository&\PHPUnit\Framework\MockObject\MockObject $reservationViewRepository;
 
     /**
      * @var FakeUser

--- a/tests/Domain/Reservation/QuotaWhenModifyingTest.php
+++ b/tests/Domain/Reservation/QuotaWhenModifyingTest.php
@@ -14,10 +14,7 @@ class QuotaWhenModifyingTest extends TestBase
      */
     public $schedule;
 
-    /**
-     * @var IReservationViewRepository
-     */
-    public $reservationViewRepository;
+    public IReservationViewRepository&\PHPUnit\Framework\MockObject\MockObject $reservationViewRepository;
 
     /**
      * @var FakeUser

--- a/tests/Domain/Schedule/ScheduleRepositoryTest.php
+++ b/tests/Domain/Schedule/ScheduleRepositoryTest.php
@@ -97,6 +97,7 @@ class ScheduleRepositoryTest extends TestBase
                       ->method('CreateLayout')
                       ->willReturn($expectedLayout);
 
+        /** @var ScheduleLayout $layout */
         $layout = $this->scheduleRepository->GetLayout($scheduleId, $layoutFactory);
 
         $this->assertEquals(new GetLayoutCommand($scheduleId), $this->db->_Commands[0]);
@@ -223,6 +224,7 @@ class ScheduleRepositoryTest extends TestBase
         $this->db->SetRow(1, [$peakTimeRows]);
 
         $layout = $this->scheduleRepository->GetLayout($scheduleId, $layoutFactory);
+        $this->assertInstanceOf(ScheduleLayout::class, $layout);
 
         $peakTimes = $layout->GetPeakTimes();
 

--- a/tests/Plugins/Authentication/ActiveDirectory/ActiveDirectoryTest.php
+++ b/tests/Plugins/Authentication/ActiveDirectory/ActiveDirectoryTest.php
@@ -319,6 +319,7 @@ class TestAdLdapEntry
 {
     public $sn;
     public $givenname;
+    public $fooName;
     public $mail;
     public $telephonenumber;
     public $physicaldeliveryofficename;

--- a/tests/Presenters/Admin/ManageReservationsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageReservationsPresenterTest.php
@@ -9,40 +9,19 @@ class ManageReservationsPresenterTest extends TestBase
      */
     private $presenter;
 
-    /**
-     * @var IManageReservationsPage|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $page;
+    private IManageReservationsPage&\PHPUnit\Framework\MockObject\MockObject $page;
 
-    /**
-     * @var IManageReservationsService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $reservationsService;
+    private IManageReservationsService&\PHPUnit\Framework\MockObject\MockObject $reservationsService;
 
-    /**
-     * @var IScheduleRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $scheduleRepository;
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
 
-    /**
-     * @var IResourceRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $resourceRepository;
+    private IResourceRepository&\PHPUnit\Framework\MockObject\MockObject $resourceRepository;
 
-    /**
-     * @var IAttributeService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $attributeService;
+    private IAttributeService&\PHPUnit\Framework\MockObject\MockObject $attributeService;
 
-    /**
-     * @var IUserRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $userRepository;
+    private IUserRepository&\PHPUnit\Framework\MockObject\MockObject $userRepository;
 
-    /**
-     * @var ITermsOfServiceRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $termsOfServiceRepository;
+    private ITermsOfServiceRepository&\PHPUnit\Framework\MockObject\MockObject $termsOfServiceRepository;
 
     public function setUp(): void
     {
@@ -87,7 +66,7 @@ class ManageReservationsPresenterTest extends TestBase
         $searchedResourceStatusReasonId = 4292;
         /** @var TestCustomAttribute[] $customAttributes */
         $customAttributes = [new TestCustomAttribute(1, 'something')];
-        /** @var Attribute[] $attributes */
+        /** @var LBAttribute[] $attributes */
         $attributes = [new LBAttribute($customAttributes[0], 'value')];
 
         $this->resourceRepository->expects($this->once())

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -20,10 +20,7 @@ class ManageUsersPresenterTest extends TestBase
      */
     public $resourceRepo;
 
-    /**
-     * @var IManageUsersService|PHPUnit\Framework\MockObject\MockObject
-     */
-    public $manageUsersService;
+    public IManageUsersService&\PHPUnit\Framework\MockObject\MockObject $manageUsersService;
 
     /**
      * @var ManageUsersPresenter
@@ -35,20 +32,11 @@ class ManageUsersPresenterTest extends TestBase
      */
     public $attributeService;
 
-    /**
-     * @var PasswordEncryption
-     */
-    public $encryption;
+    public PasswordEncryption&\PHPUnit\Framework\MockObject\MockObject $encryption;
 
-    /**
-     * @var IGroupRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    public $groupRepository;
+    public IGroupRepository&\PHPUnit\Framework\MockObject\MockObject $groupRepository;
 
-    /**
-     * @var IGroupViewRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    public $groupViewRepository;
+    public IGroupViewRepository&\PHPUnit\Framework\MockObject\MockObject $groupViewRepository;
 
     public function setUp(): void
     {

--- a/tests/Presenters/CalendarPresenterTest.php
+++ b/tests/Presenters/CalendarPresenterTest.php
@@ -5,45 +5,27 @@ require_once(ROOT_DIR . 'Presenters/Calendar/CalendarPresenter.php');
 
 class CalendarPresenterTest extends TestBase
 {
-    /**
-     * @var ICommonCalendarPage|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $page;
+    private ICommonCalendarPage&\PHPUnit\Framework\MockObject\MockObject $page;
 
     /**
      * @var CalendarPresenter
      */
     private $presenter;
 
-    /**
-     * @var IReservationViewRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $repository;
+    private IReservationViewRepository&\PHPUnit\Framework\MockObject\MockObject $repository;
 
-    /**
-     * @var ICalendarFactory|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $calendarFactory;
+    private ICalendarFactory&\PHPUnit\Framework\MockObject\MockObject $calendarFactory;
 
-    /**
-     * @var IScheduleRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $scheduleRepository;
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
 
     /**
      * @var FakeUserRepository
      */
     private $userRepository;
 
-    /**
-     * @var IResourceService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $resourceService;
+    private IResourceService&\PHPUnit\Framework\MockObject\MockObject $resourceService;
 
-    /**
-     * @var ICalendarSubscriptionService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $subscriptionService;
+    private ICalendarSubscriptionService&\PHPUnit\Framework\MockObject\MockObject $subscriptionService;
 
     /**
      * @var FakePrivacyFilter
@@ -151,7 +133,7 @@ class CalendarPresenterTest extends TestBase
         $calendarFilters = new CalendarFilters($schedules, $resources, $defaultScheduleId, null, new ResourceGroupTree());
         $this->page->expects($this->atLeastOnce())->method('BindFilters')->with($this->equalTo($calendarFilters));
 
-        $this->presenter->PageLoad($this->fakeUser, $userTimezone);
+        $this->presenter->PageLoad($this->fakeUser);
     }
 
     public function testSkipsReservationsForUnknownResources()

--- a/tests/Presenters/Dashboard/UpcomingReservationsPresenterTest.php
+++ b/tests/Presenters/Dashboard/UpcomingReservationsPresenterTest.php
@@ -9,15 +9,9 @@ class UpcomingReservationsPresenterTest extends TestBase
      */
     private $presenter;
 
-    /**
-     * @var IUpcomingReservationsControl
-     */
-    private $control;
+    private IUpcomingReservationsControl&\PHPUnit\Framework\MockObject\MockObject $control;
 
-    /**
-     * @var IReservationViewRepository
-     */
-    private $repository;
+    private IReservationViewRepository&\PHPUnit\Framework\MockObject\MockObject $repository;
 
     public function setUp(): void
     {

--- a/tests/Presenters/PersonalCalendarPresenterTest.php
+++ b/tests/Presenters/PersonalCalendarPresenterTest.php
@@ -5,45 +5,24 @@ require_once(ROOT_DIR . 'Presenters/Calendar/PersonalCalendarPresenter.php');
 
 class PersonalCalendarPresenterTest extends TestBase
 {
-    /**
-     * @var ICommonCalendarPage|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $page;
+    private ICommonCalendarPage&\PHPUnit\Framework\MockObject\MockObject $page;
 
     /**
      * @var PersonalCalendarPresenter
      */
     private $presenter;
 
-    /**
-     * @var IReservationViewRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $repository;
+    private IReservationViewRepository&\PHPUnit\Framework\MockObject\MockObject $repository;
 
-    /**
-     * @var ICalendarFactory|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $calendarFactory;
+    private ICalendarFactory&\PHPUnit\Framework\MockObject\MockObject $calendarFactory;
 
-    /**
-     * @var ICalendarSubscriptionService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $subscriptionService;
+    private ICalendarSubscriptionService&\PHPUnit\Framework\MockObject\MockObject $subscriptionService;
 
-    /**
-     * @var IUserRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $userRepository;
+    private IUserRepository&\PHPUnit\Framework\MockObject\MockObject $userRepository;
 
-    /**
-     * @var IResourceService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $resourceService;
+    private IResourceService&\PHPUnit\Framework\MockObject\MockObject $resourceService;
 
-    /**
-     * @var IScheduleRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $scheduleRepository;
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
 
     public function setUp(): void
     {
@@ -144,6 +123,6 @@ class PersonalCalendarPresenterTest extends TestBase
         $calendarFilters = new CalendarFilters($schedules, $resources, $defaultScheduleId, null, $resourceGroupTree);
         $this->page->expects($this->atLeastOnce())->method('BindFilters')->with($this->equalTo($calendarFilters));
 
-        $this->presenter->PageLoad($this->fakeUser, $userTimezone);
+        $this->presenter->PageLoad($this->fakeUser);
     }
 }

--- a/tests/Presenters/RegisterPresenterTest.php
+++ b/tests/Presenters/RegisterPresenterTest.php
@@ -27,20 +27,12 @@ class RegisterPresenterTest extends TestBase
      */
     private $fakeAuth;
 
-    /**
-     * @var ICaptchaService
-     */
-    private $captcha;
+    private ICaptchaService&\PHPUnit\Framework\MockObject\MockObject $captcha;
 
-    /**
-     * @var IAttributeService
-     */
-    private $attributeService;
+    private IAttributeService&\PHPUnit\Framework\MockObject\MockObject $attributeService;
 
-    /**
-     * @var ITermsOfServiceRepository
-     */
-    private $termsOfServiceRepository;
+    // Intentionally concrete fake in setUp(), not a PHPUnit mock.
+    private ITermsOfServiceRepository $termsOfServiceRepository;
 
     private $login = 'testlogin';
     private $email = 'test@test.com';

--- a/tests/Presenters/Reservation/EditReservationPresenterTest.php
+++ b/tests/Presenters/Reservation/EditReservationPresenterTest.php
@@ -9,30 +9,15 @@ class EditReservationPresenterTest extends TestBase
 
     private $userId;
 
-    /**
-     * @var IExistingReservationPage
-     */
-    private $page;
+    private IExistingReservationPage&\PHPUnit\Framework\MockObject\MockObject $page;
 
-    /**
-     * @var IReservationViewRepository
-     */
-    private $reservationViewRepository;
+    private IReservationViewRepository&\PHPUnit\Framework\MockObject\MockObject $reservationViewRepository;
 
-    /**
-     * @var IReservationPreconditionService
-     */
-    private $preconditionService;
+    private EditReservationPreconditionService&\PHPUnit\Framework\MockObject\MockObject $preconditionService;
 
-    /**
-     * @var IReservationInitializerFactory
-     */
-    private $initializerFactory;
+    private IReservationInitializerFactory&\PHPUnit\Framework\MockObject\MockObject $initializerFactory;
 
-    /**
-     * @var IReservationInitializer
-     */
-    private $initializer;
+    private IReservationInitializer&\PHPUnit\Framework\MockObject\MockObject $initializer;
 
     public function setUp(): void
     {

--- a/tests/Presenters/Reservation/GuestReservationPresenterTest.php
+++ b/tests/Presenters/Reservation/GuestReservationPresenterTest.php
@@ -13,23 +13,14 @@ class GuestReservationPresenterTest extends TestBase
      */
     private $presenter;
 
-    /**
-     * @var IReservationInitializerFactory
-     */
-    private $factory;
+    private IReservationInitializerFactory&\PHPUnit\Framework\MockObject\MockObject $factory;
 
-    /**
-     * @var INewReservationPreconditionService
-     */
-    private $preconditionService;
+    private INewReservationPreconditionService&\PHPUnit\Framework\MockObject\MockObject $preconditionService;
     /**
      * @var FakeRegistration
      */
     private $registration;
-    /**
-     * @var IReservationInitializer
-     */
-    private $initializer;
+    private IReservationInitializer&\PHPUnit\Framework\MockObject\MockObject $initializer;
     /**
      * @var FakeWebAuthentication
      */

--- a/tests/Presenters/Reservation/ReservationAttributesPresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationAttributesPresenterTest.php
@@ -4,13 +4,11 @@ require_once(ROOT_DIR . 'Presenters/Reservation/ReservationAttributesPresenter.p
 
 class ReservationAttributesPresenterTest extends TestBase
 {
-    /**
-     * @var IAttributeService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $attributeService;
+    // Intentionally concrete service in setUp(), not a PHPUnit mock.
+    private IAttributeService $attributeService;
 
     /**
-     * @var FakeReservationAuthorization
+     * @var FakeAuthorizationService
      */
     private $authorizationService;
 
@@ -34,10 +32,7 @@ class ReservationAttributesPresenterTest extends TestBase
      */
     private $presenter;
 
-    /**
-     * @var IAttributeRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $attributeRepository;
+    private IAttributeRepository&\PHPUnit\Framework\MockObject\MockObject $attributeRepository;
 
     public function setUp(): void
     {
@@ -215,7 +210,7 @@ class ReservationAttributesPresenterTest extends TestBase
 class FakeReservationAttributesPage implements IReservationAttributesPage
 {
     /**
-     * @var Attribute[]
+     * @var LBAttribute[]
      */
     public $_Attributes;
 
@@ -238,7 +233,7 @@ class FakeReservationAttributesPage implements IReservationAttributesPage
     }
 
     /**
-     * @param Attribute[] $attributes
+     * @param LBAttribute[] $attributes
      */
     public function SetAttributes($attributes)
     {

--- a/tests/Presenters/Reservation/ReservationDeletePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationDeletePresenterTest.php
@@ -13,20 +13,11 @@ class ReservationDeletePresenterTest extends TestBase
      */
     private $user;
 
-    /**
-     * @var IReservationDeletePage
-     */
-    private $page;
+    private IReservationDeletePage&\PHPUnit\Framework\MockObject\MockObject $page;
 
-    /**
-     * @var IDeleteReservationPersistenceService
-     */
-    private $persistenceService;
+    private IDeleteReservationPersistenceService&\PHPUnit\Framework\MockObject\MockObject $persistenceService;
 
-    /**
-     * @var IReservationHandler
-     */
-    private $handler;
+    private IReservationHandler&\PHPUnit\Framework\MockObject\MockObject $handler;
 
     /**
      * @var ReservationDeletePresenter

--- a/tests/Presenters/Reservation/ReservationMovePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationMovePresenterTest.php
@@ -18,25 +18,16 @@ class ReservationMovePresenterTest extends TestBase
      */
     private $page;
 
-    /**
-     * @var IUpdateReservationPersistenceService
-     */
-    private $persistenceService;
+    private IUpdateReservationPersistenceService&\PHPUnit\Framework\MockObject\MockObject $persistenceService;
 
-    /**
-     * @var IReservationHandler
-     */
-    private $handler;
+    private IReservationHandler&\PHPUnit\Framework\MockObject\MockObject $handler;
 
     /**
      * @var ReservationMovePresenter
      */
     private $presenter;
 
-    /**
-     * @var IResourceRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $resourceRepository;
+    private IResourceRepository&\PHPUnit\Framework\MockObject\MockObject $resourceRepository;
 
     public function setUp(): void
     {

--- a/tests/Presenters/Reservation/ReservationSavePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationSavePresenterTest.php
@@ -17,7 +17,7 @@ class ReservationSavePresenterTest extends TestBase
     private $userId;
 
     /**
-     * @var IReservationSavePage|FakeReservationSavePage
+     * @var FakeReservationSavePage
      */
     private $page;
 
@@ -26,20 +26,11 @@ class ReservationSavePresenterTest extends TestBase
      */
     private $presenter;
 
-    /**
-     * @var IReservationPersistenceService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $persistenceService;
+    private IReservationPersistenceService&\PHPUnit\Framework\MockObject\MockObject $persistenceService;
 
-    /**
-     * @var IReservationHandler|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $handler;
+    private IReservationHandler&\PHPUnit\Framework\MockObject\MockObject $handler;
 
-    /**
-     * @var IResourceRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $resourceRepository;
+    private IResourceRepository&\PHPUnit\Framework\MockObject\MockObject $resourceRepository;
 
     /**
      * @var FakeScheduleRepository

--- a/tests/Presenters/Reservation/ReservationUpdatePresenterTest.php
+++ b/tests/Presenters/Reservation/ReservationUpdatePresenterTest.php
@@ -18,20 +18,11 @@ class ReservationUpdatePresenterTest extends TestBase
      */
     private $page;
 
-    /**
-     * @var IUpdateReservationPersistenceService
-     */
-    private $persistenceService;
+    private IUpdateReservationPersistenceService&\PHPUnit\Framework\MockObject\MockObject $persistenceService;
 
-    /**
-     * @var IReservationHandler
-     */
-    private $handler;
+    private IReservationHandler&\PHPUnit\Framework\MockObject\MockObject $handler;
 
-    /**
-     * @var IResourceRepository
-     */
-    private $resourceRepository;
+    private IResourceRepository&\PHPUnit\Framework\MockObject\MockObject $resourceRepository;
 
     /**
      * @var FakeScheduleRepository

--- a/tests/WebServices/AccessoriesWebServiceTest.php
+++ b/tests/WebServices/AccessoriesWebServiceTest.php
@@ -15,15 +15,9 @@ class AccessoriesWebServiceTest extends TestBase
      */
     private $server;
 
-    /**
-     * @var IResourceRepository
-     */
-    private $resourceRepository;
+    private IResourceRepository&\PHPUnit\Framework\MockObject\MockObject $resourceRepository;
 
-    /**
-     * @var IAccessoryRepository
-     */
-    private $accessoryRepository;
+    private IAccessoryRepository&\PHPUnit\Framework\MockObject\MockObject $accessoryRepository;
 
     public function setUp(): void
     {

--- a/tests/WebServices/Controllers/ReservationSaveControllerTest.php
+++ b/tests/WebServices/Controllers/ReservationSaveControllerTest.php
@@ -9,10 +9,7 @@ class ReservationSaveControllerTest extends TestBase
      */
     private $controller;
 
-    /**
-     * @var IReservationPresenterFactory
-     */
-    private $presenterFactory;
+    private IReservationPresenterFactory&\PHPUnit\Framework\MockObject\MockObject $presenterFactory;
 
     public function setUp(): void
     {

--- a/tests/WebServices/Controllers/ResourceSaveControllerTest.php
+++ b/tests/WebServices/Controllers/ResourceSaveControllerTest.php
@@ -14,15 +14,9 @@ class ResourceSaveControllerTest extends TestBase
      */
     private $session;
 
-    /**
-     * @var IResourceRepository
-     */
-    private $repository;
+    private IResourceRepository&\PHPUnit\Framework\MockObject\MockObject $repository;
 
-    /**
-     * @var IResourceRequestValidator
-     */
-    private $validator;
+    private IResourceRequestValidator&\PHPUnit\Framework\MockObject\MockObject $validator;
 
     public function setUp(): void
     {

--- a/tests/WebServices/Controllers/UserSaveControllerTest.php
+++ b/tests/WebServices/Controllers/UserSaveControllerTest.php
@@ -9,20 +9,11 @@ class UserSaveControllerTest extends TestBase
      */
     private $controller;
 
-    /**
-     * @var IManageUsersServiceFactory
-     */
-    private $manageUserServiceFactory;
+    private IManageUsersServiceFactory&\PHPUnit\Framework\MockObject\MockObject $manageUserServiceFactory;
 
-    /**
-     * @var IManageUsersService
-     */
-    private $manageUsersService;
+    private IManageUsersService&\PHPUnit\Framework\MockObject\MockObject $manageUsersService;
 
-    /**
-     * @var IUserRequestValidator
-     */
-    private $requestValidator;
+    private IUserRequestValidator&\PHPUnit\Framework\MockObject\MockObject $requestValidator;
 
     public function setUp(): void
     {

--- a/tests/WebServices/GroupsWebServiceTest.php
+++ b/tests/WebServices/GroupsWebServiceTest.php
@@ -14,15 +14,9 @@ class GroupsWebServiceTest extends TestBase
      */
     private $service;
 
-    /**
-     * @var IGroupRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $groupRepository;
+    private IGroupRepository&\PHPUnit\Framework\MockObject\MockObject $groupRepository;
 
-    /**
-     * @var IGroupViewRepository
-     */
-    private $groupViewRepository;
+    private IGroupViewRepository&\PHPUnit\Framework\MockObject\MockObject $groupViewRepository;
 
     public function setUp(): void
     {

--- a/tests/WebServices/ReservationsWebServiceTest.php
+++ b/tests/WebServices/ReservationsWebServiceTest.php
@@ -14,20 +14,11 @@ class ReservationsWebServiceTest extends TestBase
      */
     private $service;
 
-    /**
-     * @var IReservationViewRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $reservationViewRepository;
+    private IReservationViewRepository&\PHPUnit\Framework\MockObject\MockObject $reservationViewRepository;
 
-    /**
-     * @var IPrivacyFilter
-     */
-    private $privacyFilter;
+    private IPrivacyFilter&\PHPUnit\Framework\MockObject\MockObject $privacyFilter;
 
-    /**
-     * @var IAttributeService
-     */
-    private $attributeService;
+    private IAttributeService&\PHPUnit\Framework\MockObject\MockObject $attributeService;
 
     /**
      * @var WebServiceUserSession

--- a/tests/WebServices/ResourcesWebServiceTest.php
+++ b/tests/WebServices/ResourcesWebServiceTest.php
@@ -9,20 +9,11 @@ class ResourcesWebServiceTest extends TestBase
      */
     private $server;
 
-    /**
-     * @var IResourceRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $repository;
+    private IResourceRepository&\PHPUnit\Framework\MockObject\MockObject $repository;
 
-    /**
-     * @var IReservationViewRepository|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $reservationRepository;
+    private IReservationViewRepository&\PHPUnit\Framework\MockObject\MockObject $reservationRepository;
 
-    /**
-     * @var IAttributeService|PHPUnit\Framework\MockObject\MockObject
-     */
-    private $attributeService;
+    private IAttributeService&\PHPUnit\Framework\MockObject\MockObject $attributeService;
 
     /**
      * @var ResourcesWebService
@@ -227,7 +218,7 @@ class ResourcesWebServiceTest extends TestBase
                                     )
                                     ->willReturn($reservations);
 
-        $this->service->GetAvailability($resourceId1);
+        $this->service->GetAvailability();
     }
 
     public function testGetsSingleResourceAvailabilityForARequestTime()
@@ -262,6 +253,6 @@ class ResourcesWebServiceTest extends TestBase
                                     )
                                     ->willReturn($reservations);
 
-        $this->service->GetAvailability($resourceId1);
+        $this->service->GetAvailability();
     }
 }

--- a/tests/WebServices/SchedulesWebServiceTest.php
+++ b/tests/WebServices/SchedulesWebServiceTest.php
@@ -16,15 +16,9 @@ class SchedulesWebServiceTest extends TestBase
      */
     private $server;
 
-    /**
-     * @var IScheduleRepository
-     */
-    private $scheduleRepository;
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
 
-    /**
-     * @var IPrivacyFilter
-     */
-    private $privacyFilter;
+    private IPrivacyFilter&\PHPUnit\Framework\MockObject\MockObject $privacyFilter;
 
     public function setUp(): void
     {

--- a/tests/WebServices/Validators/ResourceRequestValidatorTest.php
+++ b/tests/WebServices/Validators/ResourceRequestValidatorTest.php
@@ -9,10 +9,7 @@ class ResourceRequestValidatorTest extends TestBase
      */
     private $validator;
 
-    /**
-     * @var IAttributeService
-     */
-    private $attributeService;
+    private IAttributeService&\PHPUnit\Framework\MockObject\MockObject $attributeService;
 
     public function setUp(): void
     {

--- a/tests/WebServices/Validators/UserRequestValidatorTest.php
+++ b/tests/WebServices/Validators/UserRequestValidatorTest.php
@@ -4,20 +4,14 @@ require_once(ROOT_DIR . 'WebServices/Validators/UserRequestValidator.php');
 
 class UserRequestValidatorTest extends TestBase
 {
-    /**
-     * @var IAttributeService
-     */
-    private $attributeService;
+    private IAttributeService&\PHPUnit\Framework\MockObject\MockObject $attributeService;
 
     /**
      * @var UserRequestValidator
      */
     private $validator;
 
-    /**
-     * @var IUserViewRepository
-     */
-    private $userRepository;
+    private IUserViewRepository&\PHPUnit\Framework\MockObject\MockObject $userRepository;
 
     public function setUp(): void
     {

--- a/tests/fakes/EmailFakes.php
+++ b/tests/fakes/EmailFakes.php
@@ -20,11 +20,13 @@ class FakeMailer extends PHPMailer
     public function AddAddress($address, $name = '')
     {
         $this->addresses[] = $address;
+        return true;
     }
 
     public function Send()
     {
         $this->sendWasCalled = true;
+        return true;
     }
 
     public function IsHTML($bool = true)


### PR DESCRIPTION
Add phpstan/phpstan-phpunit to support mock type inference in tests. Re-add tests directory to PHPStan scanning paths (was excluded in the prior commit). Fix all PHPStan level 2 errors in test files:

- Use PHP 8.1 intersection types (Interface&MockObject) for mock property declarations instead of @var docblocks
- Fix incorrect @var annotations (InstanceAddedEvent -> InstanceUpdatedEvent, Attribute -> LBAttribute, FakeReservationAuthorization -> FakeAuthorizationService)
- Add missing return values in FakeMailer (AddAddress, Send)
- Add assertInstanceOf guards before accessing concrete-type methods
- Remove invalid method arguments (PageLoad extra param, GetAvailability extra param, assertEquals non-stringable third arg)
- Remove redundant __toString() calls on string return values
- Add missing property to TestAdLdapEntry
- Fix Attribute -> LBAttribute in ResourceService phpdoc

Closes: #737