### PR TITLE
feat(api): Add scheduleId filter to GET Resources endpoint

### DIFF
--- a/WebServices/ResourcesWebService.php
+++ b/WebServices/ResourcesWebService.php
@@ -51,12 +51,40 @@ class ResourcesWebService
     /**
      * @name GetAllResources
      * @description Loads all resources
+     * Optional query string parameter: scheduleId. One or more schedule IDs, comma-separated (e.g. scheduleId=1,2,3). If provided, only resources belonging to those schedules will be returned. Each value must be a positive integer (greater than zero); if any value is non-integer or zero, a 400 Bad Request is returned.
      * @response ResourcesResponse
      * @return void
      */
     public function GetAll()
     {
+        $scheduleIds = null;
+        $scheduleIdParam = $this->server->GetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID);
+        if ($scheduleIdParam !== null && $scheduleIdParam !== '') {
+            $rawIds = explode(',', $scheduleIdParam);
+            foreach ($rawIds as $id) {
+                if (!ctype_digit($id) || (int)$id === 0) {
+                    $this->server->WriteResponse(
+                        RestResponse::BadRequest("Invalid scheduleId '$id': must be a positive integer"),
+                        RestResponse::BAD_REQUEST_CODE
+                    );
+                    return;
+                }
+            }
+            $scheduleIds = array_map('intval', $rawIds);
+        }
+
         $resources = $this->resourceRepository->GetUserResourceList();
+
+        if ($scheduleIds !== null) {
+            $filteredResources = [];
+            foreach ($resources as $resource) {
+                if (in_array($resource->GetScheduleId(), $scheduleIds)) {
+                    $filteredResources[] = $resource;
+                }
+            }
+            $resources = $filteredResources;
+        }
+
         $resourceIds = [];
         foreach ($resources as $resource) {
             $resourceIds[] = $resource->GetId();

--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -42,6 +42,26 @@ For all of the secure service calls it is required to be
    2. ``X-Booked-UserId`` set to the value of ``userId`` returned by the
       `Authenticate <#authenticate>`__ API call.
 
+GET Requests / Query String Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some GET endpoints support optional query string parameters for
+filtering results. To pass a query string parameter, append ``?`` to
+the URL followed by ``key=value``. Multiple parameters can be combined
+using ``&``.
+
+For example, to filter resources by schedule::
+
+    /Web/Services/index.php/Resources/?scheduleId=1
+
+Some parameters accept comma-separated values to match multiple options::
+
+    /Web/Services/index.php/Resources/?scheduleId=1,2,3
+
+To combine multiple parameters::
+
+    /Web/Services/index.php/Reservations/?scheduleId=1&userId=5
+
 POST Requests
 ~~~~~~~~~~~~~
 
@@ -1671,6 +1691,12 @@ GetAllResources
 **Description:**
 
 Loads all resources
+
+Optional query string parameter: ``scheduleId``. One or more schedule IDs,
+comma-separated (e.g. ``scheduleId=1,2,3``). If provided, only resources
+belonging to those schedules will be returned. Each value must be a positive
+integer (greater than zero); if any value is non-integer or zero, a ``400 Bad
+Request`` is returned.
 
 **Route:** ``/Web/Services/index.php/Resources/``
 

--- a/lib/WebService/RestResponse.php
+++ b/lib/WebService/RestResponse.php
@@ -61,4 +61,11 @@ class RestResponse
         $response->message = 'You do not have access to the requested resource';
         return $response;
     }
+
+    public static function BadRequest(string $message)
+    {
+        $response = new RestResponse();
+        $response->message = $message;
+        return $response;
+    }
 }

--- a/tests/WebServices/ResourcesWebServiceTest.php
+++ b/tests/WebServices/ResourcesWebServiceTest.php
@@ -107,6 +107,129 @@ class ResourcesWebServiceTest extends TestBase
         );
     }
 
+    public function testFiltersResourceListByScheduleId()
+    {
+        $scheduleId = 5;
+        $matchingResourceId = 123;
+        $otherResourceId = 456;
+
+        $matchingResource = new FakeBookableResource($matchingResourceId);
+        $matchingResource->SetScheduleId($scheduleId);
+
+        $otherResource = new FakeBookableResource($otherResourceId);
+        $otherResource->SetScheduleId(99);
+
+        $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, $scheduleId);
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceList')
+                         ->willReturn([$matchingResource, $otherResource]);
+
+        $attributes = new AttributeList();
+        $this->attributeService->expects($this->once())
+                               ->method('GetAttributes')
+                               ->with(
+                                   $this->equalTo(CustomAttributeCategory::RESOURCE),
+                                   $this->equalTo([$matchingResourceId])
+                               )
+                               ->willReturn($attributes);
+
+        $this->service->GetAll();
+
+        $this->assertEquals(
+            new ResourcesResponse($this->server, [$matchingResource], $attributes),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testFiltersResourceListByMultipleScheduleIds()
+    {
+        $scheduleId1 = 5;
+        $scheduleId2 = 7;
+        $resourceId1 = 123;
+        $resourceId2 = 456;
+        $otherResourceId = 789;
+
+        $resource1 = new FakeBookableResource($resourceId1);
+        $resource1->SetScheduleId($scheduleId1);
+
+        $resource2 = new FakeBookableResource($resourceId2);
+        $resource2->SetScheduleId($scheduleId2);
+
+        $otherResource = new FakeBookableResource($otherResourceId);
+        $otherResource->SetScheduleId(99);
+
+        $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, "$scheduleId1,$scheduleId2");
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceList')
+                         ->willReturn([$resource1, $resource2, $otherResource]);
+
+        $attributes = new AttributeList();
+        $this->attributeService->expects($this->once())
+                               ->method('GetAttributes')
+                               ->with(
+                                   $this->equalTo(CustomAttributeCategory::RESOURCE),
+                                   $this->equalTo([$resourceId1, $resourceId2])
+                               )
+                               ->willReturn($attributes);
+
+        $this->service->GetAll();
+
+        $this->assertEquals(
+            new ResourcesResponse($this->server, [$resource1, $resource2], $attributes),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testReturns400ForNonIntegerScheduleId()
+    {
+        $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, '1,abc,2');
+
+        $this->repository->expects($this->never())
+                         ->method('GetUserResourceList');
+
+        $this->service->GetAll();
+
+        $this->assertEquals(RestResponse::BAD_REQUEST_CODE, $this->server->_LastResponseCode);
+        $this->assertEquals(
+            RestResponse::BadRequest("Invalid scheduleId 'abc': must be a positive integer"),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testReturns400ForZeroScheduleId()
+    {
+        $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, '1,0,2');
+
+        $this->repository->expects($this->never())
+                         ->method('GetUserResourceList');
+
+        $this->service->GetAll();
+
+        $this->assertEquals(RestResponse::BAD_REQUEST_CODE, $this->server->_LastResponseCode);
+        $this->assertEquals(
+            RestResponse::BadRequest("Invalid scheduleId '0': must be a positive integer"),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testReturns400ForZeroScheduleIdAlone()
+    {
+        $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, '0');
+
+        $this->repository->expects($this->never())
+                         ->method('GetUserResourceList');
+
+        $this->service->GetAll();
+
+        $this->assertEquals(RestResponse::BAD_REQUEST_CODE, $this->server->_LastResponseCode);
+        $this->assertEquals(
+            RestResponse::BadRequest("Invalid scheduleId '0': must be a positive integer"),
+            $this->server->_LastResponse
+        );
+    }
+
     public function testGetsStatuses()
     {
         $this->service->GetStatuses();


### PR DESCRIPTION
Add optional scheduleId query string parameter to GET /Resources/. Accepts one or more comma-separated positive integer IDs (e.g. ?scheduleId=1,2,3). Returns 400 Bad Request if any value is non-integer or zero.

Also adds RestResponse::BadRequest() factory method and updates API documentation in both the inline @description and docs/source/API.rst, including a new "GET Requests / Query String Parameters" section in the Getting Started guide.