### PR TITLE
refactor(ScheduleStyle): Convert ScheduleStyle to an enum

### DIFF
--- a/Domain/Access/ScheduleRepository.php
+++ b/Domain/Access/ScheduleRepository.php
@@ -240,7 +240,7 @@ class ScheduleRepository implements IScheduleRepository
             $schedule->GetAdminGroupId(),
             $schedule->GetAvailabilityBegin(),
             $schedule->GetAvailabilityEnd(),
-            $schedule->GetDefaultStyle(),
+            $schedule->GetDefaultStyleInt(),
             $schedule->GetTotalConcurrentReservations(),
             $schedule->GetMaxResourcesPerReservation()
         ));

--- a/Domain/Schedule.php
+++ b/Domain/Schedule.php
@@ -44,10 +44,7 @@ interface ISchedule
      */
     public function HasAvailability();
 
-    /**
-     * @return int
-     */
-    public function GetDefaultStyle();
+    public function GetDefaultStyle(): ScheduleStyle;
 }
 
 class Schedule implements ISchedule
@@ -64,7 +61,7 @@ class Schedule implements ISchedule
     protected $_adminGroupId;
     protected $_availabilityBegin;
     protected $_availabilityEnd;
-    protected $_defaultStyle;
+    protected ScheduleStyle $_defaultStyle;
     protected $_layoutType;
     protected $_totalConcurrentReservations = 0;
     protected $_maxResourcesPerReservation = 0;
@@ -272,20 +269,24 @@ class Schedule implements ISchedule
         return $this->GetAvailabilityBegin()->ToString() != '' && $this->GetAvailabilityEnd()->ToString() != '';
     }
 
-    /**
-     * @return int|ScheduleStyle
-     */
-    public function GetDefaultStyle()
+    public function GetDefaultStyle(): ScheduleStyle
     {
         return $this->_defaultStyle;
     }
 
-    /**
-     * @param $defaultDisplay int|ScheduleStyle
-     */
-    public function SetDefaultStyle($defaultDisplay)
+    public function GetDefaultStyleInt(): int
     {
-        $this->_defaultStyle = $defaultDisplay;
+        return $this->_defaultStyle->value;
+    }
+
+    public function SetDefaultStyle(int|ScheduleStyle $defaultDisplay): void
+    {
+        if ($defaultDisplay instanceof ScheduleStyle) {
+            $this->_defaultStyle = $defaultDisplay;
+            return;
+        }
+
+        $this->_defaultStyle = ScheduleStyle::tryFrom($defaultDisplay) ?? ScheduleStyle::Standard;
     }
 
     /**
@@ -434,10 +435,10 @@ class NullSchedule extends Schedule
 }
 
 
-class ScheduleStyle
+enum ScheduleStyle: int
 {
-    public const Standard = 0;
-    public const Wide = 1;
-    public const Tall = 2;
-    public const CondensedWeek = 3;
+    case Standard = 0;
+    case Wide = 1;
+    case Tall = 2;
+    case CondensedWeek = 3;
 }

--- a/Pages/Admin/ManageSchedulesPage.php
+++ b/Pages/Admin/ManageSchedulesPage.php
@@ -288,10 +288,10 @@ class ManageSchedulesPage extends ActionPage implements IManageSchedulesPage
         $this->Set('Months', Resources::GetInstance()->GetMonths('full'));
         $this->Set('DayList', range(1, 31));
         $this->Set('StyleNames', [
-            ScheduleStyle::Standard => $resources->GetString('Standard'),
-            ScheduleStyle::Wide => $resources->GetString('Wide'),
-            ScheduleStyle::Tall => $resources->GetString('Tall'),
-            ScheduleStyle::CondensedWeek => $resources->GetString('Week'),
+            ScheduleStyle::Standard->value => $resources->GetString('Standard'),
+            ScheduleStyle::Wide->value => $resources->GetString('Wide'),
+            ScheduleStyle::Tall->value => $resources->GetString('Tall'),
+            ScheduleStyle::CondensedWeek->value => $resources->GetString('Week'),
         ]);
         $this->Display('Admin/Schedules/manage_schedules.tpl');
     }

--- a/Pages/SchedulePage.php
+++ b/Pages/SchedulePage.php
@@ -86,14 +86,14 @@ interface ISchedulePage extends IActionPage
 
     /**
      * @param int $scheduleId
-     * @return string|ScheduleStyle
+     * @return ScheduleStyle|null
      */
-    public function GetScheduleStyle($scheduleId);
+    public function GetScheduleStyle(int $scheduleId): ?ScheduleStyle;
 
     /**
-     * @param string|ScheduleStyle $direction
+     * @param ScheduleStyle $direction
      */
-    public function SetScheduleStyle($direction);
+    public function SetScheduleStyle(ScheduleStyle $direction): void;
 
     /**
      * @return int
@@ -237,9 +237,9 @@ class SchedulePage extends ActionPage implements ISchedulePage
     protected $_presenter;
 
     private $_styles = [
-        ScheduleStyle::Wide => 'Schedule/schedule-days-horizontal.tpl',
-        ScheduleStyle::Tall => 'Schedule/schedule-flipped.tpl',
-        ScheduleStyle::CondensedWeek => 'Schedule/schedule-week-condensed.tpl',
+        ScheduleStyle::Wide->value => 'Schedule/schedule-days-horizontal.tpl',
+        ScheduleStyle::Tall->value => 'Schedule/schedule-flipped.tpl',
+        ScheduleStyle::CondensedWeek->value => 'Schedule/schedule-week-condensed.tpl',
     ];
 
     /**
@@ -259,7 +259,6 @@ class SchedulePage extends ActionPage implements ISchedulePage
         $this->Set('CanViewUsers', !Configuration::Instance()->GetKey(ConfigKeys::PRIVACY_HIDE_USER_DETAILS, new BooleanConverter()));
         $this->Set('AllowParticipation', !Configuration::Instance()->GetKey(ConfigKeys::RESERVATION_PREVENT_PARTICIPATION, new BooleanConverter()));
         $this->Set('AllowCreatePastReservationsButton', ServiceLocator::GetServer()->GetUserSession()->IsAdmin);
-
         $permissionServiceFactory = new PermissionServiceFactory();
         $scheduleRepository = new ScheduleRepository();
         $userRepository = new UserRepository();
@@ -319,8 +318,9 @@ class SchedulePage extends ActionPage implements ISchedulePage
                 $this->Display('Schedule/schedule-mobile.tpl');
             }
         } else {
-            if (array_key_exists($this->ScheduleStyle, $this->_styles)) {
-                $this->Display($this->_styles[$this->ScheduleStyle]);
+            $styleValue = $this->ScheduleStyle->value;
+            if (array_key_exists($styleValue, $this->_styles)) {
+                $this->Display($this->_styles[$styleValue]);
             } else {
                 $this->Display('Schedule/schedule.tpl');
             }
@@ -457,21 +457,21 @@ class SchedulePage extends ActionPage implements ISchedulePage
         return $this->GetQuerystring(QueryStringKeys::LAYOUT_DATE);
     }
 
-    public function GetScheduleStyle($scheduleId)
+    public function GetScheduleStyle(int $scheduleId): ?ScheduleStyle
     {
         $cookie = $this->server->GetCookie("schedule-style-$scheduleId");
-        if ($cookie != null) {
-            return $cookie;
+        if ($cookie == null || $cookie === '') {
+            return null;
         }
 
-        return null;
+        return ScheduleStyle::tryFrom(intval($cookie));
     }
 
-    public function SetScheduleStyle($style)
+    public function SetScheduleStyle(ScheduleStyle $style): void
     {
         $this->ScheduleStyle = $style;
         $this->Set('CookieName', 'schedule-style-' . $this->GetVar('ScheduleId'));
-        $this->Set('ScheduleStyle', $style);
+        $this->Set('ScheduleStyle', $style->value);
     }
 
     /**

--- a/Pages/ScheduleViewerViewSchedulesPage.php
+++ b/Pages/ScheduleViewerViewSchedulesPage.php
@@ -37,10 +37,10 @@ class ScheduleViewerViewSchedulesPage extends Page implements IPageable
         $this->Set('Today', Resources::GetInstance()->GetString('Today'));
         $this->Set('Months', Resources::GetInstance()->GetMonths('full'));
         $this->Set('StyleNames', [
-            ScheduleStyle::Standard => $resources->GetString('Standard'),
-            ScheduleStyle::Wide => $resources->GetString('Wide'),
-            ScheduleStyle::Tall => $resources->GetString('Tall'),
-            ScheduleStyle::CondensedWeek => $resources->GetString('Week'),
+            ScheduleStyle::Standard->value => $resources->GetString('Standard'),
+            ScheduleStyle::Wide->value => $resources->GetString('Wide'),
+            ScheduleStyle::Tall->value => $resources->GetString('Tall'),
+            ScheduleStyle::CondensedWeek->value => $resources->GetString('Week'),
         ]);
 
         $this->Display(ROOT_DIR.'tpl/Admin/Schedules/view_schedules.tpl');

--- a/Pages/ViewSchedulePage.php
+++ b/Pages/ViewSchedulePage.php
@@ -9,9 +9,9 @@ class ViewSchedulePage extends SchedulePage
     private $userRepository;
 
     private $_styles = [
-        ScheduleStyle::Wide => 'Schedule/schedule-days-horizontal.tpl',
-        ScheduleStyle::Tall => 'Schedule/schedule-flipped.tpl',
-        ScheduleStyle::CondensedWeek => 'Schedule/schedule-week-condensed.tpl',
+        ScheduleStyle::Wide->value => 'Schedule/schedule-days-horizontal.tpl',
+        ScheduleStyle::Tall->value => 'Schedule/schedule-flipped.tpl',
+        ScheduleStyle::CondensedWeek->value => 'Schedule/schedule-week-condensed.tpl',
     ];
 
     public function __construct()
@@ -66,8 +66,9 @@ class ViewSchedulePage extends SchedulePage
                 $this->Display('Schedule/schedule-mobile.tpl');
             }
         } else {
-            if (array_key_exists($this->ScheduleStyle, $this->_styles)) {
-                $this->Display($this->_styles[$this->ScheduleStyle]);
+            $styleValue = $this->ScheduleStyle->value;
+            if (array_key_exists($styleValue, $this->_styles)) {
+                $this->Display($this->_styles[$styleValue]);
             } else {
                 $this->Display('Schedule/schedule.tpl');
             }

--- a/Presenters/Schedule/SchedulePageBuilder.php
+++ b/Presenters/Schedule/SchedulePageBuilder.php
@@ -103,7 +103,7 @@ class SchedulePageBuilder implements ISchedulePageBuilder
         $page->SetScheduleName($currentSchedule->GetName());
         $page->SetFirstWeekday($currentSchedule->GetWeekdayStart());
         $style = $page->GetScheduleStyle($scheduleId);
-        $page->SetScheduleStyle($style == '' ? $currentSchedule->GetDefaultStyle() : $style);
+        $page->SetScheduleStyle($style ?? $currentSchedule->GetDefaultStyle());
         if ($currentSchedule->GetIsCalendarSubscriptionAllowed()) {
             $page->SetSubscriptionUrl(new CalendarSubscriptionUrl(null, $currentSchedule->GetPublicId(), null));
         }

--- a/WebServices/SchedulesWebService.php
+++ b/WebServices/SchedulesWebService.php
@@ -307,12 +307,12 @@ class ScheduleWebServiceView implements ISchedulePage
         return '';
     }
 
-    public function GetScheduleStyle($scheduleId)
+    public function GetScheduleStyle(int $scheduleId): ?ScheduleStyle
     {
         return ScheduleStyle::Standard;
     }
 
-    public function SetScheduleStyle($direction)
+    public function SetScheduleStyle(ScheduleStyle $direction): void
     {
         // no op
     }

--- a/tests/Domain/Schedule/ScheduleRepositoryTest.php
+++ b/tests/Domain/Schedule/ScheduleRepositoryTest.php
@@ -342,7 +342,7 @@ class ScheduleRepositoryTest extends TestBase
         $begin = Date::Now();
         $end = Date::Now()->AddDays(1);
         $allowConcurrent = true;
-        $style = ScheduleStyle::CondensedWeek;
+        $style = ScheduleStyle::CondensedWeek->value;
         $maxConcurrent = 10;
         $maxResources = 50;
 

--- a/tests/Presenters/SchedulePresenterTest.php
+++ b/tests/Presenters/SchedulePresenterTest.php
@@ -1061,17 +1061,17 @@ class FakeSchedulePage implements ISchedulePage
 
     /**
      * @param int $scheduleId
-     * @return string|ScheduleStyle
+     * @return ScheduleStyle|null
      */
-    public function GetScheduleStyle($scheduleId)
+    public function GetScheduleStyle(int $scheduleId): ?ScheduleStyle
     {
-        return '';
+        return null;
     }
 
     /**
-     * @param string|ScheduleStyle $direction
+     * @param ScheduleStyle $direction
      */
-    public function SetScheduleStyle($direction)
+    public function SetScheduleStyle(ScheduleStyle $direction): void
     {
     }
 

--- a/tests/fakes/FakeSchedules.php
+++ b/tests/fakes/FakeSchedules.php
@@ -141,7 +141,7 @@ class FakeScheduleRepository implements IScheduleRepository
             ColumnNames::SCHEDULE_ADMIN_GROUP_ID => $adminId,
             ColumnNames::SCHEDULE_AVAILABLE_START_DATE => $availableStart,
             ColumnNames::SCHEDULE_AVAILABLE_END_DATE => $availableEnd,
-            ColumnNames::SCHEDULE_DEFAULT_STYLE => ScheduleStyle::Standard,
+            ColumnNames::SCHEDULE_DEFAULT_STYLE => ScheduleStyle::Standard->value,
             ColumnNames::LAYOUT_TYPE => ScheduleLayout::Standard,
             ColumnNames::TOTAL_CONCURRENT_RESERVATIONS => $totalConcurrentReservations,
             ColumnNames::MAX_RESOURCES_PER_RESERVATION => $maxResourcesPerReservation,

--- a/tpl/Admin/Schedules/manage_schedules.tpl
+++ b/tpl/Admin/Schedules/manage_schedules.tpl
@@ -132,7 +132,7 @@
 																class="propertyValue defaultScheduleStyle inlineUpdate fw-bold text-decoration-underline"
 																data-type="select" data-pk="{$id}"
 																data-name="{FormKeys::SCHEDULE_DEFAULT_STYLE}"
-																data-value="{$schedule->GetDefaultStyle()}">{$StyleNames[$schedule->GetDefaultStyle()]}</span>
+																data-value="{$schedule->GetDefaultStyle()->value}">{$StyleNames[$schedule->GetDefaultStyle()->value]}</span>
 														</div>
 
 														{if $CreditsEnabled}

--- a/tpl/Admin/Schedules/view_schedules.tpl
+++ b/tpl/Admin/Schedules/view_schedules.tpl
@@ -76,7 +76,7 @@
 														<div>
 															{translate key=DefaultStyle}
 															<span
-																class="fw-bold">{$StyleNames[$schedule->GetDefaultStyle()]}</span>
+																class="fw-bold">{$StyleNames[$schedule->GetDefaultStyle()->value]}</span>
 														</div>
 
 														{if $CreditsEnabled}

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -90,18 +90,18 @@
                                 <a href="#" id="make_default" class="link-primary me-2" style="display:none;"><i
                                         class="bi bi-star-fill"></i></a>
                                 <a href="#" class="schedule-style me-1" id="schedule_standard"
-                                    schedule-display="{ScheduleStyle::Standard}">
+                                    schedule-display="{ScheduleStyle::Standard->value}">
                                     <img src="img/table.png" alt="{translate key='StandardScheduleDisplay'}" />
                                 </a>
-                                <a href="#" class="schedule-style me-1" id="schedule_tall" schedule-display="{ScheduleStyle::Tall}">
+                                <a href="#" class="schedule-style me-1" id="schedule_tall" schedule-display="{ScheduleStyle::Tall->value}">
                                     <img src="img/table-tall.png" alt="{translate key='TallScheduleDisplay'}" />
                                 </a>
                                 <a href="#" class="schedule-style d-none d-md-block me-1" id="schedule_wide"
-                                    schedule-display="{ScheduleStyle::Wide}">
+                                    schedule-display="{ScheduleStyle::Wide->value}">
                                     <img src="img/table-wide.png" alt="{translate key='WideScheduleDisplay'}" />
                                 </a>
                                 <a href="#" class="schedule-style d-none d-md-block" id="schedule_week"
-                                    schedule-display="{ScheduleStyle::CondensedWeek}">
+                                    schedule-display="{ScheduleStyle::CondensedWeek->value}">
                                     <img src="img/table-week.png" alt="{translate key='CondensedWeekScheduleDisplay'}" />
                                 </a>
                             </div>


### PR DESCRIPTION
This is done so that it will work better with types in the future. Previously it would have to be typed as an int. Now we can type as ScheduleStyle in many places. Not all as sometimes do need to pass the int value.