### PR TITLE
test(reservation): fix issue with DST causing test failure

### DIFF
--- a/tests/Application/Reservation/ScheduleTotalConcurrentReservationsRuleTest.php
+++ b/tests/Application/Reservation/ScheduleTotalConcurrentReservationsRuleTest.php
@@ -146,6 +146,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testChecksEachInstanceOfASeries()
     {
+        Date::_SetNow(Date::Create(2026, 1, 15, 12, 0, 0, 'America/Chicago'));
         $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(30);
         $resourceId = 1;
@@ -161,6 +162,7 @@ class ScheduleTotalConcurrentReservationsRuleTest extends TestBase
 
     public function testIncludesBufferTime()
     {
+        Date::_SetNow(Date::Create(2026, 1, 15, 12, 0, 0, 'America/Chicago'));
         $start = TestBase::GetTestDate();
         $end = $start->AddMinutes(90);
         $resourceId = 1;


### PR DESCRIPTION
Due to DST (Daylight Savings Time) coming up in the next few days it caused a test failure.

Freeze "now" to a fixed midday anchor in
ScheduleTotalConcurrentReservationsRuleTest::testChecksEachInstanceOfASeries before deriving test dates from TestBase::GetTestDate().

This test was intermittently failing when the generated recurrence window crossed a DST boundary in the booked-by timezone (America/New_York), which could shift overlap behavior and flip the assertion result.

Related: #544