### PR TITLE
fix: pdf generation for on the reservation page

### DIFF
--- a/tpl/Ajax/reservation/reservation_attributes_print.tpl
+++ b/tpl/Ajax/reservation/reservation_attributes_print.tpl
@@ -1,13 +1,14 @@
+{ldelim}
 {if $Attributes|default:array()|count > 0}
 	{foreach from=$Attributes item=attribute name=attributes}
 		 "{$attribute->Id()}" :
 		[ "{$attribute->Type()}" ,
-		"{$attribute->Label()|escape:'json'}" ,
+		"{$attribute->Label()|default:''|escape:'json'}" ,
 		{if $attribute->Type() eq '5'}
-			"{formatdate date=$attribute->Value() key=embedded_datetime}" ] {if $smarty.foreach.attributes.last}{else},{/if}
+			"{if $attribute->Value() neq null}{formatdate date=$attribute->Value() key=embedded_datetime}{/if}" ] {if $smarty.foreach.attributes.last}{else},{/if}
 		{else}
-			"{$attribute->Value()|escape:'json'}" ] {if $smarty.foreach.attributes.last}{else},{/if}
+			"{$attribute->Value()|default:''|escape:'json'}" ] {if $smarty.foreach.attributes.last}{else},{/if}
 		{/if}
 	{/foreach}
 {/if}
-}
+{rdelim}


### PR DESCRIPTION
Previously the JSON template lost its opening {, and after the recent async change the PDF flow now waits on that malformed JSON, so .done() never runs and the button appears dead.

Also add some default values if `null` values are present