### PR TITLE
docs(api): add note to API web page about slash characters

### DIFF
--- a/Web/Services/Help/ApiHelpPage.php
+++ b/Web/Services/Help/ApiHelpPage.php
@@ -79,6 +79,8 @@ EOT;
         );
         echo $security;
 
+        echo "<div class='alert alert-warning mb-0'>⚠️ Use the Route URL as specified in regards to having or not having an ending <code>/</code> (forward slash) character.</div>";
+
         echo <<<EOT
                 </div>
             </div>


### PR DESCRIPTION
On the API web page: http://<system>/Web/Services/index.php

Add an "important" note about paying attention to forward slash characters being present or not present at the end of the Route URL