### PR TITLE
fix(schedule): avoid recursive buffer item ids

### DIFF
--- a/lib/Application/Schedule/ReservationListItem.php
+++ b/lib/Application/Schedule/ReservationListItem.php
@@ -376,7 +376,7 @@ class BufferItem extends ReservationListItem
 
     public function Id()
     {
-        return $this->Id() . 'buffer_' . $this->location;
+        return $this->reservationItem->Id() . 'buffer_' . $this->location;
     }
 
     public function IsReservation()

--- a/tests/Application/Schedule/ReservationListingTest.php
+++ b/tests/Application/Schedule/ReservationListingTest.php
@@ -150,6 +150,19 @@ class ReservationListingTest extends TestBase
         $this->assertEquals($expectedSlot, $actualSlot);
     }
 
+    public function testBufferItemIdUsesWrappedReservationId()
+    {
+        $view = new TestReservationItemView(42, Date::Parse('2011-11-22 04:34'), Date::Parse('2011-11-23 14:43'), 123);
+        $view->WithBufferTime(3600);
+        $item = new ReservationListItem($view);
+
+        $beforeBuffer = new BufferItem($item, BufferItem::LOCATION_BEFORE);
+        $afterBuffer = new BufferItem($item, BufferItem::LOCATION_AFTER);
+
+        $this->assertEquals('42buffer_begin', $beforeBuffer->Id());
+        $this->assertEquals('42buffer_end', $afterBuffer->Id());
+    }
+
     /**
      * @param $startDateString
      * @param $endDateString


### PR DESCRIPTION
Use the wrapped reservation item's id when building BufferItem ids instead of recursively calling BufferItem::Id().

Closes: #1008