### PR TITLE
feat(email): add SMTP AutoTLS configuration option

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -138,6 +138,9 @@ return [
             # Options: tls, ssl
             'smtp.secure' => '',
 
+            # SMTP Auto TLS, if an unencrypted SMTP connection should attempt to use STARTTLS
+            'smtp.autotls' => true,
+
             # Enable SMTP authentication (true/false)
             'smtp.auth' => true,
 

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -159,6 +159,7 @@ Advanced PHPMailer Settings
    'phpmailer' => [
        'sendmail.path' => '/usr/sbin/sendmail',
        'smtp.debug' => false,
+       'smtp.autotls' => true,
    ],
 
 **phpmailer.sendmail.path**
@@ -166,6 +167,10 @@ Advanced PHPMailer Settings
 
 **phpmailer.smtp.debug**
   Enable SMTP debug output (true/false).
+
+**phpmailer.smtp.autotls**
+  Set PHPMailer's SMTPAutoTLS setting (true/false). Determines if an
+  unencrypted SMTP connection should attempt to use STARTTLS.
 
 Logging Configuration
 ---------------------

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -312,6 +312,15 @@ class ConfigKeys
         'section' => 'phpmailer'
     ];
 
+    public const PHPMAILER_SMTP_AUTOTLS = [
+        'key' => 'phpmailer.smtp.autotls',
+        'type' => 'boolean',
+        'default' => true,
+        'label' => 'SMTP AutoTLS',
+        'description' => 'If an unencrypted SMTP connection should attempt to use STARTTLS',
+        'section' => 'phpmailer'
+    ];
+
     public const PHPMAILER_SMTP_AUTH = [
         'key' => 'phpmailer.smtp.auth',
         'type' => 'boolean',

--- a/lib/Email/EmailService.php
+++ b/lib/Email/EmailService.php
@@ -31,6 +31,7 @@ class EmailService implements IEmailService
             $phpMailer->Host = $this->Config(ConfigKeys::PHPMAILER_SMTP_HOST);
             $phpMailer->Port = $this->Config(ConfigKeys::PHPMAILER_SMTP_PORT, new IntConverter());
             $phpMailer->SMTPSecure = $this->Config(ConfigKeys::PHPMAILER_SMTP_SECURE);
+            $phpMailer->SMTPAutoTLS = $this->Config(ConfigKeys::PHPMAILER_SMTP_AUTOTLS, new BooleanConverter());
             $phpMailer->SMTPAuth = $this->Config(ConfigKeys::PHPMAILER_SMTP_AUTH, new BooleanConverter());
             $phpMailer->Username = $this->Config(ConfigKeys::PHPMAILER_SMTP_USERNAME);
             $phpMailer->Password = $this->Config(ConfigKeys::PHPMAILER_SMTP_PASSWORD);


### PR DESCRIPTION
Add control of the PHPMailer `SMTPAutoTLS` option. This allows disabling
of attempting to do STARTTLS when connecting to an email server.

Closes: #801
