### PR TITLE
test(phpstan): fix some level 3 typing issues in `tests/`

### DIFF
--- a/Domain/Reservation.php
+++ b/Domain/Reservation.php
@@ -720,7 +720,7 @@ class ReferenceNumberGenerator
 {
     /**
      * Just for testing
-     * @var string
+     * @var string|null
      */
     public static $__referenceNumber = null;
 

--- a/lib/Common/LoginTime.php
+++ b/lib/Common/LoginTime.php
@@ -3,7 +3,7 @@
 class LoginTime
 {
     /**
-     * @var null
+     * @var int|false|null
      * Only for testing
      */
     public static $Now = null;

--- a/phpstan_next.neon
+++ b/phpstan_next.neon
@@ -40,6 +40,7 @@ parameters:
             - Presenters/
             - WebServices/
             - lib/
-            - tests/
+            - tests/fakes/
+            - tests/Presenters/
     bootstrapFiles:
         - vendor/autoload.php

--- a/tests/Application/Attributes/AttributeServiceTest.php
+++ b/tests/Application/Attributes/AttributeServiceTest.php
@@ -92,7 +92,7 @@ class AttributeServiceTest extends TestBase
         ];
 
         $this->attributeRepository->_CustomAttributes = $attributes;
-        $this->attributeRepository->_EntityValues = $values;
+        $this->attributeRepository->_EntityValues = [];
 
         $result = $this->attributeService->Validate($category, $values, $entityId);
 
@@ -109,7 +109,7 @@ class AttributeServiceTest extends TestBase
         $values = [new AttributeValue(1, 'value1')];
 
         $this->attributeRepository->_CustomAttributes = $attributes;
-        $this->attributeRepository->_EntityValues = $values;
+        $this->attributeRepository->_EntityValues = [];
 
         $result = $this->attributeService->Validate($category, $values, null, false, $isAdmin);
 
@@ -125,7 +125,7 @@ class AttributeServiceTest extends TestBase
         $values = [new AttributeValue(1, 'value1')];
 
         $this->attributeRepository->_CustomAttributes = $attributes;
-        $this->attributeRepository->_EntityValues = $values;
+        $this->attributeRepository->_EntityValues = [];
 
         $result = $this->attributeService->Validate($category, $values, null, false, $isAdmin);
 

--- a/tests/Application/Authentication/PasswordMigrationTest.php
+++ b/tests/Application/Authentication/PasswordMigrationTest.php
@@ -24,7 +24,7 @@ class PasswordMigrationTest extends TestBase
 
     public function teardown(): void
     {
-        $this->_db = null;
+        parent::teardown();
     }
 
     public function testPasswordValidatesWithNewValidationAndDoesNotMigrate()

--- a/tests/Application/Authentication/RegistrationTest.php
+++ b/tests/Application/Authentication/RegistrationTest.php
@@ -54,7 +54,6 @@ class RegistrationTest extends TestBase
     public function teardown(): void
     {
         parent::teardown();
-        $this->registration = null;
     }
 
     public function testRegistersUserWhenNoManualActivationRequired()
@@ -371,7 +370,7 @@ class RegistrationTest extends TestBase
     public function testSyncsGroups()
     {
         $userRepository = new FakeUserRepository();
-        $userRepository->_Exists = false;
+        $userRepository->_Exists = null;
 
         $username = 'un';
         $email = 'e';

--- a/tests/Application/Reservation/CreditsRuleTest.php
+++ b/tests/Application/Reservation/CreditsRuleTest.php
@@ -11,7 +11,7 @@ class CreditsRuleTest extends TestBase
     public $userRepository;
 
     /**
-     * @var AccessoryAvailabilityRule
+     * @var CreditsRule
      */
     public $rule;
 

--- a/tests/Application/Reservation/ReservationComponentTest.php
+++ b/tests/Application/Reservation/ReservationComponentTest.php
@@ -543,7 +543,7 @@ class ReservationComponentTest extends TestBase
         $participatingGuests = ['p1@email.com', 'p2@email.com'];
         $invitedGuests = ['i1@email.com', 'i2@email.com'];
         $accessories = [
-            new ReservationAccessory(1, 2)
+            new ReservationAccessoryView(1, 2, 'a1', 10)
         ];
 
         $attachments = [

--- a/tests/Application/Schedule/CalendarMonthTest.php
+++ b/tests/Application/Schedule/CalendarMonthTest.php
@@ -101,21 +101,21 @@ class CalendarMonthTest extends TestBase
         $r1->ResourceId = 1;
         $r1->StartDate = $start;
         $r1->EndDate = $end;
-        $r1->ReferenceNumber = 1;
+        $r1->ReferenceNumber = '1';
 
         $r2 = new ReservationItemView();
         $r2->SeriesId = 1;
         $r2->ResourceId = 2;
         $r2->StartDate = $start;
         $r2->EndDate = $end;
-        $r2->ReferenceNumber = 1;
+        $r2->ReferenceNumber = '1';
 
         $r3 = new ReservationItemView();
         $r3->SeriesId = 2;
         $r3->ResourceId = 1;
         $r3->StartDate = $start;
         $r3->EndDate = $end;
-        $r3->ReferenceNumber = 2;
+        $r3->ReferenceNumber = '2';
 
         $reservations = [$r1, $r2, $r3];
 

--- a/tests/Domain/Announcement/AnnouncementRepositoryTest.php
+++ b/tests/Domain/Announcement/AnnouncementRepositoryTest.php
@@ -29,8 +29,6 @@ class AnnouncementRepositoryTest extends TestBase
         parent::teardown();
 
         Date::_ResetNow();
-
-        $this->repository = null;
     }
 
     public function testGetFutureCallDBCorrectly()

--- a/tests/Domain/Reservation/QuotaRepositoryTest.php
+++ b/tests/Domain/Reservation/QuotaRepositoryTest.php
@@ -20,8 +20,6 @@ class QuotaRepositoryTest extends TestBase
     public function teardown(): void
     {
         parent::teardown();
-
-        $this->repository = null;
     }
 
     public function testCanGetQuotas()

--- a/tests/Domain/Reservation/ReservationRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationRepositoryTest.php
@@ -21,8 +21,6 @@ class ReservationRepositoryTest extends TestBase
     public function teardown(): void
     {
         parent::teardown();
-
-        $this->repository = null;
     }
 
     public function testAddReservationWithOneUserAndOneResource()

--- a/tests/Domain/Reservation/ReservationServiceTest.php
+++ b/tests/Domain/Reservation/ReservationServiceTest.php
@@ -61,9 +61,7 @@ class ReservationServiceTest extends TestBase
         $listing = $service->GetReservations($range, $scheduleId, $timezone);
 
         $this->assertEquals($reservationListing, $listing);
-        $this->assertTrue(in_array($res1, $reservationListing->reservations));
-        $this->assertTrue(in_array($res2, $reservationListing->reservations));
-        $this->assertTrue(in_array($res3, $reservationListing->reservations));
+        $this->assertEquals([$res1, $res2, $res3], array_map(fn (ReservationListItem $i) => $i->ReservedItem(), $reservationListing->reservations));
         $this->assertTrue(in_array($blackout1, $reservationListing->blackouts));
         $this->assertTrue(in_array($blackout2, $reservationListing->blackouts));
         $this->assertTrue(in_array($blackout3, $reservationListing->blackouts));
@@ -73,7 +71,7 @@ class ReservationServiceTest extends TestBase
 class TestReservationListing implements IMutableReservationListing
 {
     /**
-     * @var array|ReservationItemView[]
+     * @var array|ReservationListItem[]
      */
     public $reservations = [];
 
@@ -87,27 +85,24 @@ class TestReservationListing implements IMutableReservationListing
      */
     public function Count()
     {
-        // TODO: Implement Count() method.
-        return null;
+        return count($this->Reservations());
     }
 
     /**
-     * @return array|ReservationItemView[]
+     * @return array|ReservationListItem[]
      */
     public function Reservations()
     {
-        // TODO: Implement Reservations() method.
-        return null;
+        return $this->reservations;
     }
 
     /**
      * @param Date $date
-     * @return IDateReservationListing
+     * @return IReservationListing
      */
     public function OnDate($date)
     {
-        // TODO: Implement OnDate() method.
-        return null;
+        return new EmptyReservationListing();
     }
 
     /**
@@ -116,7 +111,7 @@ class TestReservationListing implements IMutableReservationListing
      */
     public function Add($reservation)
     {
-        $this->reservations[] = $reservation;
+        $this->reservations[] = new ReservationListItem($reservation);
     }
 
     /**
@@ -134,8 +129,7 @@ class TestReservationListing implements IMutableReservationListing
      */
     public function ForResource($resourceId)
     {
-        // TODO: Implement ForResource() method.
-        return null;
+        return new EmptyReservationListing();
     }
 
     /**
@@ -145,7 +139,6 @@ class TestReservationListing implements IMutableReservationListing
      */
     public function OnDateForResource(Date $date, $resourceId)
     {
-        // TODO: Implement OnDateForResource() method.
-        return null;
+        return [];
     }
 }

--- a/tests/Domain/Reservation/ReservationViewRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationViewRepositoryTest.php
@@ -224,7 +224,7 @@ class ReservationViewRepositoryTest extends TestBase
         $expectedView->StartDate = $startDate;
         $expectedView->Title = $title;
         $expectedView->RepeatType = $repeatType;
-        $expectedView->RepeatInterval = '5';
+        $expectedView->RepeatInterval = 5;
         $expectedView->SeriesId = $seriesId;
         $expectedView->OwnerFirstName = $ownerFirst;
         $expectedView->OwnerLastName = $ownerLast;

--- a/tests/Domain/Schedule/ScheduleRepositoryTest.php
+++ b/tests/Domain/Schedule/ScheduleRepositoryTest.php
@@ -19,8 +19,6 @@ class ScheduleRepositoryTest extends TestBase
     public function teardown(): void
     {
         parent::teardown();
-
-        $this->scheduleRepository = null;
     }
 
     public function testCanGetAllSchedules()

--- a/tests/Presenters/CalendarPresenterTest.php
+++ b/tests/Presenters/CalendarPresenterTest.php
@@ -162,15 +162,15 @@ class CalendarPresenterTest extends TestBase
 
         $r1 = new TestReservationItemView(1, $start, $end, 1);
         $r1->SeriesId = 1;
-        $r1->ReferenceNumber = 1;
+        $r1->ReferenceNumber = '1';
 
         $r2 = new TestReservationItemView(2, $start, $end, 2);
         $r2->SeriesId = 1;
-        $r2->ReferenceNumber = 2;
+        $r2->ReferenceNumber = '2';
 
         $r3 = new TestReservationItemView(3, $start, $end, 1);
         $r3->SeriesId = 2;
-        $r3->ReferenceNumber = 2;
+        $r3->ReferenceNumber = '2';
 
         $reservations = [$r1, $r2, $r3];
         $blackouts = [];

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -144,11 +144,8 @@ class TestBase extends TestCase
 
     public function teardown(): void
     {
-        $this->db = null;
-        $this->fakeServer = null;
         Configuration::SetInstance(null);
         PluginManager::SetInstance(null);
-        $this->fakeResources = null;
         Date::_ResetNow();
     }
 

--- a/tests/WebService/SlimWebServiceRegistryTest.php
+++ b/tests/WebService/SlimWebServiceRegistryTest.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once(ROOT_DIR . 'lib/external/Slim/Slim.php');
+require_once(ROOT_DIR . 'lib/external/Slim/Route.php');
 require_once(ROOT_DIR . 'lib/WebService/Slim/namespace.php');
 
 class TestSlimCall
@@ -18,22 +19,16 @@ class TestSlimCall
 
     public function name()
     {
-        return $this->response->name;
-    }
-}
-
-class TestSlimResponse
-{
-    public $name;
-
-    public function name($name)
-    {
-        $this->name = $name;
+        return $this->response->getName();
     }
 }
 
 class TestSlim extends Slim\Slim
 {
+    public function __construct()
+    {
+    }
+
     /**
      * @var array|TestSlimCall[]
      */
@@ -46,60 +41,35 @@ class TestSlim extends Slim\Slim
      * @var array|TestSlimCall[]
      */
     public $deletes = [];
-    /**
-     * @var TestSlimResponse
-     */
-    public $getResponse;
-
-    public function __construct()
-    {
-        $this->getResponse = new TestSlimResponse();
-    }
-
-    /**
-     * @param $route
-     * @param $callback
-     * @return TestSlimResponse
-     */
     public function get()
     {
         $args = func_get_args();
         $route = $args[0];
         $callback = $args[1];
 
-        $response = new TestSlimResponse();
+        $response = new Slim\Route($route, $callback);
         $this->gets[] = new TestSlimCall($route, $callback, $response);
         return $response;
     }
 
-    /**
-     * @param $route
-     * @param $callback
-     * @return TestSlimResponse
-     */
     public function post()
     {
         $args = func_get_args();
         $route = $args[0];
         $callback = $args[1];
 
-        $response = new TestSlimResponse();
+        $response = new Slim\Route($route, $callback);
         $this->posts[] = new TestSlimCall($route, $callback, $response);
         return $response;
     }
 
-    /**
-     * @param $route
-     * @param $callback
-     * @return TestSlimResponse
-     */
     public function delete()
     {
         $args = func_get_args();
         $route = $args[0];
         $callback = $args[1];
 
-        $response = new TestSlimResponse();
+        $response = new Slim\Route($route, $callback);
         $this->deletes[] = new TestSlimCall($route, $callback, $response);
         return $response;
     }

--- a/tests/WebServices/AccountWebServiceTest.php
+++ b/tests/WebServices/AccountWebServiceTest.php
@@ -159,13 +159,11 @@ class FakeAccountController implements IAccountController
 
     public function LoadUser(WebServiceUserSession $session)
     {
-        // TODO: Implement GetUserAttributes() method.
-        return null;
+        return new FakeUser();
     }
 
     public function GetUserAttributes(WebServiceUserSession $session)
     {
-        // TODO: Implement GetUserAttributes() method.
-        return null;
+        return new AttributeList();
     }
 }

--- a/tests/WebServices/Controllers/AccountControllerTest.php
+++ b/tests/WebServices/Controllers/AccountControllerTest.php
@@ -147,6 +147,7 @@ class AccountControllerTest extends TestBase
 
         $result = $this->controller->UpdatePassword($request, $this->session);
 
+        /** @var FakeUser $user */
         $user = $this->userRepository->_UpdatedUser;
 
         $this->assertTrue($result->WasSuccessful());

--- a/tests/WebServices/Controllers/AttributeSaveControllerTest.php
+++ b/tests/WebServices/Controllers/AttributeSaveControllerTest.php
@@ -77,7 +77,7 @@ class AttributeSaveControllerTest extends TestBase
         $request->required = true;
         $request->possibleValues = '1,2,3';
         $request->sortOrder = 9;
-        $request->appliesToIds = 100;
+        $request->appliesToIds = [100];
 
         $result = $this->controller->Update($attributeId, $request, $this->session);
 

--- a/tests/WebServices/Validators/ResourceRequestValidatorTest.php
+++ b/tests/WebServices/Validators/ResourceRequestValidatorTest.php
@@ -21,9 +21,13 @@ class ResourceRequestValidatorTest extends TestBase
     public function testBasicRequiredFields()
     {
         $request = ResourceRequest::Example();
-        $request->customAttributes = null;
-        $request->name = null;
-        $request->scheduleId = '   ';
+        $request->customAttributes = [];
+        /** @var mixed $missingName */
+        $missingName = null;
+        /** @var mixed $missingScheduleId */
+        $missingScheduleId = '   ';
+        $request->name = $missingName;
+        $request->scheduleId = $missingScheduleId;
 
         $createErrors = $this->validator->ValidateCreateRequest($request);
         $updateErrors = $this->validator->ValidateUpdateRequest(1, $request);
@@ -35,7 +39,7 @@ class ResourceRequestValidatorTest extends TestBase
     public function testTimesAreCheckedWhenProvided()
     {
         $request = ResourceRequest::Example();
-        $request->customAttributes = null;
+        $request->customAttributes = [];
         $request->maxNotice = 'xyz';
 
         $createErrors = $this->validator->ValidateCreateRequest($request);
@@ -68,7 +72,6 @@ class ResourceRequestValidatorTest extends TestBase
     public function testUpdateAndDeleteRequireResourceId()
     {
         $request = ResourceRequest::Example();
-        $request->customAttributes = null;
 
         $deleteErrors = $this->validator->ValidateDeleteRequest(null);
         $updateErrors = $this->validator->ValidateUpdateRequest('', $request);

--- a/tests/fakes/FakeSchedules.php
+++ b/tests/fakes/FakeSchedules.php
@@ -23,7 +23,7 @@ class FakeScheduleRepository implements IScheduleRepository
     public $_Schedule;
 
     /**
-     * @var ScheduleLayout|null
+     * @var IScheduleLayout|null
      */
     public $_Layout;
 

--- a/tests/fakes/FakeUserRepository.php
+++ b/tests/fakes/FakeUserRepository.php
@@ -3,15 +3,15 @@
 class FakeUserRepository implements IUserRepository
 {
     /**
-     * @var FakeUser
+     * @var User
      */
     public $_User;
     /**
-     * @var FakeUser
+     * @var User
      */
     public $_UpdatedUser;
     /**
-     * @var FakeUser
+     * @var User
      */
     public $_AddedUser;
 


### PR DESCRIPTION
Enable PHPStan level 3 checking of most of the `tests/` directory. Excluding `tests/fakes/` and `tests/Presenters/`