### PR TITLE
fix: when an unknown error happens use HTTP 500

### DIFF
--- a/lib/Common/Logging/ExceptionHandler.php
+++ b/lib/Common/Logging/ExceptionHandler.php
@@ -42,6 +42,16 @@ class WebExceptionHandler extends ExceptionHandler
         ob_start();
         debug_print_backtrace();
         error_log(ob_get_clean());
+
+        // Uncaught exceptions indicate a server-side failure.
+        // Set 500 only while headers are still mutable.
+        if (!headers_sent() && !connection_aborted()) {
+            $currentStatus = http_response_code();
+            if ($currentStatus === false || $currentStatus < 400) {
+                http_response_code(500);
+            }
+        }
+
         $errorMessageId = ErrorMessages::UNKNOWN_ERROR;
         if (is_a($exception, 'DatabaseConnectionException')) {
             $errorMessageId = ErrorMessages::DATABASE_CONNECTION;


### PR DESCRIPTION
Uncaught exceptions indicate a server-side failure. Use an HTTP response of 500 (Internal Server Error).