### PR TITLE
refactor: reservation email template context for multi-resource emails

### DIFF
--- a/lang/en_us/ReservationCreated.tpl
+++ b/lang/en_us/ReservationCreated.tpl
@@ -14,19 +14,26 @@
 </p>
 
 <p>
-{if $ResourceNames|default:array()|count > 1}
-    <strong>Resources ({$ResourceNames|default:array()|count}):</strong> <br />
-    {foreach from=$ResourceNames item=resourceName}
-        {$resourceName}<br/>
-    {/foreach}
-{else}
-    <strong>Resource:</strong> {$ResourceName}<br/>
-{/if}
-</p>
+    <strong>Resources ({$Resources|default:array()|count}):</strong> <br />
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.location}<strong>Location:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
 
-{if $ResourceImage}
-    <div class="resource-image"><img alt="{$ResourceName|escape}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributes|default:array()|count > 0}
+            <strong>Resource Details:</strong><br/>
+            {foreach from=$resource.attributes item=attribute}
+                <div>{control type="AttributeControl" attribute=$attribute readonly=true}</div>
+            {/foreach}
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 {if $RequiresApproval}
 	<p>* At least one of the resources reserved requires approval before usage. This reservation will be pending until it is approved. *</p>
@@ -124,4 +131,3 @@
 	|
 {/if}
 <a href="{$ScriptUrl}">Log in to {$AppTitle}</a>
-

--- a/lang/en_us/ReservationCreatedAdmin.tpl
+++ b/lang/en_us/ReservationCreatedAdmin.tpl
@@ -20,22 +20,27 @@
 </p>
 
 <p>
-    {if $ResourceNames|default:array()|count > 1}
-		<strong>Resources:</strong>
-		<br/>
-        {foreach from=$ResourceNames item=resourceName}
-            {$resourceName}
-			<br/>
-        {/foreach}
-    {else}
-		<strong>Resource:</strong>
-        {$ResourceName}
-    {/if}
-</p>
+	<strong>Resources ({$Resources|default:array()|count}):</strong>
+	<br/>
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.location}<strong>Location:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img alt="{$ResourceName}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributes|default:array()|count > 0}
+            <strong>Resource Details:</strong><br/>
+            {foreach from=$resource.attributes item=attribute}
+                <div>{control type="AttributeControl" attribute=$attribute readonly=true}</div>
+            {/foreach}
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 
 {if $RequiresApproval}

--- a/lib/Email/Messages/ReservationCreatedEmailAdmin.php
+++ b/lib/Email/Messages/ReservationCreatedEmailAdmin.php
@@ -1,53 +1,26 @@
 <?php
 
 require_once(ROOT_DIR . 'lib/Email/namespace.php');
+require_once(ROOT_DIR . 'lib/Email/Messages/ReservationEmailTemplateContext.php');
 
 // TODO: Need a way to unit test this
 class ReservationCreatedEmailAdmin extends EmailMessage
 {
-    /**
-     * @var UserDto
-     */
-    protected $adminDto;
+    protected UserDto $adminDto;
 
-    /**
-     * @var User
-     */
-    protected $reservationOwner;
+    protected User $reservationOwner;
 
-    /**
-     * @var ReservationSeries
-     */
-    protected $reservationSeries;
+    protected ReservationSeries $reservationSeries;
 
-    /**
-     * @var IResource
-     */
-    protected $resource;
+    protected BookableResource $resource;
 
-    /**
-     * @var IAttributeRepository
-     */
-    protected $attributeRepository;
+    protected IAttributeRepository $attributeRepository;
 
-    /**
-     * @var string
-     */
-    protected $timezone;
-    /**
-     * @var IUserRepository
-     */
-    private $userRepository;
+    private string $timezone;
 
-    /**
-     * @param UserDto $adminDto
-     * @param User $reservationOwner
-     * @param ReservationSeries $reservationSeries
-     * @param IResource $primaryResource
-     * @param IAttributeRepository $attributeRepository
-     * @param IUserRepository $userRepository
-     */
-    public function __construct(UserDto $adminDto, User $reservationOwner, ReservationSeries $reservationSeries, IResource $primaryResource, IAttributeRepository $attributeRepository, IUserRepository $userRepository)
+    private IUserRepository $userRepository;
+
+    public function __construct(UserDto $adminDto, User $reservationOwner, ReservationSeries $reservationSeries, BookableResource $primaryResource, IAttributeRepository $attributeRepository, IUserRepository $userRepository)
     {
         parent::__construct($adminDto->Language());
 
@@ -56,7 +29,8 @@ class ReservationCreatedEmailAdmin extends EmailMessage
         $this->reservationSeries = $reservationSeries;
         $this->resource = $primaryResource;
         $this->attributeRepository = $attributeRepository;
-        $this->timezone = $adminDto->Timezone();
+        $adminTimezone = $adminDto->Timezone();
+        $this->timezone = !empty($adminTimezone) ? $adminTimezone : Configuration::Instance()->GetDefaultTimezone();
         $this->userRepository = $userRepository;
     }
 
@@ -100,6 +74,13 @@ class ReservationCreatedEmailAdmin extends EmailMessage
 
     protected function PopulateTemplate()
     {
+        $context = new ReservationEmailTemplateContext(
+            reservationSeries: $this->reservationSeries,
+            reservationOwner: $this->reservationOwner,
+            primaryResource: $this->resource,
+            attributeRepository: $this->attributeRepository
+        );
+
         $this->Set('UserName', $this->reservationOwner->FullName());
 
         $currentInstance = $this->reservationSeries->CurrentInstance();
@@ -107,54 +88,30 @@ class ReservationCreatedEmailAdmin extends EmailMessage
         $this->Set('StartDate', $currentInstance->StartDate()->ToTimezone($this->timezone));
         $this->Set('EndDate', $currentInstance->EndDate()->ToTimezone($this->timezone));
         $this->Set('ResourceName', $this->resource->GetName());
+        $resourceImage = ReservationEmailTemplateContext::BuildResourceImageUrl($this->reservationSeries->Resource()->GetImage());
+        if ($resourceImage != null) {
+            $this->Set('ResourceImage', $resourceImage);
+        }
         $this->Set('Title', $this->reservationSeries->Title());
         $this->Set('Description', $this->reservationSeries->Description());
 
-        $img = $this->reservationSeries->Resource()->GetImage();
-        if (!empty($img)) {
-            $this->Set('ResourceImage', $this->GetFullImagePath($img));
-        }
-
-        $repeatDates = [];
-        $repeatRanges = [];
-        if ($this->reservationSeries->IsRecurring()) {
-            foreach ($this->reservationSeries->Instances() as $repeated) {
-                $repeatDates[] = $repeated->StartDate()->ToTimezone($this->timezone);
-                $repeatRanges[] = $repeated->Duration()->ToTimezone($this->timezone);
-            }
-        }
-        $this->Set('RepeatDates', $repeatDates);
-        $this->Set('RepeatRanges', $repeatRanges);
+        $repeatVariables = $context->GetRecurrenceInstances($this->timezone);
+        $this->Set('RepeatDates', $repeatVariables['RepeatDates']);
+        $this->Set('RepeatRanges', $repeatVariables['RepeatRanges']);
         $this->Set('RequiresApproval', $this->reservationSeries->RequiresApproval());
         $this->Set('ReservationUrl', Pages::RESERVATION . '?' . QueryStringKeys::REFERENCE_NUMBER . '=' . $currentInstance->ReferenceNumber());
 
-        $resourceNames = [];
-        foreach ($this->reservationSeries->AllResources() as $resource) {
-            $resourceNames[] = $resource->GetName();
-        }
-        $this->Set('ResourceNames', $resourceNames);
+        $this->Set('ResourceNames', $context->ResourceNames());
+        $this->Set('Resources', $context->Resources(true));
         $this->Set('Accessories', $this->reservationSeries->Accessories());
 
-        $attributes = $this->attributeRepository->GetByCategory(CustomAttributeCategory::RESERVATION);
-        $attributeValues = [];
-        foreach ($attributes as $attribute) {
-            if (($attribute->HasSecondaryEntities()) && in_array($this->reservationSeries->ResourceId(), $attribute->SecondaryEntityIds())) {
-                $attributeValues[] = new LBAttribute($attribute, $this->reservationSeries->GetAttributeValue($attribute->Id()));
-            }
-        }
+        $this->Set('Attributes', $context->ReservationAttributes());
 
-        $this->Set('Attributes', $attributeValues);
-
-        $bookedBy = $this->reservationSeries->BookedBy();
-        if ($bookedBy != null && ($bookedBy->UserId != $this->reservationOwner->Id())) {
-            $this->Set('CreatedBy', new FullName($bookedBy->FirstName, $bookedBy->LastName));
+        $createdBy = $context->CreatedBy();
+        if ($createdBy != null) {
+            $this->Set('CreatedBy', $createdBy);
         }
 
         $this->Set('ReferenceNumber', $this->reservationSeries->CurrentInstance()->ReferenceNumber());
-    }
-
-    private function GetFullImagePath($img)
-    {
-        return Configuration::Instance()->GetKey(ConfigKeys::UPLOAD_IMAGE_URL) . '/' . $img;
     }
 }

--- a/lib/Email/Messages/ReservationEmailMessage.php
+++ b/lib/Email/Messages/ReservationEmailMessage.php
@@ -6,6 +6,7 @@ require_once(ROOT_DIR . 'Pages/Export/CalendarExportDisplay.php');
 require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Reservation/namespace.php');
 require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+require_once(ROOT_DIR . 'lib/Email/Messages/ReservationEmailTemplateContext.php');
 
 abstract class ReservationEmailMessage extends EmailMessage
 {
@@ -20,14 +21,11 @@ abstract class ReservationEmailMessage extends EmailMessage
     protected $reservationSeries;
 
     /**
-     * @var IResource
+     * @var BookableResource
      */
     protected $primaryResource;
 
-    /**
-     * @var string
-     */
-    protected $timezone;
+    protected ?string $timezone;
 
     /**
      * @var IAttributeRepository
@@ -53,7 +51,8 @@ abstract class ReservationEmailMessage extends EmailMessage
 
         $this->reservationOwner = $reservationOwner;
         $this->reservationSeries = $reservationSeries;
-        $this->timezone = $reservationOwner->Timezone();
+        $ownerTimezone = $reservationOwner->Timezone();
+        $this->timezone = !empty($ownerTimezone) ? $ownerTimezone : Configuration::Instance()->GetDefaultTimezone();
         $this->attributeRepository = $attributeRepository;
         $this->primaryResource = $reservationSeries->Resource();
         $this->userRepository = $userRepository;
@@ -92,28 +91,29 @@ abstract class ReservationEmailMessage extends EmailMessage
     protected function PopulateTemplate()
     {
         $currentInstance = $this->reservationSeries->CurrentInstance();
+        $context = new ReservationEmailTemplateContext(
+            reservationSeries: $this->reservationSeries,
+            reservationOwner: $this->reservationOwner,
+            primaryResource: $this->primaryResource,
+            attributeRepository: $this->attributeRepository
+        );
+
         $this->Set('UserName', $this->reservationOwner->FullName());
         $this->Set('StartDate', $currentInstance->StartDate()->ToTimezone($this->timezone));
         $this->Set('EndDate', $currentInstance->EndDate()->ToTimezone($this->timezone));
         $this->Set('ScheduleId', $this->reservationSeries->ScheduleId());
         $this->Set('ResourceName', $this->reservationSeries->Resource()->GetName());
-        $img = $this->reservationSeries->Resource()->GetImage();
-        if (!empty($img)) {
-            $this->Set('ResourceImage', $this->GetFullImagePath($img));
+        $resourceImage = ReservationEmailTemplateContext::BuildResourceImageUrl($this->reservationSeries->Resource()->GetImage());
+        if ($resourceImage != null) {
+            $this->Set('ResourceImage', $resourceImage);
         }
+
         $this->Set('Title', $this->reservationSeries->Title());
         $this->Set('Description', $this->reservationSeries->Description());
 
-        $repeatDates = [];
-        $repeatRanges = [];
-        if ($this->reservationSeries->IsRecurring()) {
-            foreach ($this->reservationSeries->Instances() as $repeated) {
-                $repeatDates[] = $repeated->StartDate()->ToTimezone($this->timezone);
-                $repeatRanges[] = $repeated->Duration()->ToTimezone($this->timezone);
-            }
-        }
-        $this->Set('RepeatDates', $repeatDates);
-        $this->Set('RepeatRanges', $repeatRanges);
+        $repeatVariables = $context->GetRecurrenceInstances($this->timezone);
+        $this->Set('RepeatDates', $repeatVariables['RepeatDates']);
+        $this->Set('RepeatRanges', $repeatVariables['RepeatRanges']);
         $this->Set('RequiresApproval', $this->reservationSeries->RequiresApproval());
 
         $this->Set('ReservationUrl', sprintf('%s?%s=%s', Pages::RESERVATION, QueryStringKeys::REFERENCE_NUMBER, $currentInstance->ReferenceNumber()));
@@ -133,26 +133,16 @@ abstract class ReservationEmailMessage extends EmailMessage
         );
         $this->Set('GoogleCalendarUrl', $googleCalendarUrl);
 
-        $resourceNames = [];
-        foreach ($this->reservationSeries->AllResources() as $resource) {
-            $resourceNames[] = $resource->GetName();
-        }
-        $this->Set('ResourceNames', $resourceNames);
+        $this->Set('ResourceNames', $context->ResourceNames());
+        $this->Set('Resources', $context->Resources());
         $this->Set('Accessories', $this->reservationSeries->Accessories());
 
-        $attributes = $this->attributeRepository->GetByCategory(CustomAttributeCategory::RESERVATION);
-        $attributeValues = [];
-        foreach ($attributes as $attribute) {
-            if (($attribute->HasSecondaryEntities()) && in_array($this->reservationSeries->ResourceId(), $attribute->SecondaryEntityIds())) {
-                $attributeValues[] = new LBAttribute($attribute, $this->reservationSeries->GetAttributeValue($attribute->Id()));
-            }
-        }
-
+        $attributeValues = $context->ReservationAttributes();
         $this->Set('Attributes', $attributeValues);
 
-        $bookedBy = $this->reservationSeries->BookedBy();
-        if ($bookedBy != null && ($bookedBy->UserId != $this->reservationOwner->Id())) {
-            $this->Set('CreatedBy', new FullName($bookedBy->FirstName, $bookedBy->LastName));
+        $createdBy = $context->CreatedBy();
+        if ($createdBy != null) {
+            $this->Set('CreatedBy', $createdBy);
         }
 
         $minimumAutoRelease = null;
@@ -189,11 +179,6 @@ abstract class ReservationEmailMessage extends EmailMessage
 
         $this->Set('CreditsCurrent', $currentInstance->GetCreditsRequired());
         $this->Set('CreditsTotal', $this->reservationSeries->GetCreditsRequired());
-    }
-
-    private function GetFullImagePath($img)
-    {
-        return Configuration::Instance()->GetKey(ConfigKeys::UPLOAD_IMAGE_URL) . '/' . $img;
     }
 
     /**

--- a/lib/Email/Messages/ReservationEmailTemplateContext.php
+++ b/lib/Email/Messages/ReservationEmailTemplateContext.php
@@ -1,0 +1,152 @@
+<?php
+
+class ReservationEmailTemplateContext
+{
+    public static function BuildResourceImageUrl(?string $image): ?string
+    {
+        if (empty($image)) {
+            return null;
+        }
+
+        return Configuration::Instance()->GetKey(ConfigKeys::UPLOAD_IMAGE_URL) . '/' . $image;
+    }
+
+    public function __construct(
+        private ReservationSeries $reservationSeries,
+        private User $reservationOwner,
+        private BookableResource $primaryResource,
+        private IAttributeRepository $attributeRepository
+    ) {
+    }
+
+    /**
+     * Returns the start dates and durations for each instance of a recurring series,
+     * converted to the given timezone. Both lists are empty for non-recurring reservations.
+     *
+     * @return array{RepeatDates: list<Date>, RepeatRanges: list<DateRange>}
+     */
+    public function GetRecurrenceInstances(string $timezone): array
+    {
+        $repeatDates = [];
+        $repeatRanges = [];
+
+        if ($this->reservationSeries->IsRecurring()) {
+            foreach ($this->reservationSeries->Instances() as $repeated) {
+                $repeatDates[] = $repeated->StartDate()->ToTimezone($timezone);
+                $repeatRanges[] = $repeated->Duration()->ToTimezone($timezone);
+            }
+        }
+
+        return ['RepeatDates' => $repeatDates, 'RepeatRanges' => $repeatRanges];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function ResourceNames(): array
+    {
+        $resourceNames = [];
+        foreach ($this->reservationSeries->AllResources() as $resource) {
+            $resourceNames[] = $resource->GetName();
+        }
+
+        return $resourceNames;
+    }
+
+    /**
+     * @return list<LBAttribute>
+     */
+    public function ReservationAttributes(): array
+    {
+        $attributes = $this->attributeRepository->GetByCategory(CustomAttributeCategory::RESERVATION);
+        $attributeValues = [];
+
+        foreach ($attributes as $attribute) {
+            if (!$attribute->HasSecondaryEntities()) {
+                continue;
+            }
+
+            if (!in_array($this->reservationSeries->ResourceId(), $attribute->SecondaryEntityIds())) {
+                continue;
+            }
+
+            $attributeValues[] = new LBAttribute($attribute, $this->reservationSeries->GetAttributeValue($attribute->Id()));
+        }
+
+        return $attributeValues;
+    }
+
+    public function CreatedBy(): ?FullName
+    {
+        $bookedBy = $this->reservationSeries->BookedBy();
+        if ($bookedBy != null && ($bookedBy->UserId != $this->reservationOwner->Id())) {
+            return new FullName($bookedBy->FirstName, $bookedBy->LastName);
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<array{
+     *   id: int,
+     *   name: string,
+     *   location: string|null,
+     *   contact: string|null,
+     *   notes: string|null,
+     *   description: string|null,
+     *   image: string|null,
+     *   attributes: list<LBAttribute>
+     * }>
+     */
+    public function Resources(bool $includeAdminOnly = false): array
+    {
+        $resourceAttributes = $this->attributeRepository->GetByCategory(CustomAttributeCategory::RESOURCE);
+        $resources = [];
+
+        foreach ($this->reservationSeries->AllResources() as $resource) {
+            $resources[] = $this->BuildResourceData($resource, $resourceAttributes, $includeAdminOnly);
+        }
+
+        return $resources;
+    }
+
+    /**
+     * @param list<CustomAttribute> $resourceAttributeDefinitions
+     * @return array{
+     *   id: int,
+     *   name: string,
+     *   location: string|null,
+     *   contact: string|null,
+     *   notes: string|null,
+     *   description: string|null,
+     *   image: string|null,
+     *   attributes: list<LBAttribute>
+     * }
+     */
+    private function BuildResourceData(BookableResource $resource, array $resourceAttributeDefinitions, bool $includeAdminOnly): array
+    {
+        $resourceImage = self::BuildResourceImageUrl($resource->GetImage());
+
+        $resourceAttributeValues = [];
+        foreach ($resourceAttributeDefinitions as $attribute) {
+            if (!$includeAdminOnly && $attribute->AdminOnly()) {
+                continue;
+            }
+
+            if ($attribute->AppliesToEntity($resource->GetId())) {
+                $resourceAttributeValues[] = new LBAttribute($attribute, $resource->GetAttributeValue($attribute->Id()));
+            }
+        }
+
+        return [
+            'id' => $resource->GetId(),
+            'name' => $resource->GetName(),
+            'location' => $resource->GetLocation(),
+            'contact' => $resource->GetContact(),
+            'notes' => $resource->GetNotes(),
+            'description' => $resource->GetDescription(),
+            'image' => $resourceImage,
+            'attributes' => $resourceAttributeValues,
+        ];
+    }
+}

--- a/lib/Email/Messages/ReservationRequiresApprovalEmailAdmin.php
+++ b/lib/Email/Messages/ReservationRequiresApprovalEmailAdmin.php
@@ -4,17 +4,16 @@ require_once(ROOT_DIR . 'lib/Email/namespace.php');
 
 class ReservationRequiresApprovalEmailAdmin extends ReservationCreatedEmailAdmin
 {
-    /**
-     * @param UserDto $adminDto
-     * @param User $reservationOwner
-     * @param ReservationSeries $reservationSeries
-     * @param IResource $primaryResource
-     * @param IAttributeRepository $attributeRepository
-     * @param IUserRepository $userRepository
-     */
-    public function __construct(UserDto $adminDto, User $reservationOwner, ReservationSeries $reservationSeries, IResource $primaryResource, IAttributeRepository $attributeRepository, IUserRepository $userRepository)
+    public function __construct(UserDto $adminDto, User $reservationOwner, ReservationSeries $reservationSeries, BookableResource $primaryResource, IAttributeRepository $attributeRepository, IUserRepository $userRepository)
     {
-        parent::__construct($adminDto, $reservationOwner, $reservationSeries, $primaryResource, $attributeRepository, $userRepository);
+        parent::__construct(
+            adminDto: $adminDto,
+            reservationOwner: $reservationOwner,
+            reservationSeries: $reservationSeries,
+            primaryResource: $primaryResource,
+            attributeRepository: $attributeRepository,
+            userRepository: $userRepository
+        );
     }
 
     public function Subject()

--- a/tests/Application/Reservation/ReservationEmailTemplateContextTest.php
+++ b/tests/Application/Reservation/ReservationEmailTemplateContextTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Email/Messages/ReservationEmailTemplateContext.php');
+
+class ReservationEmailTemplateContextTest extends TestBase
+{
+    public function testReservationAttributesMatchLegacySelectionRules(): void
+    {
+        $owner = new FakeUser(10);
+        $primaryResource = new FakeBookableResource(100, 'Primary');
+        $additionalResource = new FakeBookableResource(200, 'Additional');
+
+        $series = new TestReservationSeries();
+        $series->WithOwnerId($owner->Id());
+        $series->WithResource($primaryResource);
+        $series->AddResource($additionalResource);
+        $series->WithAttributeValue(new AttributeValue(1, 'primary match'));
+        $series->WithAttributeValue(new AttributeValue(2, 'no secondary entities'));
+        $series->WithAttributeValue(new AttributeValue(3, 'additional resource only'));
+
+        $matchingPrimary = (new ReservationEmailTemplateTestAttribute(1))
+            ->ForResourceIds([$primaryResource->GetResourceId()]);
+        $noSecondaryEntities = new ReservationEmailTemplateTestAttribute(2);
+        $matchingAdditionalOnly = (new ReservationEmailTemplateTestAttribute(3))
+            ->ForResourceIds([$additionalResource->GetResourceId()]);
+
+        $attributeRepository = new FakeAttributeRepository();
+        $attributeRepository->_CustomAttributes = [
+            $matchingPrimary,
+            $noSecondaryEntities,
+            $matchingAdditionalOnly,
+        ];
+
+        $context = new ReservationEmailTemplateContext($series, $owner, $primaryResource, $attributeRepository);
+
+        $attributes = $context->ReservationAttributes();
+
+        $this->assertCount(1, $attributes);
+        $this->assertEquals(1, $attributes[0]->Id());
+        $this->assertEquals('primary match', $attributes[0]->Value());
+    }
+
+    public function testResourcesReturnsMultiResourcePayloadAndHonorsAdminOnlyFilter(): void
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::UPLOAD_IMAGE_URL, 'uploads');
+
+        $owner = new FakeUser(10);
+        $primaryResource = new FakeBookableResource(100, 'Primary');
+        $primaryResource->SetLocation('Room A');
+        $primaryResource->SetContact('owner@example.com');
+        $primaryResource->SetImage('primary.png');
+        $primaryResource->WithAttribute(new AttributeValue(11, 'primary-visible'));
+        $primaryResource->WithAttribute(new AttributeValue(12, 'primary-admin'));
+
+        $additionalResource = new FakeBookableResource(200, 'Secondary');
+        $additionalResource->SetLocation('Room B');
+        $additionalResource->SetContact('secondary@example.com');
+        $additionalResource->WithAttribute(new AttributeValue(11, 'secondary-visible'));
+        $additionalResource->WithAttribute(new AttributeValue(12, 'secondary-admin'));
+
+        $series = new TestReservationSeries();
+        $series->WithOwnerId($owner->Id());
+        $series->WithResource($primaryResource);
+        $series->AddResource($additionalResource);
+
+        $visibleResourceAttribute = $this->createResourceAttribute(11, [100, 200], false);
+        $adminOnlyResourceAttribute = $this->createResourceAttribute(12, [100, 200], true);
+
+        $attributeRepository = new FakeAttributeRepository();
+        $attributeRepository->_CustomAttributes = [$visibleResourceAttribute, $adminOnlyResourceAttribute];
+
+        $context = new ReservationEmailTemplateContext($series, $owner, $primaryResource, $attributeRepository);
+
+        $withoutAdminOnly = $context->Resources(false);
+        $this->assertCount(2, $withoutAdminOnly);
+        $this->assertEquals('Primary', $withoutAdminOnly[0]['name']);
+        $this->assertEquals('Room A', $withoutAdminOnly[0]['location']);
+        $this->assertEquals('owner@example.com', $withoutAdminOnly[0]['contact']);
+        $this->assertEquals('uploads/primary.png', $withoutAdminOnly[0]['image']);
+        $this->assertCount(1, $withoutAdminOnly[0]['attributes']);
+        $this->assertEquals(11, $withoutAdminOnly[0]['attributes'][0]->Id());
+        $this->assertEquals('primary-visible', $withoutAdminOnly[0]['attributes'][0]->Value());
+        $this->assertEquals('Secondary', $withoutAdminOnly[1]['name']);
+        $this->assertCount(1, $withoutAdminOnly[1]['attributes']);
+        $this->assertEquals(11, $withoutAdminOnly[1]['attributes'][0]->Id());
+        $this->assertEquals('secondary-visible', $withoutAdminOnly[1]['attributes'][0]->Value());
+
+        $withAdminOnly = $context->Resources(true);
+        $this->assertCount(2, $withAdminOnly[0]['attributes']);
+        $this->assertEquals(12, $withAdminOnly[0]['attributes'][1]->Id());
+        $this->assertEquals('primary-admin', $withAdminOnly[0]['attributes'][1]->Value());
+        $this->assertCount(2, $withAdminOnly[1]['attributes']);
+        $this->assertEquals(12, $withAdminOnly[1]['attributes'][1]->Id());
+        $this->assertEquals('secondary-admin', $withAdminOnly[1]['attributes'][1]->Value());
+    }
+
+    public function testRepeatVariablesReturnsEmptyListsForNonRecurringSeries(): void
+    {
+        $owner = new FakeUser(10);
+        $primaryResource = new FakeBookableResource(100, 'Primary');
+
+        $series = new TestReservationSeries();
+        $series->WithOwnerId($owner->Id());
+        $series->WithResource($primaryResource);
+        $series->WithCurrentInstance(new TestReservation());
+
+        $context = new ReservationEmailTemplateContext($series, $owner, $primaryResource, new FakeAttributeRepository());
+        $repeatVariables = $context->GetRecurrenceInstances('UTC');
+
+        $this->assertEmpty($repeatVariables['RepeatDates']);
+        $this->assertEmpty($repeatVariables['RepeatRanges']);
+    }
+
+    public function testRepeatVariablesExpandsRecurringSeriesUsingRequestedTimezone(): void
+    {
+        $owner = new FakeUser(10);
+        $primaryResource = new FakeBookableResource(100, 'Primary');
+
+        $series = new TestReservationSeries();
+        $series->WithOwnerId($owner->Id());
+        $series->WithBookedBy(new FakeUserSession(false, 'UTC', 20));
+        $series->WithResource($primaryResource);
+
+        $start = Date::Parse('2026-03-01 10:00:00', 'UTC');
+        $end = Date::Parse('2026-03-01 11:00:00', 'UTC');
+        $series->WithCurrentInstance(new TestReservation('ref-1', new DateRange($start, $end), 1));
+        $series->WithRepeatOptions(new RepeatDaily(1, Date::Parse('2026-03-03', 'UTC')));
+
+        $context = new ReservationEmailTemplateContext($series, $owner, $primaryResource, new FakeAttributeRepository());
+        $repeatVariables = $context->GetRecurrenceInstances('America/Chicago');
+
+        $this->assertCount(3, $repeatVariables['RepeatDates']);
+        $this->assertCount(3, $repeatVariables['RepeatRanges']);
+        $this->assertEquals('America/Chicago', $repeatVariables['RepeatDates'][0]->Timezone());
+        $this->assertEquals('America/Chicago', $repeatVariables['RepeatRanges'][0]->GetBegin()->Timezone());
+    }
+
+    public function testCreatedByReturnsNullWhenBookedByMatchesOwner(): void
+    {
+        $owner = new FakeUser(10);
+        $primaryResource = new FakeBookableResource(100, 'Primary');
+
+        $series = new TestReservationSeries();
+        $series->WithOwnerId($owner->Id());
+        $series->WithBookedBy(new FakeUserSession(false, 'UTC', $owner->Id()));
+        $series->WithResource($primaryResource);
+
+        $context = new ReservationEmailTemplateContext($series, $owner, $primaryResource, new FakeAttributeRepository());
+
+        $this->assertNull($context->CreatedBy());
+    }
+
+    public function testCreatedByReturnsNameWhenBookedByDiffersFromOwner(): void
+    {
+        $owner = new FakeUser(10);
+        $primaryResource = new FakeBookableResource(100, 'Primary');
+
+        $series = new TestReservationSeries();
+        $series->WithOwnerId($owner->Id());
+        $series->WithBookedBy(new FakeUserSession(false, 'UTC', 99));
+        $series->WithResource($primaryResource);
+
+        $context = new ReservationEmailTemplateContext($series, $owner, $primaryResource, new FakeAttributeRepository());
+        $createdBy = $context->CreatedBy();
+
+        $this->assertNotNull($createdBy);
+        $this->assertEquals('first last', (string)$createdBy);
+    }
+
+    private function createResourceAttribute(int $id, array $entityIds, bool $adminOnly): CustomAttribute
+    {
+        return new CustomAttribute(
+            $id,
+            'resource attribute ' . $id,
+            CustomAttributeTypes::SINGLE_LINE_TEXTBOX,
+            CustomAttributeCategory::RESOURCE,
+            null,
+            false,
+            null,
+            1,
+            $entityIds,
+            $adminOnly
+        );
+    }
+}
+
+class ReservationEmailTemplateTestAttribute extends FakeCustomAttribute
+{
+    public function __construct(int $id)
+    {
+        parent::__construct($id);
+    }
+
+    public function ForResourceIds(array $entityIds): self
+    {
+        $this->WithSecondaryEntities(CustomAttributeCategory::RESOURCE, $entityIds);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Extract shared reservation email template data building into ReservationEmailTemplateContext and update reservation email messages to use it.

This change:

- centralizes resource, repeat, reservation attribute, and created-by template data
- switches reservation created emails to render from structured $Resources data instead of single-resource / name-list conditionals
- updates admin reservation email classes to use BookableResource consistently
- removes duplicated template-population logic from reservation email message classes

Behaviorally, this prepares reservation emails for richer per-resource rendering while preserving the existing line-by-line resource details output.