### PR TITLE
fix: issue with GetHeader called with non-existing header

### DIFF
--- a/lib/Server/Server.php
+++ b/lib/Server/Server.php
@@ -269,7 +269,7 @@ class Server
      */
     public function GetHeader($headerCode)
     {
-        return $_SERVER[$headerCode];
+        return $_SERVER[$headerCode] ?? '';
     }
 
     /**


### PR DESCRIPTION
This would cause errors like:
 PHP Warning:  Undefined array key "HTTP_ACCEPT_LANGUAGE" in
 /home/runner/work/librebooking/librebooking/lib/Server/Server.php on
 line 272

 PHP Deprecated:  strlen(): Passing null to parameter #1 ($string) of
 type string is deprecated in
 /home/runner/work/librebooking/librebooking/lib/Server/Server.php on
 line 260