### PR TITLE
fix(config): Precise units for reservation reminders

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -346,10 +346,10 @@ return [
             # Enable reminder notifications for upcoming reservations (true/false)
             'reminders.enabled' => false,
 
-            # Default reminder time before reservation start (in minutes)
+            # Default reminder time before reservation start (e.g., '15 minutes', '1 hours', '1 days')
             'default.start.reminder' => '',
 
-            # Default reminder time before reservation end (in minutes)
+            # Default reminder time before reservation end (e.g., '15 minutes', '1 hours', '1 days')
             'default.end.reminder' => '',
         ],
 

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -349,7 +349,7 @@ Reservation Behavior
   Enable email reminders before reservations start/end.
 
 **reservation.default.start.reminder**
-  Default reminder time before start (e.g., '15 minutes', '1 hour').
+  Default reminder time before start (e.g., '15 minutes', '1 hours', '1 days').
 
 **reservation.default.end.reminder**
   Default reminder time before end.

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -808,8 +808,8 @@ class ConfigKeys
         'key' => 'reservation.default.start.reminder',
         'type' => 'string',
         'default' => '',
-        'label' => 'Default Start Reminder (minutes)',
-        'description' => 'Default start reservation reminder. format is ## interval. for example, 10 minutes, 2 hours, 6 days.',
+        'label' => 'Default reminder time before reservation start (e.g., \'15 minutes\', \'1 hours\', \'1 days\')',
+        'description' => 'Default start reservation reminder. Format is an interval using only minutes, hours, or days',
         'section' => 'reservation'
     ];
     # previously RESERVATION_DEFAULT_END_REMINDER
@@ -817,8 +817,8 @@ class ConfigKeys
         'key' => 'reservation.default.end.reminder',
         'type' => 'string',
         'default' => '',
-        'label' => 'Default End Reminder (minutes)',
-        'description' => 'Default end reservation reminder. format is ## interval. for example, 10 minutes, 2 hours, 6 days.',
+        'label' => 'Default reminder time before reservation end (e.g., \'15 minutes\', \'1 hours\', \'1 days\')',
+        'description' => 'Default end reservation reminder. Format is an interval using only minutes, hours, or days (e.g., 1 days)',
         'section' => 'reservation'
     ];
 


### PR DESCRIPTION
update configuration comments to specify that start/end
 reminder times require units like hour/minute rather than just numbers.