### PR TITLE
Fix: Select all when managing reservations 

### DIFF
--- a/Web/scripts/admin/reservations.js
+++ b/Web/scripts/admin/reservations.js
@@ -48,7 +48,6 @@ function ReservationManagement(opts, approval) {
         deleteMultiplePrompt: $('#delete-selected'),
         deleteMultipleDialog: $('#deleteMultipleDialog'),
         deleteMultipleForm: $('#deleteMultipleForm'),
-        deleteMultipleCheckboxes: $('.delete-multiple'),
         deleteMultipleSelectAll: $('#delete-all'),
         deleteMultipleCount: $('#deleteMultipleCount'),
         deleteMultiplePlaceHolder: $('#deleteMultiplePlaceHolder'),
@@ -201,14 +200,15 @@ function ReservationManagement(opts, approval) {
         elements.deleteMultipleSelectAll.click(function (e) {
             e.stopPropagation();
             var isChecked = elements.deleteMultipleSelectAll.is(":checked");
-            elements.deleteMultipleCheckboxes.prop('checked', isChecked);
+            elements.reservationTable.find('.delete-multiple').prop('checked', isChecked);
             elements.deleteMultiplePrompt.toggleClass('d-none', !isChecked);
         });
 
-        elements.deleteMultipleCheckboxes.click(function (e) {
+        elements.reservationTable.on('click', '.delete-multiple', function (e) {
             e.stopPropagation();
-            var numberChecked = elements.reservationTable.find('.delete-multiple:checked').length;
-            var allSelected = numberChecked == elements.reservationTable.find('.delete-multiple').length;
+            var allCheckboxes = elements.reservationTable.find('.delete-multiple');
+            var numberChecked = allCheckboxes.filter(':checked').length;
+            var allSelected = numberChecked == allCheckboxes.length;
             elements.deleteMultipleSelectAll.prop('checked', allSelected);
             elements.deleteMultiplePrompt.toggleClass('d-none', numberChecked == 0);
         });


### PR DESCRIPTION
Fixes the select all checkbox when managing reservations to select all visible reservations, even if there are more than 25 shown. Before visible elements cache wasn't updated when more elements where selected to be shown.
Closes #918