### PR TITLE
fix(config) time constraint 'same_day' config not working

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -308,7 +308,7 @@ return [
             # Enable a waitlist for fully booked reservations (true/false)
             'allow.wait.list' => false,
 
-            # Restrict start times (e.g., 'future', 'none', 'same_day')
+            # Restrict start times (e.g., 'future', 'none', 'current')
             'start.time.constraint' => 'future',
 
             # Require approval when an existing reservation is updated (true/false)

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -320,7 +320,7 @@ Reservation Behavior
   Enable waitlist when resources are fully booked.
 
 **reservation.start.time.constraint**
-  When reservations can be made: 'future', 'any', 'same_day'.
+  Restrictions on when reservations can be made: 'none', 'current', 'future'.
 
 **reservation.updates.require.approval**
   Require approval when editing existing approved reservations.

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -727,10 +727,10 @@ class ConfigKeys
         'choices' => [
             'none' => 'Any time',
             'future' => 'Future',
-            'same_day' => 'Same day'
+            'current' => 'Current'
         ],
         'label' => 'Start Time Constraint',
-        'description' => 'Restrict start times. Options: future, any, same_day',
+        'description' => 'Restrict start times. Options: future, none, current',
         'section' => 'reservation'
     ];
     public const RESERVATION_UPDATES_REQUIRE_APPROVAL = [


### PR DESCRIPTION
The value 'same_day' of the config reservation.start.time.constraint is reverted to its previous value 'current'. same_day was not taken into account. The 'current' value describe more the behavior than 'same_day' since the reservations can not be changed after they are finished.

Closes #1043