### PR TITLE
fix(time): make Time parsing/formatting DST-safe for time-only values

### DIFF
--- a/lib/Common/Time.php
+++ b/lib/Common/Time.php
@@ -2,6 +2,15 @@
 
 class Time
 {
+    // A date that is not a Daylight Savings Time transition day
+    private const ANCHOR_YEAR = 2000;
+    private const ANCHOR_MONTH = 1;
+    private const ANCHOR_DAY = 1;
+    private const FORMATS_24H_WITH_SECONDS = ['!Y-m-d H:i:s', '!Y-m-d G:i:s'];
+    private const FORMATS_24H_NO_SECONDS = ['!Y-m-d H:i', '!Y-m-d G:i'];
+    private const FORMATS_12H_WITH_SECONDS = ['!Y-m-d h:i:s A', '!Y-m-d h:i:s a', '!Y-m-d g:i:s A', '!Y-m-d g:i:s a'];
+    private const FORMATS_12H_NO_SECONDS = ['!Y-m-d h:i A', '!Y-m-d h:i a', '!Y-m-d g:i A', '!Y-m-d g:i a'];
+
     private $_hour;
     private $_minute;
     private $_second;
@@ -23,8 +32,17 @@ class Time
 
     private function GetDate()
     {
-        $parts = getdate(strtotime("$this->_hour:$this->_minute:$this->_second"));
-        return new Date("{$parts['year']}-{$parts['mon']}-{$parts['mday']} $this->_hour:$this->_minute:$this->_second", $this->_timezone);
+        // Use a fixed anchor date so time-only parsing/comparison is not affected
+        // by the current day crossing DST boundaries.
+        return Date::Create(
+            self::ANCHOR_YEAR,
+            self::ANCHOR_MONTH,
+            self::ANCHOR_DAY,
+            $this->_hour,
+            $this->_minute,
+            $this->_second,
+            $this->_timezone
+        );
     }
 
     /**
@@ -34,6 +52,43 @@ class Time
      */
     public static function Parse($time, $timezone = null)
     {
+        if (empty($timezone)) {
+            $timezone = date_default_timezone_get();
+        }
+        $dateTimeZone = new DateTimeZone($timezone);
+        $time = trim((string)$time);
+
+        $hasMeridiem = preg_match('/[[:space:]]*[ap]m$/i', $time) === 1;
+        $hasSeconds = substr_count($time, ':') >= 2;
+
+        if ($hasMeridiem) {
+            $formats = $hasSeconds ? self::FORMATS_12H_WITH_SECONDS : self::FORMATS_12H_NO_SECONDS;
+        } else {
+            $formats = $hasSeconds ? self::FORMATS_24H_WITH_SECONDS : self::FORMATS_24H_NO_SECONDS;
+        }
+        static $anchorDatePrefix = null;
+        $anchorDatePrefix ??= sprintf('%04d-%02d-%02d ', self::ANCHOR_YEAR, self::ANCHOR_MONTH, self::ANCHOR_DAY);
+        $anchoredInput = $anchorDatePrefix . $time;
+
+        foreach ($formats as $format) {
+            $date = DateTime::createFromFormat(
+                $format,
+                $anchoredInput,
+                $dateTimeZone
+            );
+            $errors = DateTime::getLastErrors();
+            $hasErrors = is_array($errors) && (($errors['warning_count'] ?? 0) > 0 || ($errors['error_count'] ?? 0) > 0);
+
+            if ($date !== false && !$hasErrors) {
+                return new Time(
+                    intval($date->format('H')),
+                    intval($date->format('i')),
+                    intval($date->format('s')),
+                    $timezone
+                );
+            }
+        }
+
         $date = new Date($time, $timezone);
 
         return new Time($date->Hour(), $date->Minute(), $date->Second(), $timezone);

--- a/tests/Infrastructure/Common/DateTest.php
+++ b/tests/Infrastructure/Common/DateTest.php
@@ -271,6 +271,26 @@ class DateTest extends TestBase
         $this->assertEquals(-1, $early2->Compare($late2, $date));
     }
 
+    public function testTimeParsingDoesNotShiftAroundDstGapTimes()
+    {
+        $central = Time::Parse('02:00', 'America/Chicago');
+        $eastern = Time::Parse('02:30', 'America/New_York');
+
+        $this->assertEquals('02:00:00', $central->ToString());
+        $this->assertEquals('02:00:00', $central->Format('H:i:s'));
+
+        $this->assertEquals('02:30:00', $eastern->ToString());
+        $this->assertEquals('02:30:00', $eastern->Format('H:i:s'));
+    }
+
+    public function testTimeParsingWithEmptyTimezoneFallsBackToServerTimezone()
+    {
+        $time = Time::Parse('10:11', '');
+
+        $this->assertEquals(date_default_timezone_get(), $time->Timezone());
+        $this->assertEquals('10:11:00', $time->ToString());
+    }
+
     public function testCanCompareDateOnlyEquality()
     {
         $date1 = Date::Parse('2008-01-01 11:00:00', 'America/Chicago');


### PR DESCRIPTION
`Time::Parse()` and internal `Time` formatting/comparison logic were implicitly tied to the current calendar date. On DST transition days, nonexistent local times like `02:00` could normalize to `03:00`, causing schedule period boundaries and related tests to shift by one hour.

This change makes `Time` deterministic as a time-of-day value object:

- Parse time strings against a fixed anchor date (`2000-01-01`) with explicit supported formats
- Keep a fallback to legacy parsing for unexpected inputs
- Use a fixed anchor date internally for `Time::Format()` / comparison support, instead of deriving date parts from "today"