### PR TITLE
feat: Enhance reservation emails with resource metadata and details table

### DIFF
--- a/lang/en_us/ReservationCreated.tpl
+++ b/lang/en_us/ReservationCreated.tpl
@@ -17,14 +17,24 @@
     <strong>Resources ({$Resources|default:array()|count}):</strong> <br />
     {foreach from=$Resources item=resource name=resourceLoop}
         <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Schedule:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>Resource ID:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Location:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Description:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Resource Administrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-        {if $resource.attributes|default:array()|count > 0}
+        {if $resource.attributeRows|default:array()|count > 0}
             <strong>Resource Details:</strong><br/>
-            {foreach from=$resource.attributes item=attribute}
-                <div>{control type="AttributeControl" attribute=$attribute readonly=true}</div>
-            {/foreach}
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
         {/if}
 
         {if $resource.image}

--- a/lang/en_us/ReservationCreatedAdmin.tpl
+++ b/lang/en_us/ReservationCreatedAdmin.tpl
@@ -24,14 +24,24 @@
 	<br/>
     {foreach from=$Resources item=resource name=resourceLoop}
         <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Schedule:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>Resource ID:</strong> {$resource.id}<br/>
         {if $resource.location}<strong>Location:</strong> {$resource.location|escape}<br/>{/if}
         {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Description:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Resource Administrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-        {if $resource.attributes|default:array()|count > 0}
+        {if $resource.attributeRows|default:array()|count > 0}
             <strong>Resource Details:</strong><br/>
-            {foreach from=$resource.attributes item=attribute}
-                <div>{control type="AttributeControl" attribute=$attribute readonly=true}</div>
-            {/foreach}
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
         {/if}
 
         {if $resource.image}

--- a/lib/Email/Messages/ReservationEmailTemplateContext.php
+++ b/lib/Email/Messages/ReservationEmailTemplateContext.php
@@ -1,7 +1,16 @@
 <?php
 
+require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+require_once(ROOT_DIR . 'Domain/Values/RoleLevel.php');
+
 class ReservationEmailTemplateContext
 {
+    /** @var array<int, Schedule>|null */
+    private ?array $schedulesById = null;
+
+    /** @var array<int, GroupItemView>|null */
+    private ?array $resourceAdminGroupsById = null;
+
     public static function BuildResourceImageUrl(?string $image): ?string
     {
         if (empty($image)) {
@@ -15,8 +24,12 @@ class ReservationEmailTemplateContext
         private ReservationSeries $reservationSeries,
         private User $reservationOwner,
         private BookableResource $primaryResource,
-        private IAttributeRepository $attributeRepository
+        private IAttributeRepository $attributeRepository,
+        private ?IScheduleRepository $scheduleRepository = null,
+        private ?IGroupViewRepository $groupRepository = null
     ) {
+        $this->scheduleRepository ??= new ScheduleRepository();
+        $this->groupRepository ??= new GroupRepository();
     }
 
     /**
@@ -32,8 +45,8 @@ class ReservationEmailTemplateContext
 
         if ($this->reservationSeries->IsRecurring()) {
             foreach ($this->reservationSeries->Instances() as $repeated) {
-                $repeatDates[] = $repeated->StartDate()->ToTimezone($timezone);
-                $repeatRanges[] = $repeated->Duration()->ToTimezone($timezone);
+                $repeatDates[] = $repeated->StartDate()->ToTimezone(timezone: $timezone);
+                $repeatRanges[] = $repeated->Duration()->ToTimezone(timezone: $timezone);
             }
         }
 
@@ -66,11 +79,14 @@ class ReservationEmailTemplateContext
                 continue;
             }
 
-            if (!in_array($this->reservationSeries->ResourceId(), $attribute->SecondaryEntityIds())) {
+            if (!in_array(needle: $this->reservationSeries->ResourceId(), haystack: $attribute->SecondaryEntityIds())) {
                 continue;
             }
 
-            $attributeValues[] = new LBAttribute($attribute, $this->reservationSeries->GetAttributeValue($attribute->Id()));
+            $attributeValues[] = new LBAttribute(
+                attributeDefinition: $attribute,
+                value: $this->reservationSeries->GetAttributeValue($attribute->Id())
+            );
         }
 
         return $attributeValues;
@@ -90,12 +106,15 @@ class ReservationEmailTemplateContext
      * @return list<array{
      *   id: int,
      *   name: string,
+     *   scheduleName: string,
      *   location: string|null,
      *   contact: string|null,
      *   notes: string|null,
      *   description: string|null,
+     *   resourceAdministrator: string,
      *   image: string|null,
-     *   attributes: list<LBAttribute>
+     *   attributes: list<LBAttribute>,
+     *   attributeRows: list<array{label: string, displayValue: string}>
      * }>
      */
     public function Resources(bool $includeAdminOnly = false): array
@@ -104,7 +123,11 @@ class ReservationEmailTemplateContext
         $resources = [];
 
         foreach ($this->reservationSeries->AllResources() as $resource) {
-            $resources[] = $this->BuildResourceData($resource, $resourceAttributes, $includeAdminOnly);
+            $resources[] = $this->BuildResourceData(
+                resource: $resource,
+                resourceAttributeDefinitions: $resourceAttributes,
+                includeAdminOnly: $includeAdminOnly
+            );
         }
 
         return $resources;
@@ -115,17 +138,20 @@ class ReservationEmailTemplateContext
      * @return array{
      *   id: int,
      *   name: string,
+     *   scheduleName: string,
      *   location: string|null,
      *   contact: string|null,
      *   notes: string|null,
      *   description: string|null,
+     *   resourceAdministrator: string,
      *   image: string|null,
-     *   attributes: list<LBAttribute>
+     *   attributes: list<LBAttribute>,
+     *   attributeRows: list<array{label: string, displayValue: string}>
      * }
      */
     private function BuildResourceData(BookableResource $resource, array $resourceAttributeDefinitions, bool $includeAdminOnly): array
     {
-        $resourceImage = self::BuildResourceImageUrl($resource->GetImage());
+        $resourceImage = self::BuildResourceImageUrl(image: $resource->GetImage());
 
         $resourceAttributeValues = [];
         foreach ($resourceAttributeDefinitions as $attribute) {
@@ -134,19 +160,133 @@ class ReservationEmailTemplateContext
             }
 
             if ($attribute->AppliesToEntity($resource->GetId())) {
-                $resourceAttributeValues[] = new LBAttribute($attribute, $resource->GetAttributeValue($attribute->Id()));
+                $resourceAttributeValues[] = new LBAttribute(
+                    attributeDefinition: $attribute,
+                    value: $resource->GetAttributeValue($attribute->Id())
+                );
             }
         }
+
+        usort(
+            $resourceAttributeValues,
+            static fn (LBAttribute $left, LBAttribute $right): int => strcasecmp($left->Label(), $right->Label())
+        );
 
         return [
             'id' => $resource->GetId(),
             'name' => $resource->GetName(),
+            'scheduleName' => $this->ScheduleName(resource: $resource),
             'location' => $resource->GetLocation(),
             'contact' => $resource->GetContact(),
             'notes' => $resource->GetNotes(),
             'description' => $resource->GetDescription(),
+            'resourceAdministrator' => $this->ResourceAdministrator(resource: $resource),
             'image' => $resourceImage,
             'attributes' => $resourceAttributeValues,
+            'attributeRows' => $this->AttributeRows(attributes: $resourceAttributeValues),
         ];
+    }
+
+    /**
+     * @param list<LBAttribute> $attributes
+     * @return list<array{label: string, displayValue: string}>
+     */
+    private function AttributeRows(array $attributes): array
+    {
+        $rows = [];
+        $resources = Resources::GetInstance();
+        $dateFormat = $resources->GetDateFormat('general_datetime');
+
+        foreach ($attributes as $attribute) {
+            $rows[] = [
+                'label' => $attribute->Label(),
+                'displayValue' => $this->AttributeDisplayValue(
+                    attribute: $attribute,
+                    resources: $resources,
+                    dateFormat: $dateFormat
+                ),
+            ];
+        }
+
+        return $rows;
+    }
+
+    private function AttributeDisplayValue(LBAttribute $attribute, Resources $resources, string $dateFormat): string
+    {
+        $value = $attribute->Value();
+
+        if ($value === null || $value === '') {
+            return '';
+        }
+
+        if ($attribute->Type() == CustomAttributeTypes::CHECKBOX) {
+            return $value == '1'
+                ? $resources->GetString('True')
+                : $resources->GetString('False');
+        }
+
+        if ($attribute->Type() == CustomAttributeTypes::DATETIME) {
+            if ($value instanceof Date) {
+                return $value->Format($dateFormat);
+            }
+
+            if (is_string($value)) {
+                try {
+                    return Date::Parse($value)->Format($dateFormat);
+                } catch (Exception $e) {
+                    return $value;
+                }
+            }
+        }
+
+        return strval($value);
+    }
+
+    private function ScheduleName(BookableResource $resource): string
+    {
+        $schedules = $this->SchedulesById();
+        $scheduleId = $resource->GetScheduleId();
+
+        return isset($schedules[$scheduleId]) ? $schedules[$scheduleId]->GetName() : '';
+    }
+
+    private function ResourceAdministrator(BookableResource $resource): string
+    {
+        $groups = $this->ResourceAdminGroupsById();
+        $groupId = $resource->GetAdminGroupId();
+
+        return isset($groups[$groupId]) ? $groups[$groupId]->Name : '';
+    }
+
+    /**
+     * @return array<int, Schedule>
+     */
+    private function SchedulesById(): array
+    {
+        if ($this->schedulesById === null) {
+            $this->schedulesById = [];
+
+            foreach ($this->scheduleRepository->GetAll() as $schedule) {
+                $this->schedulesById[$schedule->GetId()] = $schedule;
+            }
+        }
+
+        return $this->schedulesById;
+    }
+
+    /**
+     * @return array<int, GroupItemView>
+     */
+    private function ResourceAdminGroupsById(): array
+    {
+        if ($this->resourceAdminGroupsById === null) {
+            $this->resourceAdminGroupsById = [];
+
+            foreach ($this->groupRepository->GetGroupsByRole(RoleLevel::RESOURCE_ADMIN) as $group) {
+                $this->resourceAdminGroupsById[$group->Id] = $group;
+            }
+        }
+
+        return $this->resourceAdminGroupsById;
     }
 }

--- a/tests/Application/Reservation/ReservationEmailTemplateContextTest.php
+++ b/tests/Application/Reservation/ReservationEmailTemplateContextTest.php
@@ -50,6 +50,8 @@ class ReservationEmailTemplateContextTest extends TestBase
         $primaryResource = new FakeBookableResource(100, 'Primary');
         $primaryResource->SetLocation('Room A');
         $primaryResource->SetContact('owner@example.com');
+        $primaryResource->SetScheduleId(1);
+        $primaryResource->SetAdminGroupId(501);
         $primaryResource->SetImage('primary.png');
         $primaryResource->WithAttribute(new AttributeValue(11, 'primary-visible'));
         $primaryResource->WithAttribute(new AttributeValue(12, 'primary-admin'));
@@ -57,6 +59,8 @@ class ReservationEmailTemplateContextTest extends TestBase
         $additionalResource = new FakeBookableResource(200, 'Secondary');
         $additionalResource->SetLocation('Room B');
         $additionalResource->SetContact('secondary@example.com');
+        $additionalResource->SetScheduleId(2);
+        $additionalResource->SetAdminGroupId(502);
         $additionalResource->WithAttribute(new AttributeValue(11, 'secondary-visible'));
         $additionalResource->WithAttribute(new AttributeValue(12, 'secondary-admin'));
 
@@ -71,11 +75,35 @@ class ReservationEmailTemplateContextTest extends TestBase
         $attributeRepository = new FakeAttributeRepository();
         $attributeRepository->_CustomAttributes = [$visibleResourceAttribute, $adminOnlyResourceAttribute];
 
-        $context = new ReservationEmailTemplateContext($series, $owner, $primaryResource, $attributeRepository);
+        $scheduleRepository = new FakeScheduleRepository();
+        $scheduleRepository->_Schedules = [
+            new Schedule(1, 'Schedule One', true, 0, 7),
+            new Schedule(2, 'Schedule Two', false, 0, 7),
+        ];
+
+        $groupRepository = $this->createMock(IGroupViewRepository::class);
+        $groupRepository->expects($this->once())
+            ->method('GetGroupsByRole')
+            ->with(RoleLevel::RESOURCE_ADMIN)
+            ->willReturn([
+                new GroupItemView(501, 'Resource Admin Group A'),
+                new GroupItemView(502, 'Resource Admin Group B'),
+            ]);
+
+        $context = new ReservationEmailTemplateContext(
+            $series,
+            $owner,
+            $primaryResource,
+            $attributeRepository,
+            $scheduleRepository,
+            $groupRepository
+        );
 
         $withoutAdminOnly = $context->Resources(false);
         $this->assertCount(2, $withoutAdminOnly);
         $this->assertEquals('Primary', $withoutAdminOnly[0]['name']);
+        $this->assertEquals('Schedule One', $withoutAdminOnly[0]['scheduleName']);
+        $this->assertEquals('Resource Admin Group A', $withoutAdminOnly[0]['resourceAdministrator']);
         $this->assertEquals('Room A', $withoutAdminOnly[0]['location']);
         $this->assertEquals('owner@example.com', $withoutAdminOnly[0]['contact']);
         $this->assertEquals('uploads/primary.png', $withoutAdminOnly[0]['image']);
@@ -83,6 +111,8 @@ class ReservationEmailTemplateContextTest extends TestBase
         $this->assertEquals(11, $withoutAdminOnly[0]['attributes'][0]->Id());
         $this->assertEquals('primary-visible', $withoutAdminOnly[0]['attributes'][0]->Value());
         $this->assertEquals('Secondary', $withoutAdminOnly[1]['name']);
+        $this->assertEquals('Schedule Two', $withoutAdminOnly[1]['scheduleName']);
+        $this->assertEquals('Resource Admin Group B', $withoutAdminOnly[1]['resourceAdministrator']);
         $this->assertCount(1, $withoutAdminOnly[1]['attributes']);
         $this->assertEquals(11, $withoutAdminOnly[1]['attributes'][0]->Id());
         $this->assertEquals('secondary-visible', $withoutAdminOnly[1]['attributes'][0]->Value());
@@ -94,6 +124,71 @@ class ReservationEmailTemplateContextTest extends TestBase
         $this->assertCount(2, $withAdminOnly[1]['attributes']);
         $this->assertEquals(12, $withAdminOnly[1]['attributes'][1]->Id());
         $this->assertEquals('secondary-admin', $withAdminOnly[1]['attributes'][1]->Value());
+    }
+
+    public function testResourcesBuildsAttributeRowsWithBlankCheckboxAndDatetimeValues(): void
+    {
+        $owner = new FakeUser(10);
+        $primaryResource = new FakeBookableResource(100, 'Primary');
+        $primaryResource->SetScheduleId(1);
+        $primaryResource->SetAdminGroupId(501);
+
+        $dateObject = Date::Parse('2026-03-01 10:30:00', 'UTC');
+        $dateString = '2026-03-01 11:45:00';
+
+        $primaryResource->WithAttribute(new AttributeValue(21, ''));
+        $primaryResource->WithAttribute(new AttributeValue(22, '1'));
+        $primaryResource->WithAttribute(new AttributeValue(23, '0'));
+        $primaryResource->WithAttribute(new AttributeValue(24, $dateObject));
+        $primaryResource->WithAttribute(new AttributeValue(25, $dateString));
+
+        $series = new TestReservationSeries();
+        $series->WithOwnerId($owner->Id());
+        $series->WithResource($primaryResource);
+
+        $attributeRepository = new FakeAttributeRepository();
+        $attributeRepository->_CustomAttributes = [
+            $this->createResourceAttribute(21, [100], false, CustomAttributeTypes::SINGLE_LINE_TEXTBOX, 'Blank Value'),
+            $this->createResourceAttribute(22, [100], false, CustomAttributeTypes::CHECKBOX, 'Checkbox True'),
+            $this->createResourceAttribute(23, [100], false, CustomAttributeTypes::CHECKBOX, 'Checkbox False'),
+            $this->createResourceAttribute(24, [100], false, CustomAttributeTypes::DATETIME, 'Date Object'),
+            $this->createResourceAttribute(25, [100], false, CustomAttributeTypes::DATETIME, 'Date String'),
+        ];
+
+        $scheduleRepository = new FakeScheduleRepository();
+        $scheduleRepository->_Schedules = [new Schedule(1, 'Schedule One', true, 0, 7)];
+
+        $groupRepository = $this->createMock(IGroupViewRepository::class);
+        $groupRepository->expects($this->once())
+            ->method('GetGroupsByRole')
+            ->with(RoleLevel::RESOURCE_ADMIN)
+            ->willReturn([new GroupItemView(501, 'Resource Admin Group A')]);
+
+        $context = new ReservationEmailTemplateContext(
+            $series,
+            $owner,
+            $primaryResource,
+            $attributeRepository,
+            $scheduleRepository,
+            $groupRepository
+        );
+
+        $resources = $context->Resources(false);
+
+        $this->assertCount(1, $resources);
+        $rowsByLabel = [];
+        foreach ($resources[0]['attributeRows'] as $row) {
+            $rowsByLabel[$row['label']] = $row['displayValue'];
+        }
+
+        $localized = Resources::GetInstance();
+        $dateFormat = $localized->GetDateFormat('general_datetime');
+
+        $this->assertSame('', $rowsByLabel['Blank Value']);
+        $this->assertSame($localized->GetString('True'), $rowsByLabel['Checkbox True']);
+        $this->assertSame($localized->GetString('False'), $rowsByLabel['Checkbox False']);
+        $this->assertSame($dateObject->Format($dateFormat), $rowsByLabel['Date Object']);
+        $this->assertSame(Date::Parse($dateString)->Format($dateFormat), $rowsByLabel['Date String']);
     }
 
     public function testRepeatVariablesReturnsEmptyListsForNonRecurringSeries(): void
@@ -169,19 +264,24 @@ class ReservationEmailTemplateContextTest extends TestBase
         $this->assertEquals('first last', (string)$createdBy);
     }
 
-    private function createResourceAttribute(int $id, array $entityIds, bool $adminOnly): CustomAttribute
-    {
+    private function createResourceAttribute(
+        int $id,
+        array $entityIds,
+        bool $adminOnly,
+        int $type = CustomAttributeTypes::SINGLE_LINE_TEXTBOX,
+        ?string $label = null
+    ): CustomAttribute {
         return new CustomAttribute(
-            $id,
-            'resource attribute ' . $id,
-            CustomAttributeTypes::SINGLE_LINE_TEXTBOX,
-            CustomAttributeCategory::RESOURCE,
-            null,
-            false,
-            null,
-            1,
-            $entityIds,
-            $adminOnly
+            id: $id,
+            label: $label ?? ('resource attribute ' . $id),
+            type: $type,
+            category: CustomAttributeCategory::RESOURCE,
+            regex: null,
+            required: false,
+            possibleValues: null,
+            sortOrder: 1,
+            entityIds: $entityIds,
+            adminOnly: $adminOnly
         );
     }
 }


### PR DESCRIPTION
Expand reservation email resource rendering to include additional
standard resource fields and present per-resource custom attributes in a
table.

This change:

- adds schedule name, resource id, description, notes, and resource
  administrator to the reservation email resource payload
- formats per-resource custom attributes into email-ready table rows in
  ReservationEmailTemplateContext
- updates reservation created user/admin email templates to show the new
  top-level resource metadata
- changes the Resource Details section from line-by-line attribute
  blocks to a two-column table
- preserves blank custom attributes by rendering empty value cells

This improves reservation email readability and makes multi-resource
reservations more informative without changing reservation-level
attribute rendering.
