### PR TITLE
feat(flatpickr): replace legacy datepicker with modern Flatpickr inte…

### DIFF
--- a/Controls/DatePickerSetupControl.php
+++ b/Controls/DatePickerSetupControl.php
@@ -13,8 +13,14 @@ class DatePickerSetupControl extends Control
     {
         $this->SetDefault('NumberOfMonths', 1);
         $this->SetDefault('ShowButtonPanel', 'false');
+        $this->Set('ControlId', $this->Get('ControlId'));
+        $this->SetDefault('Inline', false);
+        $this->SetDefault('OnSelect', null);
+        $this->SetDefault('OnClose', null);
+        $this->SetDefault('FirstDay', 0);
+
+        /****************************** Remove upon completion of Flatpickr deployment */
         $controlId = $this->Get('ControlId');
-        $controlId = str_replace(']', '\\\\]', str_replace('[', '\\\\[', $controlId));
         $altId = $this->Get('AltId');
 
         $elementsToTrigger = '#' . $controlId;
@@ -26,24 +32,60 @@ class DatePickerSetupControl extends Control
         $this->Set('ControlId', $controlId);
         $this->Set('AltId', $altId);
 
-        $this->SetDefault('OnSelect', sprintf("function() { $('%s').trigger('change'); }", $elementsToTrigger));
-        $this->SetDefault('FirstDay', 0);
+        /****************************** */
 
         $hasTimepicker = $this->Get('HasTimepicker');
         $this->Set('HasTimepicker', $hasTimepicker);
-        $this->Set('DateFormat', Resources::GetInstance()->GetDateFormat('general_date_js'));
-        $this->Set('TimeFormat', Resources::GetInstance()->GetDateFormat('general_time_js'));
-        $this->Set('AltFormat', Resources::GetInstance()->GetDateFormat($hasTimepicker ? 'js_general_datetime' : 'js_general_date'));
+
+        if ($hasTimepicker) {
+            $phpFormat = Resources::GetInstance()->GetDateFormat('schedule_daily') . ' ' . Resources::GetInstance()->GetDateFormat('period_time');
+
+            $time24hr = (strpos($phpFormat, 'A') === false && strpos($phpFormat, 'a') === false);
+
+            $altFormat = $this->phpDateFormatToFlatpickr($phpFormat);  // The converted format is used here.
+            $dateFormat = 'Y-m-d H:i';      // backend format
+            $this->Set('Time24Hr', $time24hr);
+        } else {
+            $altFormat = Resources::GetInstance()->GetDateFormat('schedule_daily');
+            $dateFormat = 'Y-m-d';
+            $this->Set('Time24Hr', false);
+        }
+
+
+        $this->Set('AltFormat', $altFormat);
+        $this->Set('DateFormat', $dateFormat);
+        $multiple = $this->Get('Multiple');
+        $this->Set('Multiple', $multiple);
         $this->Set('DayNamesMin', $this->GetJsDayNames('two'));
         $this->Set('DayNamesShort', $this->GetJsDayNames('abbr'));
         $this->Set('DayNames', $this->GetJsDayNames('full'));
         $this->Set('MonthNames', $this->GetJsMonthNames('full'));
         $this->Set('MonthNamesShort', $this->GetJsMonthNames('abbr'));
         $this->Set('ShowWeekNumbers', Configuration::Instance()->GetKey(ConfigKeys::SCHEDULE_SHOW_WEEK_NUMBERS, new BooleanConverter()));
+        $defaultDate = $this->Get('DefaultDate');
+
+        if (is_array($defaultDate)) {
+            $dates = [];
+
+            foreach ($defaultDate as $d) {
+                if ($d instanceof Date) {
+                    $dates[] = $d->Format('Y-m-d');
+                } elseif ($d instanceof DateTime) {
+                    $dates[] = $d->format('Y-m-d');
+                } elseif (is_string($d)) {
+                    $dates[] = $d;
+                }
+            }
+
+            $this->Set('DefaultDate', $dates);
+        } elseif ($defaultDate instanceof Date) {
+            $this->Set('DefaultDate', $defaultDate->Format('Y-m-d'));
+        }
+
         $this->SetDefault('MinDate', null);
         $this->SetDefault('MaxDate', null);
 
-        if ($controlId == 'datepicker') {
+        if (!$altId) {
             $this->Display('Controls/DatePickerSetup.tpl');
         } else {
             $this->Display('Controls/DateSetup.tpl');
@@ -70,5 +112,36 @@ class DatePickerSetupControl extends Control
     private function GetJsArrayValues($values)
     {
         return "['" . implode("','", $values) . "']";
+    }
+
+    private function phpDateFormatToFlatpickr($format)
+    {
+        $replacements = [
+            'Y' => 'Y',
+            'y' => 'y',
+            'm' => 'm',
+            'n' => 'n',
+            'd' => 'd',
+            'j' => 'j',
+            'g' => 'h',
+            'h' => 'h',
+            'G' => 'H',
+            'H' => 'H',
+            'i' => 'i',
+            'A' => 'K', // AM/PM
+            'a' => 'K', // am/pm
+            '.' => '.',
+            '/' => '/',
+            '-' => '-',
+            ' ' => ' ',
+            ':' => ':'
+        ];
+
+        $result = '';
+        $chars = str_split($format);
+        foreach ($chars as $c) {
+            $result .= $replacements[$c] ?? $c; // If there's no mapping, it leaves it as is.
+        }
+        return $result;
     }
 }

--- a/tpl/Controls/DatePickerSetup.tpl
+++ b/tpl/Controls/DatePickerSetup.tpl
@@ -1,67 +1,91 @@
-{function name=datePickerDateFormat}
-    new Date({$date->Year()}, {$date->Month()-1}, {$date->Day()})
-{/function}
 <script>
-    function initFlatpickr(selector, config) {
-        flatpickr(selector, config);
-    }
+    (function() {
 
-    $(document).ready(function() {
-    const hasTimepicker = {if $HasTimepicker}true{else}false{/if};
-    const dateFormat = "{$DateFormat}" + (hasTimepicker ? " {$TimeFormat}" : "");
+            function whenFlatpickrReady(callback, retries = 150) {
+                if (window.flatpickr) {
+                    callback();
+                } else if (retries > 0) {
+                    setTimeout(() => whenFlatpickrReady(callback, retries - 1), 150);
+                } else {
+                    console.warn('Flatpickr not loaded for {$ControlId}');
+                }
+            }
 
-    const config = {
-        inline: {if $Inline|default:false}true{else}false{/if},
-        enableTime: hasTimepicker,
-        noCalendar: {if $NoCalendar|default:false}true{else}false{/if},
-        dateFormat: dateFormat,
-        locale: {
-            weekdays: {
-                shorthand: {$DayNamesShort},
-                longhand: {$DayNames}
-            },
-            months: {
-                shorthand: {$MonthNamesShort},
-                longhand: {$MonthNames}
-            },
-            {if $FirstDay >= 0 && $FirstDay <= 6}
-                firstDayOfWeek: {$FirstDay},
-            {/if}
-        },
-        showMonths: {$NumberOfMonths|default:1},
-        weekNumbers: {if $ShowWeekNumbers}true{else}false{/if},
-        defaultDate: {if $DefaultDate}{datePickerDateFormat date=$DefaultDate}{else}null{/if},
-        minDate: {if $MinDate}{datePickerDateFormat date=$MinDate}{else}null{/if},
-        maxDate: {if $MaxDate}{datePickerDateFormat date=$MaxDate->AddDays(1)}{else}null{/if},
-        onChange: {$OnSelect},
-    };
+            function initFlatpickrOnce(element, config) {
+                if (!element._flatpickr) {
+                    flatpickr(element, config);
+                }
+            }
 
-    {if $AltId neq ''}
-        config.altInput = true;
-        config.altFormat = "{$AltFormat|escape:'javascript'}";
-    {/if}
+            function initDatePicker_{$ControlId}() {
+            const control = document.getElementById("{$ControlId}");
+            if (!control) return;
 
-    // If the control is inside a collapse
-    const $collapse = $("#{$ControlId}").closest('.collapse');
-    if ($collapse.length > 0) {
-        $collapse.on('shown.bs.collapse', function() {
-            initFlatpickr("#{$ControlId}", config);
-        });
-        // If the collapse is already visible upon loading
-        if ($collapse.hasClass('show')) {
-            initFlatpickr("#{$ControlId}", config);
+            const config = {
+                inline: {$Inline|json_encode},
+                mode: {$Multiple ? '"multiple"' : '"single"'},
+                static: true,
+                altInput: {if $AltInput|default:true}true{else}false{/if},
+                altFormat: "{$AltFormat}",
+                dateFormat: "{$DateFormat}",
+                defaultDate:
+                    {if $DefaultDate}
+                        {if $Multiple}
+                            {$DefaultDate|json_encode}
+                        {else}
+                            "{$DefaultDate}"
+                        {/if}
+                    {else}
+                        null
+                {/if},
+                minDate: {if $MinDate}"{$MinDate}"{else}null{/if},
+                maxDate: {if $MaxDate}"{$MaxDate}"{else}null{/if},
+                enableTime: {$HasTimepicker ? 'true' : 'false'},
+                time_24hr: {$Time24Hr ? 'true' : 'false'},
+                onChange: {if $OnSelect}{$OnSelect}{else}null{/if},
+                onClose: {if $OnClose}{$OnClose}{else}null{/if},
+                allowInput: true,
+                disableMobile: true,
+                locale: {
+                    weekdays: {
+                        shorthand: {$DayNamesShort},
+                        longhand: {$DayNames}
+                    },
+                    months: {
+                        shorthand: {$MonthNamesShort},
+                        longhand: {$MonthNames}
+                    },
+                    {if $FirstDay >= 0 && $FirstDay <= 6}
+                        firstDayOfWeek: {$FirstDay},
+                    {/if}
+                },
+                showMonths: {$NumberOfMonths|default:1},
+                weekNumbers: {if $ShowWeekNumbers}true{else}false{/if},
+            };
+
+            const init = () => initFlatpickrOnce(control, config);
+
+            const collapse = control.closest('.collapse');
+            const modal = control.closest('.modal');
+
+            if (modal) {
+                modal.addEventListener('shown.bs.modal', init, { once: true });
+                return;
+            }
+
+            if (collapse) {
+                collapse.addEventListener('shown.bs.collapse', init);
+                if (collapse.classList.contains('show')) {
+                    init();
+                }
+                return;
+            }
+
+            init();
         }
-    } else {
-        // If not collapsed, initialize normally
-        initFlatpickr("#{$ControlId}", config);
-    }
 
-    {if $AltId neq ''}
-        $("#{$ControlId}").on('change', function () {
-        if ($(this).val() === '') {
-            $("#{$AltId}").val('');
-        }
-        });
-    {/if}
-    });
+        // Waiting for Flatpickr to exist
+        whenFlatpickrReady(initDatePicker_{$ControlId});
+
+    })();
 </script>

--- a/tpl/Controls/DateSetup.tpl
+++ b/tpl/Controls/DateSetup.tpl
@@ -4,17 +4,17 @@
         let $altId = $("#{$AltId}");
 
         {if $MinDate}
-            var minDate = "{$MinDate->format('Y-m-d')}"
+            var minDate = "{formatdate date=$MinDate format='Y-m-d'}"
             $controlId.attr('min', minDate);
         {/if}
 
         {if $MaxDate}
-            var maxDate = "{$MaxDate->AddDays(1)->format('Y-m-d')}"
+            var maxDate = "{formatdate date=$MaxDate->AddDays(1) format='Y-m-d'}"
             $controlId.attr('max', maxDate);
         {/if}
 
         {if $DefaultDate}
-            var defaultDate = "{$DefaultDate->format('Y-m-d')}";
+            var defaultDate = "{formatdate date=$DefaultDate format='Y-m-d'}";
             $controlId.val(defaultDate);
 
         {/if}


### PR DESCRIPTION
…gration

- Add Flatpickr defaults for inline mode, onSelect/onClose callbacks, first day of week, and multiple selection support
- Convert PHP date formats to Flatpickr-compatible format strings
- Normalize DefaultDate handling for arrays, Date/DateTime objects, and string inputs
- Set time_24hr option for timepicker components
- Replace jQuery-driven initialization with robust vanilla JS initializer
- Add wait-for-Flatpickr mechanism to handle async script loading
- Support dynamic content (modals, collapses) with proper re-initialization
- Prevent double-initialization with data-attribute tracking
- Update DateSetup.tpl to use template date formatting helper for min/max/default values