### PR TITLE
style(blackouts): Stylize the presentation of Blackouts and reservations when there are conflicts

### DIFF
--- a/Web/scripts/admin/blackouts.js
+++ b/Web/scripts/admin/blackouts.js
@@ -201,14 +201,13 @@ function BlackoutManagement(opts) {
 		$('#result').show();
 
 		$("#reservationTable").find('.editable').each(function () {
-			var refNum = $(this).find('.referenceNumber').text();
+			var refNum = $(this).attr('data-refnum');
 			$(this).attachReservationPopup(refNum, options.popupUrl);
 		});
 
 		$("#reservationTable").on('click', '.editable', function () {
 			$(this).addClass('clicked');
-			var td = $(this).find('.referenceNumber');
-			viewReservation(td.text());
+			viewReservation($(this).attr('data-refnum'));
 		});
 	}
 

--- a/tpl/Admin/Blackouts/manage_blackouts.tpl
+++ b/tpl/Admin/Blackouts/manage_blackouts.tpl
@@ -365,7 +365,7 @@
 
 	<div id="wait-box" class="modal fade" aria-labelledby="update-boxLabel" data-bs-backdrop="static"
 		aria-hidden="true">
-		<div class="modal-dialog modal-xl modal-dialog-centered">
+		<div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
 			<div class="modal-content">
 				<div class="modal-body">
 					<div id="creatingNotification">
@@ -379,7 +379,7 @@
 
 	<div class="modal fade" id="update-box" tabindex="-1" aria-labelledby="update-boxLabel" data-bs-backdrop="static"
 		aria-hidden="true">
-		<div class="modal-dialog modal-xl modal-dialog-centered">
+		<div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
 			<div class="modal-content">
 				<div class="modal-body">
 					{indicator id="update-spinner"}

--- a/tpl/Admin/Blackouts/manage_blackouts_response.tpl
+++ b/tpl/Admin/Blackouts/manage_blackouts_response.tpl
@@ -8,39 +8,63 @@
 	{/if}
 
 	{if !empty($Message)}
-		<h5>{$Message}</h5>
+		<h5>{$Message|escape:'html'}</h5>
 	{/if}
 
 	{if !empty($Blackouts)}
-		<h5>{translate key=BlackoutConflicts}</h5>
-		{foreach from=$Blackouts item=blackout}
-			{format_date date=$blackout->StartDate timezone=$Timezone}
-		{/foreach}
+		<h5 class="mt-2">{translate key=BlackoutConflicts}</h5>
+		<div class="table-responsive">
+			<table class="table" id="blackoutConflictsTable">
+				<thead>
+					<tr>
+						<th>{translate key='Title'}</th>
+						<th>{translate key='BeginDate'}</th>
+						<th>{translate key='EndDate'}</th>
+					</tr>
+				</thead>
+				<tbody>
+					{foreach from=$Blackouts item=blackout}
+						<tr>
+							<td>{if !empty($blackout->Title)}{$blackout->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}
+							</td>
+							<td>{formatdate date=$blackout->StartDate timezone=$Timezone key=res_popup}</td>
+							<td>{formatdate date=$blackout->EndDate timezone=$Timezone key=res_popup}</td>
+						</tr>
+					{/foreach}
+				</tbody>
+			</table>
+		</div>
 	{/if}
 
 	{if !empty($Reservations)}
-		<h5>{translate key=ReservationConflicts}</h5>
-		<table class="table" id="reservationTable" style="margin-left: auto; margin-right: auto;">
-			<thead>
-				<tr data-reservation-id="{$reservation->ReservationId}">
-					<th>{translate key='User'}</th>
-					<th>{translate key='Resource'}</th>
-					<th>{translate key='BeginDate'}</th>
-					<th>{translate key='EndDate'}</th>
-					<th>{translate key='ReferenceNumber'}</th>
-				</tr>
-			</thead>
-			<tbody>
-				{foreach from=$Reservations item=reservation}
-					<tr class="editable" data-reservation-id="{$reservation->ReferenceNumber}">
-						<td>{$reservation->FirstName} {$reservation->LastName}</td>
-						<td>{$reservation->ResourceName}</td>
-						<td>{formatdate date=$reservation->StartDate timezone=$Timezone key=res_popup}</td>
-						<td>{formatdate date=$reservation->EndDate timezone=$Timezone key=res_popup}</td>
-						<td class="referenceNumber">{$reservation->ReferenceNumber}</td>
+		<h5 class="mt-2">{translate key=ReservationConflicts}</h5>
+		<div class="table-responsive">
+			<table class="table" id="reservationTable">
+				<thead>
+					<tr>
+						<th>{translate key='User'}</th>
+						<th>{translate key='Title'}</th>
+						<th>{translate key='Resource'}</th>
+						<th>{translate key='BeginDate'}</th>
+						<th>{translate key='EndDate'}</th>
+						<th>{translate key='ReferenceNumber'}</th>
 					</tr>
-				{/foreach}
-			</tbody>
-		</table>
+				</thead>
+				<tbody>
+					{foreach from=$Reservations item=reservation}
+						<tr class="editable" data-refnum="{$reservation->ReferenceNumber|escape:'html'}">
+							<td>{$reservation->FirstName|escape:'html'} {$reservation->LastName|escape:'html'}</td>
+							<td class="reservationTitle">
+								{if !empty($reservation->Title)}{$reservation->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}
+							</td>
+							<td>{$reservation->ResourceName|escape:'html'}</td>
+							<td>{formatdate date=$reservation->StartDate timezone=$Timezone key=res_popup}</td>
+							<td>{formatdate date=$reservation->EndDate timezone=$Timezone key=res_popup}</td>
+							<td class="referenceNumber">{$reservation->ReferenceNumber|escape:'html'}</td>
+						</tr>
+					{/foreach}
+				</tbody>
+			</table>
+		</div>
 	{/if}
 </div>


### PR DESCRIPTION
This update styles conflicting blackout entries in the UI for better visibility.

Before:
<img width="431" height="155" alt="Captura de pantalla 2026-03-11 091818" src="https://github.com/user-attachments/assets/aaacf869-a111-4cb8-80d1-50cf511e9c8e" />
After:
<img width="1024" height="683" alt="Captura de pantalla 2026-03-11 092953" src="https://github.com/user-attachments/assets/075efa47-db9e-4788-989e-0876fc759a63" />
