### PR TITLE
test: enable `strict_types=1` for `tests/Application/`

### DIFF
--- a/tests/Application/Admin/GroupAdminGroupsRepositoryTest.php
+++ b/tests/Application/Admin/GroupAdminGroupsRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
 class GroupAdminGroupsRepositoryTest extends TestBase

--- a/tests/Application/Admin/GroupAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/GroupAdminManageReservationsServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
 class GroupAdminManageReservationsServiceTest extends TestBase

--- a/tests/Application/Admin/ManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ManageReservationsServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
 class ManageReservationsServiceTest extends TestBase

--- a/tests/Application/Admin/ResourceAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ResourceAdminManageReservationsServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
 class ResourceAdminManageReservationsServiceTest extends TestBase

--- a/tests/Application/Admin/ResourceAdminResourceRepositoryTest.php
+++ b/tests/Application/Admin/ResourceAdminResourceRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\MockObject\MockObject;
 
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');

--- a/tests/Application/Admin/ScheduleAdminManageReservationsServiceTest.php
+++ b/tests/Application/Admin/ScheduleAdminManageReservationsServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
 class ScheduleAdminManageReservationsServiceTest extends TestBase

--- a/tests/Application/Admin/ScheduleAdminScheduleRepositoryTest.php
+++ b/tests/Application/Admin/ScheduleAdminScheduleRepositoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Admin/namespace.php');
 
 class ScheduleAdminScheduleRepositoryTest extends TestBase

--- a/tests/Application/Attributes/AttributeListTest.php
+++ b/tests/Application/Attributes/AttributeListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Attributes/namespace.php');
 
 class AttributeListTest extends TestBase

--- a/tests/Application/Attributes/AttributeServiceTest.php
+++ b/tests/Application/Attributes/AttributeServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Attributes/namespace.php');
 
 class AttributeServiceTest extends TestBase

--- a/tests/Application/Attributes/AttributeValidatorTest.php
+++ b/tests/Application/Attributes/AttributeValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Attributes/namespace.php');
 
 class AttributeValidatorTest extends TestBase

--- a/tests/Application/Authorization/AuthorizationServiceTest.php
+++ b/tests/Application/Authorization/AuthorizationServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Authorization/namespace.php');
 
 class AuthorizationServiceTest extends TestBase

--- a/tests/Application/Authorization/PrivacyFilterTest.php
+++ b/tests/Application/Authorization/PrivacyFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
 class PrivacyFilterTest extends TestBase

--- a/tests/Application/Reporting/CannedReportTest.php
+++ b/tests/Application/Reporting/CannedReportTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class CannedReportTest extends TestBase
 {
     public function setUp(): void

--- a/tests/Application/Reporting/Report_RangeTest.php
+++ b/tests/Application/Reporting/Report_RangeTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class Report_RangeTest extends TestBase
 {
     /**

--- a/tests/Application/Reporting/ReportingServiceTest.php
+++ b/tests/Application/Reporting/ReportingServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reporting/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 

--- a/tests/Application/Reservation/AccessoryAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/AccessoryAvailabilityRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 

--- a/tests/Application/Reservation/AccessoryResourceRuleTest.php
+++ b/tests/Application/Reservation/AccessoryResourceRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 

--- a/tests/Application/Reservation/AdminEmailNotificationTest.php
+++ b/tests/Application/Reservation/AdminEmailNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Email/Messages/ReservationCreatedEmailAdmin.php');
 require_once(ROOT_DIR . 'lib/Email/Messages/ReservationUpdatedEmailAdmin.php');
 

--- a/tests/Application/Reservation/AdminExcludedRuleTest.php
+++ b/tests/Application/Reservation/AdminExcludedRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class AdminExcludedRuleTest extends TestBase
 {
     /**

--- a/tests/Application/Reservation/AttachmentExtensionTest.php
+++ b/tests/Application/Reservation/AttachmentExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/BlackoutsServiceTest.php
+++ b/tests/Application/Reservation/BlackoutsServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\MockObject\MockObject;
 
 require_once(ROOT_DIR . 'lib/Application/Reservation/ManageBlackoutsService.php');

--- a/tests/Application/Reservation/CreditsRuleTest.php
+++ b/tests/Application/Reservation/CreditsRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 

--- a/tests/Application/Reservation/CustomAttributeValidationRuleTest.php
+++ b/tests/Application/Reservation/CustomAttributeValidationRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');

--- a/tests/Application/Reservation/ExistingResourceAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/ExistingResourceAvailabilityRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use PHPUnit\Framework\MockObject\MockObject;
 
 require_once(ROOT_DIR . 'Domain/namespace.php');

--- a/tests/Application/Reservation/GuestEmailNotificationTest.php
+++ b/tests/Application/Reservation/GuestEmailNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 

--- a/tests/Application/Reservation/InvitationEmailNotificationTest.php
+++ b/tests/Application/Reservation/InvitationEmailNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 

--- a/tests/Application/Reservation/OwnerEmailNotificationTest.php
+++ b/tests/Application/Reservation/OwnerEmailNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
 require_once(ROOT_DIR . 'lib/Email/Messages/ReservationCreatedEmail.php');

--- a/tests/Application/Reservation/ParticipantEmailNotificationTest.php
+++ b/tests/Application/Reservation/ParticipantEmailNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 

--- a/tests/Application/Reservation/ParticipationNotificationTest.php
+++ b/tests/Application/Reservation/ParticipationNotificationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ParticipationNotificationTest extends TestBase
 {
     /**

--- a/tests/Application/Reservation/PermissionValidationRuleTest.php
+++ b/tests/Application/Reservation/PermissionValidationRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');

--- a/tests/Application/Reservation/QuotaRuleTest.php
+++ b/tests/Application/Reservation/QuotaRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ReminderValidationRuleTest.php
+++ b/tests/Application/Reservation/ReminderValidationRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/RequiresApprovalRuleTest.php
+++ b/tests/Application/Reservation/RequiresApprovalRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class RequiresApprovalRuleTest extends TestBase
 {
     /**

--- a/tests/Application/Reservation/ReservationAuthorizationTest.php
+++ b/tests/Application/Reservation/ReservationAuthorizationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ReservationAuthorizationTest extends TestBase
 {
     /**

--- a/tests/Application/Reservation/ReservationCanBeCheckedInRuleTest.php
+++ b/tests/Application/Reservation/ReservationCanBeCheckedInRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ReservationCanBeCheckedInRuleTest extends TestBase
 {
     /**

--- a/tests/Application/Reservation/ReservationCanBeCheckedOutRuleTest.php
+++ b/tests/Application/Reservation/ReservationCanBeCheckedOutRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ReservationCanBeCheckedOutRuleTest extends TestBase
 {
     /**

--- a/tests/Application/Reservation/ReservationComponentTest.php
+++ b/tests/Application/Reservation/ReservationComponentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/ReservationInitializerBase.php');

--- a/tests/Application/Reservation/ReservationConflictResolutionTest.php
+++ b/tests/Application/Reservation/ReservationConflictResolutionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/ManageBlackoutsService.php');
 
 class ReservationConflictResolutionTest extends TestBase

--- a/tests/Application/Reservation/ReservationDateTimeRuleTest.php
+++ b/tests/Application/Reservation/ReservationDateTimeRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ReservationNotificationFactoryTest.php
+++ b/tests/Application/Reservation/ReservationNotificationFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/Notification/namespace.php');
 
 class ReservationNotificationFactoryTest extends TestBase

--- a/tests/Application/Reservation/ReservationStartTimeRuleTest.php
+++ b/tests/Application/Reservation/ReservationStartTimeRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ReservationValidationFactoryTest.php
+++ b/tests/Application/Reservation/ReservationValidationFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
 class ReservationValidationFactoryTest extends TestBase

--- a/tests/Application/Reservation/ReservationValidationRuleProcessorTest.php
+++ b/tests/Application/Reservation/ReservationValidationRuleProcessorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
 class ReservationValidationRuleProcessorTest extends TestBase

--- a/tests/Application/Reservation/ResourceAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/ResourceAvailabilityRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ResourceCountRuleTest.php
+++ b/tests/Application/Reservation/ResourceCountRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ResourceCrossDayRuleTest.php
+++ b/tests/Application/Reservation/ResourceCrossDayRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ResourceMaximumDurationRuleTest.php
+++ b/tests/Application/Reservation/ResourceMaximumDurationRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ResourceMaximumNoticeRuleTest.php
+++ b/tests/Application/Reservation/ResourceMaximumNoticeRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ResourceMinimumDurationRuleTest.php
+++ b/tests/Application/Reservation/ResourceMinimumDurationRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ResourceMinimumNoticeRuleTest.php
+++ b/tests/Application/Reservation/ResourceMinimumNoticeRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ResourceParticipationRuleTest.php
+++ b/tests/Application/Reservation/ResourceParticipationRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 
 class ResourceParticipationRuleTest extends TestBase

--- a/tests/Application/Reservation/RetryOptionsTest.php
+++ b/tests/Application/Reservation/RetryOptionsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 
 class RetryOptionsTest extends TestBase

--- a/tests/Application/Reservation/ScheduleAvailabilityRuleTest.php
+++ b/tests/Application/Reservation/ScheduleAvailabilityRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 

--- a/tests/Application/Reservation/SchedulePeriodRuleTest.php
+++ b/tests/Application/Reservation/SchedulePeriodRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 

--- a/tests/Application/Reservation/ScheduleTotalConcurrentReservationsRuleTest.php
+++ b/tests/Application/Reservation/ScheduleTotalConcurrentReservationsRuleTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/Validation/namespace.php');
 

--- a/tests/Application/Schedule/CalendarMonthTest.php
+++ b/tests/Application/Schedule/CalendarMonthTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 

--- a/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
+++ b/tests/Application/Schedule/CalendarSubscriptionServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
 class CalendarSubscriptionServiceTest extends TestBase

--- a/tests/Application/Schedule/CalendarWeekTest.php
+++ b/tests/Application/Schedule/CalendarWeekTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
 

--- a/tests/Application/Schedule/DailyLayoutTest.php
+++ b/tests/Application/Schedule/DailyLayoutTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
 class DailyLayoutTest extends TestBase

--- a/tests/Application/Schedule/LayoutValidatorTest.php
+++ b/tests/Application/Schedule/LayoutValidatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Common/Validators/namespace.php');
 
 class LayoutValidatorTest extends TestBase

--- a/tests/Application/Schedule/ReservationListingTest.php
+++ b/tests/Application/Schedule/ReservationListingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 

--- a/tests/Application/Schedule/ResourcePermissionStoreTest.php
+++ b/tests/Application/Schedule/ResourcePermissionStoreTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 
 class ResourcePermissionStoreTest extends TestBase

--- a/tests/Application/Schedule/ResourceServiceTest.php
+++ b/tests/Application/Schedule/ResourceServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Schedule/ResourceService.php');
 
 class ResourceServiceTest extends TestBase

--- a/tests/Application/Schedule/ScheduleLayoutSerializableTest.php
+++ b/tests/Application/Schedule/ScheduleLayoutSerializableTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ScheduleLayoutSerializableTest extends TestBase
 {
     public function setUp(): void

--- a/tests/Application/Schedule/ScheduleLayoutTest.php
+++ b/tests/Application/Schedule/ScheduleLayoutTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 

--- a/tests/Application/Schedule/ScheduleReservationListTest.php
+++ b/tests/Application/Schedule/ScheduleReservationListTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'Domain/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 

--- a/tests/Application/Schedule/ScheduleResourceFilterTest.php
+++ b/tests/Application/Schedule/ScheduleResourceFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 
 class ScheduleResourceFilterTest extends TestBase

--- a/tests/Application/Schedule/SlotLabelFactoryTest.php
+++ b/tests/Application/Schedule/SlotLabelFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class SlotLabelFactoryTest extends TestBase
 {
     /**
@@ -121,7 +123,7 @@ class SlotLabelFactoryTest extends TestBase
 
         $label = $factory->Format($this->reservation);
 
-        $fullName = $this->reservation->GetUserName();
+        $fullName = (string)$this->reservation->GetUserName();
 
         $this->assertStringNotContainsString($fullName, $label);
     }
@@ -141,7 +143,7 @@ class SlotLabelFactoryTest extends TestBase
 
         $label = $factory->Format($this->reservation);
 
-        $fullName = $this->reservation->GetUserName();
+        $fullName = (string)$this->reservation->GetUserName();
 
         $this->assertStringContainsString($fullName, $label);
     }

--- a/tests/Application/User/ManageUsersServiceTest.php
+++ b/tests/Application/User/ManageUsersServiceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 require_once(ROOT_DIR . 'lib/Application/User/ManageUsersService.php');
 
 class ManageUsersServiceTest extends TestBase


### PR DESCRIPTION
Add `declare(strict_types=1);` to all the tests files in `tests/Application/` and below.

Resolve one issue found.