### PR TITLE
feat(config): support optional footer version suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,10 @@
 /tools/*
 /var/*
 
-# Customized Confiuration Files
+# Customized Configuration Files
 /config/config.php
 /config/log4php.config.xml
+/config/version-suffix.txt
 **/*.config.php
 
 /lib/external/phpqrcode/cache/*

--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -13,6 +13,8 @@ use Detection\MobileDetect;
 
 abstract class Page implements IPage
 {
+    private static ?string $displayVersion = null;
+
     /**
      * @var SmartyPage
      */
@@ -58,6 +60,7 @@ abstract class Page implements IPage
 
         $this->smarty->assign('LoggedIn', $userSession->IsLoggedIn());
         $this->smarty->assign('Version', Configuration::VERSION);
+        $this->smarty->assign('DisplayVersion', $this->GetDisplayVersion());
         $this->smarty->assign('Path', $this->path);
         $this->smarty->assign('ScriptUrl', Configuration::Instance()->GetScriptUrl());
         $this->smarty->assign('UserName', !is_null($userSession) ? $userSession->FirstName : '');
@@ -483,5 +486,16 @@ abstract class Page implements IPage
         // TODO Actually check for new versions on git / save install date to DB.
         // The old Method doesn't work when deleting cookies and confuses the users.
         return false;
+    }
+
+    private function GetDisplayVersion(): string
+    {
+        if (self::$displayVersion !== null) {
+            return self::$displayVersion;
+        }
+
+        $resolver = new VersionDisplayResolver();
+        self::$displayVersion = $resolver->GetDisplayVersion(Configuration::VERSION);
+        return self::$displayVersion;
     }
 }

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -4,8 +4,10 @@ Advanced Configuration
 This guide covers all advanced configuration options available in LibreBooking.
 For basic setup, see :doc:`BASIC-CONFIGURATION` first.
 
-All settings are configured in the ``/config/config.php`` file. The
-configuration uses a mix of flat dot notation and nested arrays.
+All settings are configured in the ``<INSTALL_DIR>/config/config.php`` file,
+where ``<INSTALL_DIR>`` is the root directory of your LibreBooking
+installation. The configuration uses a mix of flat dot notation and nested
+arrays.
 
 Environment Variable Override
 -----------------------------
@@ -57,6 +59,40 @@ sensitive data separate from configuration files.
 **Complete Example**
   See ``develop/app/.env.example`` for a comprehensive list of all available
   environment variables with their default values and descriptions.
+
+Version Suffix
+--------------
+
+LibreBooking can optionally append a suffix to the version shown in the page
+footer.
+
+Create ``<INSTALL_DIR>/config/version-suffix.txt`` with a value such as
+``abc123``. This file is intended for local or deployment-time metadata and
+should not be committed to source control. If the file is present and contains
+a non-empty value, the footer version will be displayed as ``v4.1.0-abc123``.
+If the file is missing or empty, LibreBooking displays the base version only.
+
+This is intended for deployment metadata such as a Docker image build
+identifier or short Git commit SHA. Only the footer display is affected. The
+application base version and asset cache-busting remain unchanged.
+
+The file must contain a single line only. A trailing newline is allowed, but
+additional lines are ignored. After trimming, the suffix must be 40 characters
+or fewer.
+
+Valid characters are letters, numbers, ``.``, ``_``, and ``-``. If the file
+contains multiple lines, exceeds 40 characters, or includes invalid characters,
+LibreBooking ignores the suffix and logs an error.
+
+**Example**
+
+  .. code-block:: bash
+
+     git rev-parse --short HEAD > config/version-suffix.txt
+
+This writes the current short Git commit SHA into
+``<INSTALL_DIR>/config/version-suffix.txt`` so the footer displays a version
+such as ``v4.1.0-a1b2c3d``.
 
 Application Advanced Settings
 -----------------------------

--- a/lib/Common/VersionDisplayResolver.php
+++ b/lib/Common/VersionDisplayResolver.php
@@ -1,0 +1,55 @@
+<?php
+
+class VersionDisplayResolver
+{
+    private const MAX_VERSION_SUFFIX_LENGTH = 40;
+
+    private string $versionSuffixFile;
+
+    public function __construct(?string $versionSuffixFile = null)
+    {
+        $this->versionSuffixFile = $versionSuffixFile ?? ROOT_DIR . 'config/version-suffix.txt';
+    }
+
+    public function GetDisplayVersion(string $baseVersion): string
+    {
+        if (!is_file($this->versionSuffixFile) || !is_readable($this->versionSuffixFile)) {
+            return $baseVersion;
+        }
+
+        $versionSuffixContents = file_get_contents($this->versionSuffixFile);
+        if ($versionSuffixContents === false) {
+            return $baseVersion;
+        }
+
+        $versionSuffixContents = rtrim($versionSuffixContents, "\r\n");
+        if (preg_match('/\R/', $versionSuffixContents) === 1) {
+            Log::Error('Ignoring version suffix in %s because it contains more than one line', $this->versionSuffixFile);
+            return $baseVersion;
+        }
+
+        $versionSuffix = trim($versionSuffixContents);
+        if (empty($versionSuffix)) {
+            return $baseVersion;
+        }
+
+        if (strlen($versionSuffix) > self::MAX_VERSION_SUFFIX_LENGTH) {
+            Log::Error(
+                'Ignoring version suffix in %s because it exceeds %d characters',
+                $this->versionSuffixFile,
+                self::MAX_VERSION_SUFFIX_LENGTH
+            );
+            return $baseVersion;
+        }
+
+        if (preg_match('/^[A-Za-z0-9._-]+$/', $versionSuffix) !== 1) {
+            Log::Error(
+                'Ignoring version suffix in %s because it contains invalid characters. Allowed characters are letters, numbers, ".", "_", and "-"',
+                $this->versionSuffixFile
+            );
+            return $baseVersion;
+        }
+
+        return $baseVersion . '-' . $versionSuffix;
+    }
+}

--- a/lib/Common/namespace.php
+++ b/lib/Common/namespace.php
@@ -15,3 +15,4 @@ require_once(ROOT_DIR . 'lib/Common/ErrorMessages.php');
 require_once(ROOT_DIR . 'lib/Common/Logging/Log.php');
 require_once(ROOT_DIR . 'lib/Common/Logging/ExceptionHandler.php');
 require_once(ROOT_DIR . 'lib/Common/ContrastingColor.php');
+require_once(ROOT_DIR . 'lib/Common/VersionDisplayResolver.php');

--- a/tests/Infrastructure/Common/VersionDisplayResolverTest.php
+++ b/tests/Infrastructure/Common/VersionDisplayResolverTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Common/namespace.php');
+
+class VersionDisplayResolverTest extends TestBase
+{
+    private const BASE_VERSION = '4.1.0';
+
+    private array $tempPaths = [];
+
+    public function testReturnsBaseVersionWhenSuffixFileIsMissing()
+    {
+        $resolver = new VersionDisplayResolver(ROOT_DIR . 'tests/data/does-not-exist-version-suffix.txt');
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals(self::BASE_VERSION, $displayVersion);
+    }
+
+    public function testAppendsValidSuffix()
+    {
+        $suffixFile = $this->createTempSuffixFile('abc123');
+        $resolver = new VersionDisplayResolver($suffixFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals('4.1.0-abc123', $displayVersion);
+    }
+
+    public function testAllowsSingleTrailingNewline()
+    {
+        $suffixFile = $this->createTempSuffixFile("abc123\n");
+        $resolver = new VersionDisplayResolver($suffixFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals('4.1.0-abc123', $displayVersion);
+    }
+
+    public function testReturnsBaseVersionWhenSuffixHasMultipleLines()
+    {
+        $suffixFile = $this->createTempSuffixFile("abc123\nsecond-line");
+        $resolver = new VersionDisplayResolver($suffixFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals(self::BASE_VERSION, $displayVersion);
+    }
+
+    public function testReturnsBaseVersionWhenSuffixExceedsFortyCharacters()
+    {
+        $suffixFile = $this->createTempSuffixFile(str_repeat('a', 41));
+        $resolver = new VersionDisplayResolver($suffixFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals(self::BASE_VERSION, $displayVersion);
+    }
+
+    public function testReturnsBaseVersionWhenSuffixContainsInvalidCharacters()
+    {
+        $suffixFile = $this->createTempSuffixFile('abc/123');
+        $resolver = new VersionDisplayResolver($suffixFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals(self::BASE_VERSION, $displayVersion);
+    }
+
+    public function tearDown(): void
+    {
+        foreach ($this->tempPaths as $tempPath) {
+            if (file_exists($tempPath)) {
+                unlink($tempPath);
+            }
+        }
+
+        $this->tempPaths = [];
+
+        parent::tearDown();
+    }
+
+    private function createTempSuffixFile(string $contents): string
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'lb-version-suffix-');
+        if ($tempFile === false) {
+            throw new RuntimeException('Failed to create temporary version suffix file');
+        }
+
+        file_put_contents($tempFile, $contents);
+        $this->tempPaths[] = $tempFile;
+
+        return $tempFile;
+    }
+}

--- a/tpl/globalfooter.tpl
+++ b/tpl/globalfooter.tpl
@@ -5,7 +5,7 @@
 	<footer class="bg-light border-top text-center pt-2">
 		<div><a class="link-primary" href="{$CompanyUrl}">{$CompanyName}</a></div>
 		<div><a class="link-primary" href="https://github.com/LibreBooking/librebooking">LibreBooking - GPLv3
-				v{$Version}</a></div>
+				v{$DisplayVersion}</a></div>
 	</footer>
 
 	<script type="text/javascript">


### PR DESCRIPTION
Add support for an optional version suffix loaded from `config/version-suffix.txt` and append it to the version displayed in the global footer.

Only the footer display uses the composed version string.

Document the feature in ADVANCED-CONFIGURATION.rst.