### PR TITLE
fix(reports): prevent chart modal from hanging on render errors

### DIFF
--- a/Web/scripts/reports/chart.js
+++ b/Web/scripts/reports/chart.js
@@ -38,7 +38,7 @@ function Chart(options) {
 			series = new DateSeries(options);
 		}
 
-		$('#report-results>tbody>tr').not(':first').each(function () {
+		$('#report-results>tbody>tr').each(function () {
 			series.Add($(this));
 		});
 

--- a/Web/scripts/reports/common.js
+++ b/Web/scripts/reports/common.js
@@ -7,12 +7,15 @@ function ReportsCommon(opts) {
 
                 // Use a small delay to ensure the modal is displayed sooner
                 setTimeout(function () {
-                    var chart = new Chart(opts.chartOpts);
-                    chart.generate();
-
-                    $('#report-results').hide();
-                    $('#approveDiv').modal('hide');
-
+                    try {
+                        var chart = new Chart(opts.chartOpts);
+                        chart.generate();
+                        $('#report-results').hide();
+                    } catch (error) {
+                        console.error('Unable to generate report chart', error);
+                    } finally {
+                        $('#approveDiv').modal('hide');
+                    }
                 }, 500);
             });
             /*


### PR DESCRIPTION
Always close the report chart "Working" modal even when jqPlot throws during client-side chart generation. Also include the first report row when building chart data so single-row reports do not produce an empty dataset.

The first-row bug appears to be stale logic from the original 2012 chart
implementation, when the report table header lived in the first table
row. After the 2018 reports markup update introduced explicit
thead/tbody sections, that selector began dropping the first actual data
row instead.

Closes: #1133