### PR TITLE
fix(authentication): preserve guest sessions during cookie login

### DIFF
--- a/lib/Application/Authentication/WebAuthentication.php
+++ b/lib/Application/Authentication/WebAuthentication.php
@@ -150,7 +150,11 @@ class WebAuthentication implements IWebAuthentication
             if ($valid) {
                 $loginContext->GetData()->Persist = true;
                 $this->Login($validEmail, $loginContext);
+            } else {
+                $this->DeletePersistLoginCookie();
             }
+        } else {
+            $this->DeletePersistLoginCookie();
         }
 
         Log::Debug('Cookie login. IsValid: %s', $valid);
@@ -171,6 +175,11 @@ class WebAuthentication implements IWebAuthentication
     private function DeleteLoginCookie($userid)
     {
         ServiceLocator::GetServer()->DeleteCookie(new LoginCookie($userid, null));
+    }
+
+    private function DeletePersistLoginCookie()
+    {
+        $this->server->DeleteCookie(new Cookie(CookieKeys::PERSIST_LOGIN, ''));
     }
 
     private function ValidateCookie($loginCookie)

--- a/lib/Server/Server.php
+++ b/lib/Server/Server.php
@@ -219,18 +219,16 @@ class Server
     {
         $userSession = $this->GetSession(SessionKeys::USER_SESSION);
 
-        if (!empty($userSession)) {
-            // return (UserSession) $userSession;
-            $class = 'UserSession';
-            return unserialize(
-                preg_replace(
-                    '/^O:\d+:"[^"]++"/',
-                    'O:'.strlen($class).':"'.$class.'"',
-                    serialize($userSession)
-                )
-            );
+        if (empty($userSession)) {
+            return new NullUserSession();
         }
 
+        if ($userSession instanceof UserSession) {
+            return $userSession;
+        }
+
+        // Fail closed for unexpected session payloads instead of coercing them
+        // into authenticated UserSession instances.
         return new NullUserSession();
     }
 

--- a/tests/Application/Authentication/WebAuthenticationTest.php
+++ b/tests/Application/Authentication/WebAuthenticationTest.php
@@ -121,6 +121,18 @@ class WebAuthenticationTest extends TestBase
         $this->assertEquals(1, count($this->db->_Commands));
         $this->assertFalse($this->fakeAuth->_LoginCalled);
         $this->assertEquals(new NullUserSession(), $this->fakeServer->GetUserSession());
+        $this->assertEquals(CookieKeys::PERSIST_LOGIN, $this->fakeServer->_DeletedCookie->Name);
+    }
+
+    public function testDoesNotAutoLoginIfCookieValueIsMalformed()
+    {
+        $valid = $this->webAuth->CookieLogin('malformed-cookie-value', $this->loginContext);
+
+        $this->assertFalse($valid, 'should not be valid if cookie cannot be parsed');
+        $this->assertEquals(0, count($this->db->_Commands));
+        $this->assertFalse($this->fakeAuth->_LoginCalled);
+        $this->assertEquals(new NullUserSession(), $this->fakeServer->GetUserSession());
+        $this->assertEquals(CookieKeys::PERSIST_LOGIN, $this->fakeServer->_DeletedCookie->Name);
     }
 
     public function testLogsUserOut()

--- a/tests/Infrastructure/Common/ServerTest.php
+++ b/tests/Infrastructure/Common/ServerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Server/namespace.php');
+
+class ServerTest extends TestBase
+{
+    public function testGetUserSessionReturnsUserSessionForValidPayload()
+    {
+        $server = new InMemorySessionServer();
+        $expected = new UserSession(123);
+        $expected->FirstName = 'Test';
+        $expected->LastName = 'User';
+        $server->SetSession(SessionKeys::USER_SESSION, $expected);
+
+        $session = $server->GetUserSession();
+
+        $this->assertInstanceOf(UserSession::class, $session);
+        $this->assertNotInstanceOf(NullUserSession::class, $session);
+        $this->assertSame($expected, $session);
+        $this->assertTrue($session->IsLoggedIn());
+    }
+
+    public function testGetUserSessionPreservesNullUserSessionType()
+    {
+        $server = new InMemorySessionServer();
+        $server->SetSession(SessionKeys::USER_SESSION, new NullUserSession());
+
+        $session = $server->GetUserSession();
+
+        $this->assertInstanceOf(NullUserSession::class, $session);
+        $this->assertFalse($session->IsLoggedIn());
+        $this->assertTrue($session->IsGuest());
+    }
+
+    public function testGetUserSessionReturnsNullUserSessionForUnknownPayload()
+    {
+        $server = new InMemorySessionServer();
+        $server->SetSession(SessionKeys::USER_SESSION, (object) ['foo' => 'bar']);
+
+        $session = $server->GetUserSession();
+
+        $this->assertInstanceOf(NullUserSession::class, $session);
+        $this->assertFalse($session->IsLoggedIn());
+        $this->assertTrue($session->IsGuest());
+    }
+}
+
+class InMemorySessionServer extends Server
+{
+    private array $session = [];
+
+    public function SetSession($name, $value)
+    {
+        $this->session[$name] = $value;
+    }
+
+    public function GetSession($name)
+    {
+        return $this->session[$name] ?? null;
+    }
+}


### PR DESCRIPTION
Fixes an issue introduced by commit
2898946a8eaf37f8b84e9b732760c3f8930c1cd6 in PR 381.

Prevent invalid remember-me logins from producing a ghost authenticated state across requests.

Update Server::GetUserSession() to preserve real UserSession subclasses, including NullUserSession, instead of coercing arbitrary session payloads into UserSession. Unexpected session payloads now fail closed to NullUserSession.

Also clear the persist_login cookie when remember-me validation fails or the cookie value is malformed, so stale auto-login attempts do not repeat on subsequent requests.

Add regression coverage for:
- valid UserSession round-trip from session storage
- NullUserSession preservation
- unknown session payloads failing closed
- invalid remember-me cookie deleting persist_login
- malformed remember-me cookie deleting persist_login

Closes: #928