### PR TITLE
oauth2 add trailing slash variable

### DIFF
--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -386,11 +386,9 @@ class LoginPresenter
     {
         // Retrieve Oauth2 configuration values
         $trailingSlash = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_TRAILING_SLASH);
-        if (!$trailingSlash){
-            $baseUrl = rtrim(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_URL_AUTHORIZE), '/');
-        }
-        else {
-            $baseUrl = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_URL_AUTHORIZE);
+        $baseUrl = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_URL_AUTHORIZE);
+        if (!$trailingSlash) {
+            $baseUrl = rtrim($baseUrl, '/');
         }
         $clientId = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_CLIENT_ID);
         $redirectUri = $this->buildRedirectUri(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_REDIRECT_URI));

--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -385,7 +385,13 @@ class LoginPresenter
     public function GetOauth2Url()
     {
         // Retrieve Oauth2 configuration values
-        $baseUrl = rtrim(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_URL_AUTHORIZE), '/');
+        $trailingSlash = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_TRAILING_SLASH);
+        if (!$trailingSlash){
+            $baseUrl = rtrim(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_URL_AUTHORIZE), '/');
+        }
+        else {
+            $baseUrl = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_URL_AUTHORIZE);
+        }
         $clientId = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_CLIENT_ID);
         $redirectUri = $this->buildRedirectUri(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_REDIRECT_URI));
 

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -705,6 +705,7 @@ return [
             'oauth2.name' => 'OAuth2',
 
             # OAuth2 endpoint URLs and client credentials
+            'oauth2.trailing.slash' => false,
             'oauth2.url.authorize' => '',
             'oauth2.url.token' => '',
             'oauth2.url.userinfo' => '',

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -705,6 +705,7 @@ return [
             'oauth2.name' => 'OAuth2',
 
             # OAuth2 endpoint URLs and client credentials
+            # If true, keep the configured authorize URL's trailing slash; if false, trim it with rtrim()
             'oauth2.trailing.slash' => false,
             'oauth2.url.authorize' => '',
             'oauth2.url.token' => '',

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1495,8 +1495,8 @@ class ConfigKeys
         'key' => 'authentication.oauth2.trailing.slash',
         'type' => 'boolean',
         'default' => false,
-        'label' => 'Enable Trailing Slash',
-        'description' => 'Enable Trailing Slash for OAuth2 URL',
+        'label' => 'Preserve authorize URL trailing slash',
+        'description' => 'When enabled, preserves any trailing slash on the OAuth2 authorize URL; when disabled, removes a trailing slash if present. Does not affect token or userinfo URLs.',
         'section' => 'authentication'
     ];
     public const AUTHENTICATION_OAUTH2_URL_AUTHORIZE = [

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1491,6 +1491,14 @@ class ConfigKeys
         'description' => 'Display name for OAuth2 login',
         'section' => 'authentication'
     ];
+    public const AUTHENTICATION_OAUTH2_TRAILING_SLASH = [
+        'key' => 'authentication.oauth2.trailing.slash',
+        'type' => 'boolean',
+        'default' => false,
+        'label' => 'Enable Trailing Slash',
+        'description' => 'Enable Trailing Slash for OAuth2 URL',
+        'section' => 'authentication'
+    ];
     public const AUTHENTICATION_OAUTH2_URL_AUTHORIZE = [
         'key' => 'authentication.oauth2.url.authorize',
         'type' => 'string',


### PR DESCRIPTION
Some OAuth2 provider need a trailing slash in the authorization URL. This changes let you choose if you want to cut or keep the trailing slash in oauth2 authorize URL.