### PR TITLE
fix(view-reservation): Correctly display the duration of the reservation

### DIFF
--- a/tpl/Reservation/view.tpl
+++ b/tpl/Reservation/view.tpl
@@ -40,8 +40,7 @@
                     <div class="row">
                         <div class="col-md-6 no-padding-left">
                             <label class="fw-bold">{translate key='BeginDate'}</label> {formatdate date=$StartDate}
-                            <input type="hidden" id="formattedBeginDate"
-                                value="{formatdate date=$StartDate key=system}" />
+                            <input type="hidden" id="BeginDate" value="{formatdate date=$StartDate key=system}" />
                             {foreach from=$StartPeriods item=period}
                                 {if $period eq $SelectedStart}
                                     {$period->Label()}
@@ -51,7 +50,7 @@
                         </div>
                         <div class="col-md-6 no-padding-left">
                             <label class="fw-bold">{translate key='EndDate'}</label> {formatdate date=$EndDate}
-                            <input type="hidden" id="formattedEndDate" value="{formatdate date=$EndDate key=system}" />
+                            <input type="hidden" id="EndDate" value="{formatdate date=$EndDate key=system}" />
                             {foreach from=$EndPeriods item=period}
                                 {if $period eq $SelectedEnd}
                                     {$period->LabelEnd()}
@@ -62,7 +61,7 @@
                     </div>
 
                     <div class="col-12">
-                        {*<span class="like-label class="fw-bold"">{translate key=ReservationLength}</span>*}
+                        <span class="fw-bold">{translate key=ReservationLength}</span>
                         <span class="durationText">
                             <span id="durationDays">0</span> {translate key=days}
                             <span id="durationHours">0</span> {translate key=hours}


### PR DESCRIPTION

<img width="385" height="133" alt="image" src="https://github.com/user-attachments/assets/ef71d945-6157-415c-ab9f-9efd0b9bf28f" />

Change hidden entry IDs for start/end dates from formattedBeginDate/formattedEndDate to BeginDate/EndDate (values ​​still use {formatdate... key=system}). The span for the display ReservationLength tag is uncommented and corrected. No other logic changed.