### PR TITLE
fix: show the Custom Attribute label name when deleting

### DIFF
--- a/Web/scripts/admin/attributes.js
+++ b/Web/scripts/admin/attributes.js
@@ -21,6 +21,7 @@ function AttributeManagement(opts) {
         addDialog: $('#addAttributeDialog'),
         editDialog: $('#editAttributeDialog'),
         deleteDialog: $('#deleteDialog'),
+        deleteAttributeLabel: $('#deleteAttributeLabel'),
 
         addForm: $('#addAttributeForm'),
         form: $('#editAttributeForm'),
@@ -301,6 +302,11 @@ function AttributeManagement(opts) {
     };
 
     var showDeleteDialog = function (selectedAttributeId) {
+        var dataList = elements.attributeList.data('list');
+        var selectedAttribute = dataList[selectedAttributeId];
+
+        elements.deleteAttributeLabel.text(HtmlDecode(selectedAttribute?.label ?? ''));
+
         setActiveId(selectedAttributeId);
         elements.deleteDialog.modal('show');
     };

--- a/tpl/Admin/Attributes/manage_attributes.tpl
+++ b/tpl/Admin/Attributes/manage_attributes.tpl
@@ -278,7 +278,8 @@
 					</div>
 					<div class="modal-body">
 						<div class="alert alert-danger">
-							{translate key=DeleteWarning}
+							{translate key=DeleteWarning}<br>
+							<strong>{translate key=DisplayLabel}: <span id="deleteAttributeLabel"></span></strong>
 						</div>
 					</div>
 					<div class="modal-footer">


### PR DESCRIPTION
When deleting a Custom Attribute show the label name in the confirmation box.

Closes: #1100