### PR TITLE
refactor(search-reservations): replace native date inputs with flatpickr

### DIFF
--- a/Web/scripts/reservation-search.js
+++ b/Web/scripts/reservation-search.js
@@ -5,12 +5,10 @@ function ReservationSearch(options) {
 		resources: $('#resources'),
 		schedules: $('#schedules'),
 		userFilter: $('#userFilter'),
-		userId: $('#userId'), // today: $('#today'),
-		// tomorrow: $('#tomorrow'),
-		// thisweek: $('#thisweek'),
+		userId: $('#userId'),
 		daterange: $('input[name="AVAILABILITY_RANGE"]'),
-		beginDate: $('#beginDate'),
-		endDate: $('#endDate'),
+		beginDate: document.getElementById('beginDate'),
+		endDate: document.getElementById('endDate'),
 	};
 
 	var init = function () {
@@ -20,33 +18,39 @@ function ReservationSearch(options) {
 
 		elements.userFilter.userAutoComplete(options.autocompleteUrl, selectUser);
 
-		elements.userFilter.change(function () {
+		elements.userFilter.on('change', function () {
 			if ($(this).val() == '') {
 				elements.userId.val('');
 			}
 		});
 
-		elements.daterange.change(function (e) {
+		elements.daterange.on('change', function (e) {
 			if ($(e.target).val() == 'daterange') {
-				elements.beginDate.removeAttr('disabled');
-				elements.endDate.removeAttr('disabled');
+				setFlatpickrDisabled(elements.beginDate, false);
+				setFlatpickrDisabled(elements.endDate, false);
 			}
 			else {
-				elements.beginDate.val('').attr('disabled', 'disabled');
-				elements.endDate.val('').attr('disabled', 'disabled');
+				setFlatpickrDisabled(elements.beginDate, true);
+				setFlatpickrDisabled(elements.endDate, true);
 			}
 		});
 
-		$('input[name="AVAILABILITY_RANGE"]').change(function (e) {
-			if ($(e.target).val() == 'daterange') {
-				elements.beginDate.removeAttr('disabled');
-				elements.endDate.removeAttr('disabled');
+		function setFlatpickrDisabled(input, disabled) {
+
+			if (!input) return;
+
+			const fp = input._flatpickr;
+			input.disabled = disabled;
+
+			if (fp) {
+				if (fp.altInput) {
+					fp.altInput.disabled = disabled;
+				}
+
+				if (disabled) fp.close();
 			}
-			else {
-				elements.beginDate.val('').attr('disabled', 'disabled');
-				elements.endDate.val('').attr('disabled', 'disabled');
-			}
-		});
+		}
+
 	};
 
 	function selectUser(ui, textbox) {
@@ -61,12 +65,6 @@ function ReservationSearch(options) {
 			var seriesId = $(this).attr('data-seriesId');
 			var refNum = $(this).attr('data-refnum');
 			$(this).attachReservationPopup(refNum, options.popupUrl);
-			/* Replaced by Bootstrap 5
-			$(this).hover(function (e) {
-				$(this).find('td').addClass('highlight');
-			}, function (e) {
-				$(this).find('td').removeClass('highlight');
-			});*/
 		});
 	};
 

--- a/tpl/Search/search-reservations.tpl
+++ b/tpl/Search/search-reservations.tpl
@@ -87,17 +87,13 @@
                     <div class="d-flex ms-5">
                         <div class="form-group px-2">
                             <label for="beginDate" class="visually-hidden">{translate key=BeginDate}</label>
-                            <input type="date" id="beginDate" class="form-control form-control-sm dateinput"
-                                placeholder="{translate key=BeginDate}" />
-                            <input type="hidden" id="formattedBeginDate" {formname key=BEGIN_DATE}
-                                value="{formatdate date=$BeginDate key=system}" />
+                            <input type="text" id="beginDate" class="form-control form-control-sm w-auto"
+                                placeholder="{translate key=BeginDate}" {formname key=BEGIN_DATE} />
                         </div>
                         <div class="form-group">
-                            <label for=" endDate" class="visually-hidden">{translate key=EndDate}</label>
-                            <input type="date" id="endDate" class="form-control form-control-sm dateinput"
-                                placeholder="{translate key=EndDate}" />
-                            <input type="hidden" id="formattedEndDate" {formname key=END_DATE}
-                                value="{formatdate date=$EndDate key=system}" />
+                            <label for="endDate" class="visually-hidden">{translate key=EndDate}</label>
+                            <input type="text" id="endDate" class="form-control form-control-sm w-auto"
+                                placeholder="{translate key=EndDate}" {formname key=END_DATE} />
                         </div>
                     </div>
                 </div>
@@ -116,17 +112,16 @@
 
     {csrf_token}
 
-    {include file="javascript-includes.tpl" Select2=true Qtip=2 Clear=true DataTable=true}
+    {include file="javascript-includes.tpl" Select2=true Clear=true DataTable=true}
     {jsfile src="js/jquery.cookie.js"}
     {jsfile src="ajax-helpers.js"}
-    {jsfile src="resourcePopup.js"}
     {jsfile src="autocomplete.js"}
     {jsfile src="reservationPopup.js"}
     {jsfile src="reservation-search.js"}
     {jsfile src="search-clear.js"}
 
-    {control type="DatePickerSetupControl" ControlId="beginDate" AltId="formattedBeginDate" DefaultDate=$BeginDate}
-    {control type="DatePickerSetupControl" ControlId="endDate" AltId="formattedEndDate" DefaultDate=$EndDate}
+    {control type="DatePickerSetupControl" ControlId="beginDate" DefaultDate=$BeginDate}
+    {control type="DatePickerSetupControl" ControlId="endDate" DefaultDate=$EndDate}
 
     <script type="text/javascript">
         $(document).ready(function() {


### PR DESCRIPTION
- Convert begin/end date fields from native inputs to text to use flatpickr
- Use document.getElementById for element access instead of jQuery
- Replace jQuery .change() with .on('change') for event handling
- Add setFlatpickrDisabled(input, disabled) to properly enable/disable flatpickr and its altInput
- Close flatpickr calendar when disabled
- Remove unused hidden formatted date inputs and AltId usage in DatePickerSetupControl
- Drop resourcePopup.js and Qtip includes
- Remove obsolete hover highlight code