### PR TITLE
test: resolve issues with tests and crossing a DST boundary

### DIFF
--- a/tests/Application/Reservation/ResourceMaximumNoticeRuleTest.php
+++ b/tests/Application/Reservation/ResourceMaximumNoticeRuleTest.php
@@ -19,6 +19,8 @@ class ResourceMaximumNoticeRuleTest extends TestBase
 
     public function testMaxNoticeIsCheckedAgainstEachReservationInstanceForEachResource()
     {
+        Date::_SetNow(Date::Create(2026, 1, 15, 12, 0, 0, 'America/New_York'));
+
         $resource1 = new FakeBookableResource(1, '1');
         $resource1->SetMaxNotice(null);
 

--- a/tests/Presenters/Reservation/ExistingReservationInitializerTest.php
+++ b/tests/Presenters/Reservation/ExistingReservationInitializerTest.php
@@ -82,6 +82,8 @@ class ExistingReservationInitializerTest extends TestBase
 
     public function testBindsToClosestPeriodFromReservationDates()
     {
+        Date::_SetNow(Date::Create(2026, 1, 15, 12, 0, 0, 'America/New_York'));
+
         $page = $this->createMock('IExistingReservationPage');
         $binder = $this->createMock('IReservationComponentBinder');
 

--- a/tests/Presenters/Reservation/ReservationInitializationTest.php
+++ b/tests/Presenters/Reservation/ReservationInitializationTest.php
@@ -108,6 +108,8 @@ class ReservationInitializationTest extends TestBase
 
     public function testBindsToClosestPeriod()
     {
+        Date::_SetNow(Date::Create(2026, 1, 15, 12, 0, 0, 'America/New_York'));
+
         $page = $this->createMock('INewReservationPage');
         $binder = $this->createMock('IReservationComponentBinder');
 


### PR DESCRIPTION
Tests were failing as the range they were using was crossing a Daylight Savings Time (DST) boundary. Switch those tests to use a fixed date/time.