### PR TITLE
fix: update the reservation email templates for various languages

### DIFF
--- a/lang/da_da/ReservationCreated.tpl
+++ b/lang/da_da/ReservationCreated.tpl
@@ -4,21 +4,41 @@ Oplysninger om reservation:
 
 Begynder: {formatdate date=$StartDate key=reservation_email}<br/>
 Slutter: {formatdate date=$EndDate key=reservation_email}<br/>
-{if $ResourceNames|default:array()|count > 1}
-	Faciliteter:
-	<br/>
-	{foreach from=$ResourceNames item=resourceName}
-		{$resourceName}
-		<br/>
-	{/foreach}
-{else}
-	Facilitet: {$ResourceName}
-	<br/>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+        <strong>Faciliteter ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>Facilitet:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Tidsplan:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>Facilitets-ID:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Placering:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Beskrivelse:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Noter:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Facilitetsadministrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Facilitetsdetaljer:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 Overskrift: {$Title}<br/>
 Beskrivelse: {$Description|nl2br}

--- a/lang/da_da/ReservationCreatedAdmin.tpl
+++ b/lang/da_da/ReservationCreatedAdmin.tpl
@@ -9,21 +9,42 @@ Bruger: {$UserName}<br/>
 {/if}
 Begynder: {formatdate date=$StartDate key=reservation_email}<br/>
 Slutter: {formatdate date=$EndDate key=reservation_email}<br/>
-{if $ResourceNames|default:array()|count > 1}
-	Faciliteter:
-	<br/>
-	{foreach from=$ResourceNames item=resourceName}
-		{$resourceName}
-		<br/>
-	{/foreach}
-{else}
-	Facilitet: {$ResourceName}
-	<br/>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+    <strong>Faciliteter ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>Facilitet:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Tidsplan:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>Facilitets-ID:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Placering:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Kontakt:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Beskrivelse:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Noter:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Facilitetsadministrator:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Facilitetsdetaljer:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 Overskrift: {$Title}<br/>
 Beskrivelse: {$Description|nl2br}

--- a/lang/el_gr/ReservationCreated.tpl
+++ b/lang/el_gr/ReservationCreated.tpl
@@ -14,19 +14,41 @@
 </p>
 
 <p>
-{if $ResourceNames|default:array()|count > 1}
-    <strong>Πόροι ({$ResourceNames|default:array()|count}):</strong> <br />
-    {foreach from=$ResourceNames item=resourceName}
-        {$resourceName}<br/>
-    {/foreach}
-{else}
-    <strong>Πόρος:</strong> {$ResourceName}<br/>
-{/if}
-</p>
 
-{if $ResourceImage}
-    <div class="resource-image"><img alt="{$ResourceName|escape}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+        <strong>Πόροι ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>Πόρος:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Χρονοδιάγραμμα:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>Αναγνωριστικό πόρου:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Τοποθεσία:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Επικοινωνία:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Περιγραφή:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Σημειώσεις:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Διαχειριστής πόρου:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Λεπτομέρειες πόρου:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 {if $RequiresApproval}
 	<p>* Τουλάχιστον ένας από τους κρατημένους πόρους απαιτεί έγκριση πριν τη χρήση του. Η κράτηση θα παραμείνει σε εκκρεμότητα μέχρι να εγκριθεί. *</p>

--- a/lang/el_gr/ReservationCreatedAdmin.tpl
+++ b/lang/el_gr/ReservationCreatedAdmin.tpl
@@ -20,22 +20,42 @@
 </p>
 
 <p>
-	{if $ResourceNames|default:array()|count > 1}
-		<strong>Πόροι:</strong>
-		<br/>
-		{foreach from=$ResourceNames item=resourceName}
-			{$resourceName}
-			<br/>
-		{/foreach}
-	{else}
-		<strong>Πόρος:</strong> {$ResourceName}
-		<br/>
-	{/if}
-</p>
 
-{if $ResourceImage}
-	<div class="resource-image"><img alt="{$ResourceName}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+    <strong>Πόροι ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>Πόρος:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Χρονοδιάγραμμα:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>Αναγνωριστικό πόρου:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Τοποθεσία:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Επικοινωνία:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Περιγραφή:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Σημειώσεις:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Διαχειριστής πόρου:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Λεπτομέρειες πόρου:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 
 {if $RequiresApproval}

--- a/lang/es/ReservationCreated.tpl
+++ b/lang/es/ReservationCreated.tpl
@@ -14,19 +14,41 @@
 </p>
 
 <p>
-{if $ResourceNames|default:array()|count > 1}
-    <strong>Recursos ({$ResourceNames|default:array()|count}):</strong> <br />
-    {foreach from=$ResourceNames item=resourceName}
-        {$resourceName}<br/>
-    {/foreach}
-{else}
-    <strong>Recurso:</strong> {$ResourceName}<br/>
-{/if}
-</p>
 
-{if $ResourceImage}
-    <div class="resource-image"><img alt="{$ResourceName|escape}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+        <strong>Recursos ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>Recurso:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Horario:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID del recurso:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Ubicación:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contacto:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Descripción:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Administrador del recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Detalles del recurso:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 {if $RequiresApproval}
 	<p>* Al menos uno de los recursos reservados requiere aprobación antes de su uso. Esta reserva estará pendiente hasta que sea aprobada. *</p>

--- a/lang/es/ReservationCreatedAdmin.tpl
+++ b/lang/es/ReservationCreatedAdmin.tpl
@@ -20,22 +20,42 @@
 </p>
 
 <p>
-    {if $ResourceNames|default:array()|count > 1}
-		<strong>Recursos:</strong>
-		<br/>
-        {foreach from=$ResourceNames item=resourceName}
-            {$resourceName}
-			<br/>
-        {/foreach}
-    {else}
-		<strong>Recurso:</strong>
-        {$ResourceName}
-    {/if}
-</p>
 
-{if $ResourceImage}
-	<div class="resource-image"><img alt="{$ResourceName}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+    <strong>Recursos ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>Recurso:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Horario:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID del recurso:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Ubicación:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contacto:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Descripción:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Administrador del recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Detalles del recurso:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 
 {if $RequiresApproval}

--- a/lang/fr_fr/ReservationCreated.tpl
+++ b/lang/fr_fr/ReservationCreated.tpl
@@ -14,19 +14,41 @@
 </p>
 
 <p>
-{if $ResourceNames|default:array()|count > 1}
-    <strong>Ressources ({$ResourceNames|default:array()|count}):</strong> <br />
-    {foreach from=$ResourceNames item=resourceName}
-        {$resourceName}<br/>
-    {/foreach}
-{else}Title
-    <strong>Resource:</strong> {$ResourceName}<br/>
-{/if}
-</p>
 
-{if $ResourceImage}
-    <div class="resource-image"><img alt="{$ResourceName|escape}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+        <strong>Ressources ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>Ressource:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Calendrier:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID de la ressource:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Emplacement:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Description:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Administrateur de la ressource:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Détails de la ressource:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 {if $RequiresApproval}
 	<p>* Une ou plusieurs ressources réservées nécessitent une validation avant leur utilisation. Cette réservation est en attente jusqu'à son approbation. *</p>

--- a/lang/fr_fr/ReservationCreatedAdmin.tpl
+++ b/lang/fr_fr/ReservationCreatedAdmin.tpl
@@ -20,22 +20,42 @@
 </p>
 
 <p>
-    {if $ResourceNames|default:array()|count > 1}
-		<strong>Ressources:</strong>
-		<br/>
-        {foreach from=$ResourceNames item=resourceName}
-            {$resourceName}
-			<br/>
-        {/foreach}
-    {else}
-		<strong>Ressource:</strong>
-        {$ResourceName}
-    {/if}
-</p>
 
-{if $ResourceImage}
-	<div class="resource-image"><img alt="{$ResourceName}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+    <strong>Ressources ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>Ressource:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Calendrier:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID de la ressource:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Emplacement:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contact:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Description:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notes:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Administrateur de la ressource:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Détails de la ressource:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 
 {if $RequiresApproval}

--- a/lang/hu_hu/ReservationCreated.tpl
+++ b/lang/hu_hu/ReservationCreated.tpl
@@ -4,21 +4,41 @@ A foglalás részletei:
 
 Kezdés: {formatdate date=$StartDate key=reservation_email}<br/>
 Befejezés: {formatdate date=$EndDate key=reservation_email}<br/>
-{if $ResourceNames|default:array()|count > 1}
-	Elemek:
-	<br/>
-	{foreach from=$ResourceNames item=resourceName}
-		{$resourceName}
-		<br/>
-	{/foreach}
-{else}
-	Elem: {$ResourceName}
-	<br/>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+        <strong>Erőforrások ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>Erőforrás:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Ütemezés:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>Erőforrás azonosító:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Helyszín:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Kapcsolat:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Leírás:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Megjegyzések:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Erőforrás rendszergazda:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Erőforrás részletei:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 Megnevezés: {$Title}<br/>
 Leírás: {$Description|nl2br}

--- a/lang/hu_hu/ReservationCreatedAdmin.tpl
+++ b/lang/hu_hu/ReservationCreatedAdmin.tpl
@@ -9,21 +9,42 @@ Felhasználó: {$UserName}<br/>
 {/if}
 Kezdés: {formatdate date=$StartDate key=reservation_email}<br/>
 Befejezés: {formatdate date=$EndDate key=reservation_email}<br/>
-{if $ResourceNames|default:array()|count > 1}
-	Elemek:
-	<br/>
-	{foreach from=$ResourceNames item=resourceName}
-		{$resourceName}
-		<br/>
-	{/foreach}
-{else}
-	Elem: {$ResourceName}
-	<br/>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+    <strong>Erőforrások ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>Erőforrás:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Ütemezés:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>Erőforrás azonosító:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Helyszín:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Kapcsolat:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Leírás:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Megjegyzések:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Erőforrás rendszergazda:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Erőforrás részletei:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 Megnevezés: {$Title}<br/>
 Leírás: {$Description|nl2br}

--- a/lang/it_it/ReservationCreated.tpl
+++ b/lang/it_it/ReservationCreated.tpl
@@ -14,21 +14,41 @@
         {/foreach}
     </p>
 {/if}
-{if $ResourceNames|default:array()|count > 1}
-    <p>
-        <strong>Risorse ({$ResourceNames|default:array()|count}):</strong><br />
-        {foreach from=$ResourceNames item=resourceName}
-            {$resourceName}<br />
-        {/foreach}
-		</p>
-{else}
-    <p>
-        <strong>Risorsa:</strong> {$ResourceName}<br />
-	  </p>
-{/if}
-{if $ResourceImage}
-    <div class="resource-image"><img alt="{$ResourceName|escape}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+        <strong>Risorse ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>Risorsa:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Pianificazione:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID risorsa:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Posizione:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contatto:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Descrizione:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Note:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Amministratore della risorsa:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Dettagli risorsa:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 {if $RequiresApproval}
 	  <p>* Almeno una delle risorse prenotate richiede approvazione. Questa prenotazione rimarr&agrave; in sospeso fino a quando non verr&agrave; approvata. *</p>
 {/if}

--- a/lang/it_it/ReservationCreatedAdmin.tpl
+++ b/lang/it_it/ReservationCreatedAdmin.tpl
@@ -17,21 +17,42 @@
     {/foreach}
 	  </p>
 {/if}
-{if $ResourceNames|default:array()|count > 1}
-    <p>
-		    <strong>Risorse({$ResourceNames|default:array()|count}):</strong><br />
-        {foreach from=$ResourceNames item=resourceName}
-            {$resourceName}<br />
-        {/foreach}
-		</p>
-{else}
-		<p>
-        <strong>Risorsa:</strong> {$ResourceName}<br />
-	  </p>
-{/if}
-{if $ResourceImage}
-    <div class="resource-image"><img alt="{$ResourceName}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+    <strong>Risorse ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>Risorsa:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Pianificazione:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID risorsa:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Posizione:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contatto:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Descrizione:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Note:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Amministratore della risorsa:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Dettagli risorsa:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 {if $RequiresApproval}
 	<p>* Almeno una delle risorse prenotate richiede approvazione. Verificare questa prenotazione per approvarla o rifiutarla. *</p>
 {/if}

--- a/lang/pt_br/ReservationCreated.tpl
+++ b/lang/pt_br/ReservationCreated.tpl
@@ -19,22 +19,41 @@
 </p>
 
 <p>
-    {if $ResourceNames|default:array()|count > 1}
-        <strong>Recursos ({$ResourceNames|default:array()|count}):</strong>
-        {foreach from=$ResourceNames item=resourceName}
-            <br />
-            {$resourceName}
-        {/foreach}
-    {else}
-        <strong>Recurso:</strong> {$ResourceName}
-    {/if}
-</p>
 
-{if $ResourceImage}
-    <div class="resource-image">
-        <img alt="{$ResourceName|escape}" src="{$ScriptUrl}/{$ResourceImage}" />
-    </div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+        <strong>Recursos ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>Recurso:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Agenda:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID do recurso:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Localização:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contato:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Descrição:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Administrador do recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Detalhes do recurso:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 {if $RequiresApproval}
     <p>

--- a/lang/pt_br/ReservationCreatedAdmin.tpl
+++ b/lang/pt_br/ReservationCreatedAdmin.tpl
@@ -25,22 +25,42 @@
 </p>
 
 <p>
-    {if $ResourceNames|default:array()|count > 1}
-        <strong>Recursos ({$ResourceNames|default:array()|count}):</strong>
-        {foreach from=$ResourceNames item=resourceName}
-            <br/>
-            {$resourceName}
-        {/foreach}
-    {else}
-        <strong>Recurso:</strong> {$ResourceName}
-    {/if}
-</p>
 
-{if $ResourceImage}
-	<div class="resource-image">
-        <img alt="{$ResourceName}" src="{$ScriptUrl}/{$ResourceImage}"/>
-    </div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+    <strong>Recursos ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>Recurso:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Agenda:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID do recurso:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Localização:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contato:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Descrição:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Administrador do recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Detalhes do recurso:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 
 {if $RequiresApproval}

--- a/lang/pt_pt/ReservationCreated.tpl
+++ b/lang/pt_pt/ReservationCreated.tpl
@@ -14,19 +14,41 @@
 </p>
 
 <p>
-{if $ResourceNames|default:array()|count > 1}
-    <strong>Recursos ({$ResourceNames|default:array()|count}):</strong> <br />
-    {foreach from=$ResourceNames item=resourceName}
-        {$resourceName}<br/>
-    {/foreach}
-{else}
-    <strong>Recurso:</strong> {$ResourceName}<br/>
-{/if}
-</p>
 
-{if $ResourceImage}
-    <div class="resource-image"><img alt="{$ResourceName|escape}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+        <strong>Recursos ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>Recurso:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Agenda:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID do recurso:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Localização:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contacto:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Descrição:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Administrador do recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Detalhes do recurso:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 {if $RequiresApproval}
 	<p>* Pelo menos um dos recursos reservados requer aprovação antes do uso. Esta reserva ficará pendente até que seja aprovada. *</p>

--- a/lang/pt_pt/ReservationCreatedAdmin.tpl
+++ b/lang/pt_pt/ReservationCreatedAdmin.tpl
@@ -20,22 +20,42 @@
 </p>
 
 <p>
-    {if $ResourceNames|default:array()|count > 1}
-		<strong>Recursos:</strong>
-		<br/>
-        {foreach from=$ResourceNames item=resourceName}
-            {$resourceName}
-			<br/>
-        {/foreach}
-    {else}
-		<strong>Recurso:</strong>
-        {$ResourceName}
-    {/if}
-</p>
 
-{if $ResourceImage}
-	<div class="resource-image"><img alt="{$ResourceName}" src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+    {if $Resources|default:array()|count > 1}
+    <strong>Recursos ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>Recurso:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>Agenda:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>ID do recurso:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>Localização:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>Contacto:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>Descrição:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>Notas:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>Administrador do recurso:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
+
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>Detalhes do recurso:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 
 {if $RequiresApproval}

--- a/lang/th_th/ReservationCreated.tpl
+++ b/lang/th_th/ReservationCreated.tpl
@@ -4,21 +4,41 @@
 
 เริ่มต้น: {formatdate date=$StartDate key=reservation_email}<br/>
 สิ้นสุด: {formatdate date=$EndDate key=reservation_email}<br/>
-{if $ResourceNames|default:array()|count > 1}
-	ทรัพยากร:
-	<br/>
-	{foreach from=$ResourceNames item=resourceName}
-		{$resourceName}
-		<br/>
-	{/foreach}
-{else}
-	ทรัพยากร: {$ResourceName}
-	<br/>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+        <strong>ทรัพยากร ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>ทรัพยากร:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>ตารางเวลา:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>รหัสทรัพยากร:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>สถานที่:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>ผู้ติดต่อ:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>คำอธิบาย:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>หมายเหตุ:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>ผู้ดูแลทรัพยากร:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>รายละเอียดทรัพยากร:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 ชื่อเรื่อง: {$Title}<br/>
 รายละเอียด: {$Description|nl2br}

--- a/lang/th_th/ReservationCreatedAdmin.tpl
+++ b/lang/th_th/ReservationCreatedAdmin.tpl
@@ -9,21 +9,42 @@
 {/if}
 เริ่มต้น: {formatdate date=$StartDate key=reservation_email}<br/>
 สิ้นสุด: {formatdate date=$EndDate key=reservation_email}<br/>
-{if $ResourceNames|default:array()|count > 1}
-	ทรัพยากร:
-	<br/>
-	{foreach from=$ResourceNames item=resourceName}
-		{$resourceName}
-		<br/>
-	{/foreach}
-{else}
-	ทรัพยากร: {$ResourceName}
-	<br/>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+    <strong>ทรัพยากร ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>ทรัพยากร:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>ตารางเวลา:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>รหัสทรัพยากร:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>สถานที่:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>ผู้ติดต่อ:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>คำอธิบาย:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>หมายเหตุ:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>ผู้ดูแลทรัพยากร:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>รายละเอียดทรัพยากร:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 ชื่อเรื่อง: {$Title}<br/>
 รายละเอียด: {$Description|nl2br}

--- a/lang/zh_cn/ReservationCreated.tpl
+++ b/lang/zh_cn/ReservationCreated.tpl
@@ -4,21 +4,41 @@
 
 开始时间: {formatdate date=$StartDate key=reservation_email}<br/>
 结束时间: {formatdate date=$EndDate key=reservation_email}<br/>
-{if $ResourceNames|default:array()|count > 1}
-	资源名称:
-	<br/>
-	{foreach from=$ResourceNames item=resourceName}
-		{$resourceName}
-		<br/>
-	{/foreach}
-{else}
-	资源名称: {$ResourceName}
-	<br/>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+        <strong>资源 ({$Resources|default:array()|count}):</strong> <br />
+    {else}
+        <strong>资源:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>日程:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>资源 ID:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>位置:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>联系人:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>说明:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>备注:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>资源管理员:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>资源详情:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 预约名称: {$Title}<br/>
 预约说明: {$Description|nl2br}

--- a/lang/zh_cn/ReservationCreatedAdmin.tpl
+++ b/lang/zh_cn/ReservationCreatedAdmin.tpl
@@ -9,21 +9,42 @@
 {/if}
 开始时间: {formatdate date=$StartDate key=reservation_email}<br/>
 结束时间: {formatdate date=$EndDate key=reservation_email}<br/>
-{if $ResourceNames|default:array()|count > 1}
-	资源名称:
-	<br/>
-	{foreach from=$ResourceNames item=resourceName}
-		{$resourceName}
-		<br/>
-	{/foreach}
-{else}
-	资源名称: {$ResourceName}
-	<br/>
-{/if}
+<p>
+    {if $Resources|default:array()|count > 1}
+    <strong>资源 ({$Resources|default:array()|count}):</strong>
+    <br/>
+    {else}
+    <strong>资源:</strong><br/>
+    {/if}
+    {foreach from=$Resources item=resource name=resourceLoop}
+        <strong>{$resource.name|escape}</strong><br/>
+        {if $resource.scheduleName}<strong>日程:</strong> {$resource.scheduleName|escape}<br/>{/if}
+        <strong>资源 ID:</strong> {$resource.id}<br/>
+        {if $resource.location}<strong>位置:</strong> {$resource.location|escape}<br/>{/if}
+        {if $resource.contact}<strong>联系人:</strong> {$resource.contact|escape}<br/>{/if}
+        {if $resource.description}<strong>说明:</strong> {$resource.description|escape|nl2br}<br/>{/if}
+        {if $resource.notes}<strong>备注:</strong> {$resource.notes|escape|nl2br}<br/>{/if}
+        {if $resource.resourceAdministrator}<strong>资源管理员:</strong> {$resource.resourceAdministrator|escape}<br/>{/if}
 
-{if $ResourceImage}
-	<div class="resource-image"><img src="{$ScriptUrl}/{$ResourceImage}"/></div>
-{/if}
+        {if $resource.attributeRows|default:array()|count > 0}
+            <strong>资源详情:</strong><br/>
+            <table cellpadding="4" cellspacing="0" border="1" style="border-collapse: collapse; margin-top: 4px;">
+                {foreach from=$resource.attributeRows item=row}
+                    <tr>
+                        <th scope="row" valign="top" style="text-align: left;"><strong>{$row.label|escape}</strong></th>
+                        <td valign="top">{$row.displayValue|escape|nl2br}</td>
+                    </tr>
+                {/foreach}
+            </table>
+        {/if}
+
+        {if $resource.image}
+            <div class="resource-image"><img alt="{$resource.name|escape}" src="{$ScriptUrl}/{$resource.image|escape}"/></div>
+        {/if}
+
+        {if !$smarty.foreach.resourceLoop.last}<br/>{/if}
+    {/foreach}
+</p>
 
 预约名称: {$Title}<br/>
 预约说明: {$Description|nl2br}


### PR DESCRIPTION
Update the remaining reservation email templates for the various languages. The translations were machine generated.

Previous commit e94ad114e34d9c8aad37a41515e2be716d389d1b did not do all the languages.