### PR TITLE
docs(cron): add documentation on how to setup cron jobs

### DIFF
--- a/docs/source/BASIC-CONFIGURATION.rst
+++ b/docs/source/BASIC-CONFIGURATION.rst
@@ -323,6 +323,22 @@ Basic Privacy Settings
 **privacy.allow.guest.reservations**
   Allow guests to make reservations.
 
+Scheduled Jobs (Cron)
+---------------------
+
+Set up host cron entries to execute the job scripts directly with PHP.
+Example crontab (adjust PHP binary path and LibreBooking path):
+
+.. code-block:: text
+
+   * * * * * /usr/bin/env php -f /var/www/librebooking/Jobs/autorelease.php
+   * * * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sendreminders.php
+   * * * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sendmissedcheckin.php
+   * * * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sendwaitlist.php
+   0 0 * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sendseriesend.php
+   0 0 * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sessioncleanup.php
+   0 1 * * * /usr/bin/env php -f /var/www/librebooking/Jobs/deleteolddata.php
+
 Next Steps
 ----------
 
@@ -368,7 +384,7 @@ Quick Start with Docker Compose
             - MYSQL_ROOT_PASSWORD=your_secure_root_password
 
         app:
-          image: librebooking/librebooking:develop
+          image: librebooking/librebooking:develop # or use tagged version
           restart: always
           depends_on:
             - db
@@ -440,9 +456,6 @@ Docker Environment Variables
 ``LB_LOGGING_SQL``
   Enable SQL logging: ``false`` (default), ``true``
 
-``LB_CRON_ENABLED``
-  Enable background cron jobs: ``false`` (default), ``true``
-
 ``LB_PATH``
   URL path prefix (for reverse proxy setups)
 
@@ -478,7 +491,7 @@ Example with persistent uploads:
 .. code-block:: yaml
 
    app:
-     image: librebooking/librebooking:develop
+     image: librebooking/librebooking:develop # or use tagged version
      volumes:
        - app_config:/config
        - ./uploads/images:/var/www/html/Web/uploads/images
@@ -487,17 +500,32 @@ Example with persistent uploads:
 Background Jobs (Cron)
 ----------------------
 
-LibreBooking requires background jobs for features like reminder emails. Enable them with:
+LibreBooking requires background jobs for features like reminder emails.
+
+**Docker/Container deployments**
+
+The recommended approach is to run cron in a dedicated container instance.
+Run the main app container as non-root ``www-data``, and run a second
+container from the same image with ``root`` and
+``/usr/local/bin/cron.sh`` as the entrypoint.
 
 .. code-block:: yaml
 
-   environment:
-     - LB_CRON_ENABLED=true
+   services:
+     app:
+       image: librebooking/librebooking:develop # or use tagged version
+       user: 'www-data'
 
-Or run them manually from the host:
+     cron:
+       image: librebooking/librebooking:develop # or use tagged version
+       user: 'root'
+       entrypoint: /usr/local/bin/cron.sh
+
+Or run them manually:
 
 .. code-block:: bash
 
+   # For example run the sendreminders.php job
    docker exec <container_name> php -f /var/www/html/Jobs/sendreminders.php
 
 Docker Troubleshooting

--- a/docs/source/INSTALLATION.rst
+++ b/docs/source/INSTALLATION.rst
@@ -256,6 +256,25 @@ file.
   sample application data (this will create 2 test users: admin/password
   and user/password for testing your installation).
 
+Scheduled Jobs (Cron)
+~~~~~~~~~~~~~~~~~~~~~
+
+LibreBooking requires background jobs for features like reminder emails.
+
+For stand-alone (non-container) deployments, set up host cron entries to
+execute the job scripts directly with PHP.
+Example crontab (adjust PHP binary path and LibreBooking path):
+
+.. code-block:: text
+
+   * * * * * /usr/bin/env php -f /var/www/librebooking/Jobs/autorelease.php
+   * * * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sendreminders.php
+   * * * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sendmissedcheckin.php
+   * * * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sendwaitlist.php
+   0 0 * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sendseriesend.php
+   0 0 * * * /usr/bin/env php -f /var/www/librebooking/Jobs/sessioncleanup.php
+   0 1 * * * /usr/bin/env php -f /var/www/librebooking/Jobs/deleteolddata.php
+
 .. _preflight-check:
 
 Preflight Check
@@ -414,7 +433,7 @@ Quick Start with Docker Compose
             - MYSQL_ROOT_PASSWORD=your_secure_root_password
 
         app:
-          image: librebooking/librebooking:develop
+          image: librebooking/librebooking:develop # or use tagged version
           restart: always
           depends_on:
             - db
@@ -486,9 +505,6 @@ Docker Environment Variables
 ``LB_LOGGING_SQL``
   Enable SQL logging: ``false`` (default), ``true``
 
-``LB_CRON_ENABLED``
-  Enable background cron jobs: ``false`` (default), ``true``
-
 Docker Image Versions
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -519,17 +535,34 @@ To persist data beyond container lifecycle, mount these directories:
 Background Jobs (Cron)
 ~~~~~~~~~~~~~~~~~~~~~~
 
-LibreBooking requires background jobs for features like reminder emails:
+LibreBooking requires background jobs for features like reminder emails.
+
+**Docker/Container deployments**
+
+The recommended approach is to run cron in a dedicated container instance.
+Run the main app container as non-root ``www-data``, and run a second
+container from the same image with ``root`` and
+``/usr/local/bin/cron.sh`` as the entrypoint.
+
+Example docker-compose services:
 
 .. code-block:: yaml
 
-   environment:
-     - LB_CRON_ENABLED=true
+   services:
+     app:
+       image: librebooking/librebooking:develop # or use tagged version
+       user: 'www-data'
+
+     cron:
+       image: librebooking/librebooking:develop # or use tagged version
+       user: 'root'
+       entrypoint: /usr/local/bin/cron.sh
 
 Or run them manually:
 
 .. code-block:: bash
 
+   # For example run the sendreminders.php job
    docker exec <container_name> php -f /var/www/html/Jobs/sendreminders.php
 
 Docker Troubleshooting


### PR DESCRIPTION
  * LB_CRON_ENABLED is no longer used by the Docker container.
  * Add documentation on how to run the cron jobs on non
    container/Docker systems.
