### PR TITLE
feat(config): support custom footer version override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Customized Configuration Files
 /config/config.php
 /config/log4php.config.xml
+/config/custom-version.txt
 /config/version-suffix.txt
 **/*.config.php
 

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -60,8 +60,14 @@ sensitive data separate from configuration files.
   See ``develop/app/.env.example`` for a comprehensive list of all available
   environment variables with their default values and descriptions.
 
+Custom Footer Version Display
+-----------------------------
+
+LibreBooking can customize the version shown in the page footer using either a
+suffix or a custom version override.
+
 Version Suffix
---------------
+~~~~~~~~~~~~~~
 
 LibreBooking can optionally append a suffix to the version shown in the page
 footer.
@@ -93,6 +99,37 @@ LibreBooking ignores the suffix and logs an error.
 This writes the current short Git commit SHA into
 ``<INSTALL_DIR>/config/version-suffix.txt`` so the footer displays a version
 such as ``v4.1.0-a1b2c3d``.
+
+Custom Version
+~~~~~~~~~~~~~~
+
+LibreBooking can optionally replace the footer base version with a custom
+value.
+
+Create ``<INSTALL_DIR>/config/custom-version.txt`` with a value such as
+``v4.2.0-36-ge81f46586``. This file is intended for local or deployment-time
+metadata and should not be committed to source control. If the file is present
+and contains a valid non-empty value, the footer version will be displayed as
+``v4.2.0-36-ge81f46586 (custom)``.
+
+The usual value in this file would be the output of
+``git describe --tags --long``. If ``custom-version.txt`` contains a valid
+value, it takes precedence over ``version-suffix.txt`` and LibreBooking logs
+an error if ``version-suffix.txt`` also exists.
+
+The file must contain a single line only. A trailing newline is allowed, but
+if the file contains additional lines, LibreBooking ignores the custom
+version. After trimming, the custom version must be 40 characters or fewer.
+
+Valid characters are letters, numbers, ``.``, ``_``, and ``-``. If the file
+contains multiple lines, exceeds 40 characters, or includes invalid characters,
+LibreBooking ignores the custom version and logs an error.
+
+**Example**
+
+  .. code-block:: bash
+
+     git describe --tags --long > config/custom-version.txt
 
 Application Advanced Settings
 -----------------------------

--- a/lib/Common/VersionDisplayResolver.php
+++ b/lib/Common/VersionDisplayResolver.php
@@ -2,54 +2,83 @@
 
 class VersionDisplayResolver
 {
-    private const MAX_VERSION_SUFFIX_LENGTH = 40;
+    private const MAX_VERSION_METADATA_LENGTH = 40;
 
+    private string $customVersionFile;
     private string $versionSuffixFile;
 
-    public function __construct(?string $versionSuffixFile = null)
+    public function __construct(?string $versionSuffixFile = null, ?string $customVersionFile = null)
     {
+        $this->customVersionFile = $customVersionFile ?? ROOT_DIR . 'config/custom-version.txt';
         $this->versionSuffixFile = $versionSuffixFile ?? ROOT_DIR . 'config/version-suffix.txt';
     }
 
     public function GetDisplayVersion(string $baseVersion): string
     {
-        if (!is_file($this->versionSuffixFile) || !is_readable($this->versionSuffixFile)) {
-            return $baseVersion;
+        $customVersion = $this->GetValidatedValue($this->customVersionFile, 'custom version');
+        if ($customVersion !== null) {
+            if (is_file($this->versionSuffixFile)) {
+                Log::Error(
+                    'Ignoring version suffix in %s because custom version in %s takes precedence',
+                    $this->versionSuffixFile,
+                    $this->customVersionFile
+                );
+            }
+
+            return $customVersion . ' (custom)';
         }
 
-        $versionSuffixContents = file_get_contents($this->versionSuffixFile);
-        if ($versionSuffixContents === false) {
-            return $baseVersion;
+        $displayBaseVersion = 'v' . $baseVersion;
+        $versionSuffix = $this->GetValidatedValue($this->versionSuffixFile, 'version suffix');
+        if ($versionSuffix === null) {
+            return $displayBaseVersion;
         }
 
-        $versionSuffixContents = rtrim($versionSuffixContents, "\r\n");
-        if (preg_match('/\R/', $versionSuffixContents) === 1) {
-            Log::Error('Ignoring version suffix in %s because it contains more than one line', $this->versionSuffixFile);
-            return $baseVersion;
+        return $displayBaseVersion . '-' . $versionSuffix;
+    }
+
+    private function GetValidatedValue(string $filePath, string $label): ?string
+    {
+        if (!is_file($filePath) || !is_readable($filePath)) {
+            return null;
         }
 
-        $versionSuffix = trim($versionSuffixContents);
-        if (empty($versionSuffix)) {
-            return $baseVersion;
+        $contents = file_get_contents($filePath);
+        if ($contents === false) {
+            return null;
         }
 
-        if (strlen($versionSuffix) > self::MAX_VERSION_SUFFIX_LENGTH) {
+        $contents = rtrim($contents, "\r\n");
+        if (preg_match('/\R/', $contents) === 1) {
+            Log::Error('Ignoring %s in %s because it contains more than one line', $label, $filePath);
+            return null;
+        }
+
+        $value = trim($contents);
+        if (empty($value)) {
+            Log::Error('Ignoring %s in %s because it is empty', $label, $filePath);
+            return null;
+        }
+
+        if (strlen($value) > self::MAX_VERSION_METADATA_LENGTH) {
             Log::Error(
-                'Ignoring version suffix in %s because it exceeds %d characters',
-                $this->versionSuffixFile,
-                self::MAX_VERSION_SUFFIX_LENGTH
+                'Ignoring %s in %s because it exceeds %d characters',
+                $label,
+                $filePath,
+                self::MAX_VERSION_METADATA_LENGTH
             );
-            return $baseVersion;
+            return null;
         }
 
-        if (preg_match('/^[A-Za-z0-9._-]+$/', $versionSuffix) !== 1) {
+        if (preg_match('/^[A-Za-z0-9._-]+$/', $value) !== 1) {
             Log::Error(
-                'Ignoring version suffix in %s because it contains invalid characters. Allowed characters are letters, numbers, ".", "_", and "-"',
-                $this->versionSuffixFile
+                'Ignoring %s in %s because it contains invalid characters. Allowed characters are letters, numbers, ".", "_", and "-"',
+                $label,
+                $filePath
             );
-            return $baseVersion;
+            return null;
         }
 
-        return $baseVersion . '-' . $versionSuffix;
+        return $value;
     }
 }

--- a/tests/Infrastructure/Common/VersionDisplayResolverTest.php
+++ b/tests/Infrastructure/Common/VersionDisplayResolverTest.php
@@ -7,66 +7,132 @@ require_once(ROOT_DIR . 'lib/Common/namespace.php');
 class VersionDisplayResolverTest extends TestBase
 {
     private const BASE_VERSION = '4.1.0';
+    private const MISSING_SUFFIX_FILE = ROOT_DIR . 'tests/data/does-not-exist-version-suffix.txt';
+    private const MISSING_CUSTOM_VERSION_FILE = ROOT_DIR . 'tests/data/does-not-exist-custom-version.txt';
 
     private array $tempPaths = [];
 
     public function testReturnsBaseVersionWhenSuffixFileIsMissing()
     {
-        $resolver = new VersionDisplayResolver(ROOT_DIR . 'tests/data/does-not-exist-version-suffix.txt');
+        $resolver = new VersionDisplayResolver(self::MISSING_SUFFIX_FILE, self::MISSING_CUSTOM_VERSION_FILE);
 
         $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
 
-        $this->assertEquals(self::BASE_VERSION, $displayVersion);
+        $this->assertEquals('v4.1.0', $displayVersion);
     }
 
     public function testAppendsValidSuffix()
     {
-        $suffixFile = $this->createTempSuffixFile('abc123');
-        $resolver = new VersionDisplayResolver($suffixFile);
+        $suffixFile = $this->createTempMetadataFile('abc123');
+        $resolver = new VersionDisplayResolver($suffixFile, self::MISSING_CUSTOM_VERSION_FILE);
 
         $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
 
-        $this->assertEquals('4.1.0-abc123', $displayVersion);
+        $this->assertEquals('v4.1.0-abc123', $displayVersion);
     }
 
     public function testAllowsSingleTrailingNewline()
     {
-        $suffixFile = $this->createTempSuffixFile("abc123\n");
-        $resolver = new VersionDisplayResolver($suffixFile);
+        $suffixFile = $this->createTempMetadataFile("abc123\n");
+        $resolver = new VersionDisplayResolver($suffixFile, self::MISSING_CUSTOM_VERSION_FILE);
 
         $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
 
-        $this->assertEquals('4.1.0-abc123', $displayVersion);
+        $this->assertEquals('v4.1.0-abc123', $displayVersion);
     }
 
     public function testReturnsBaseVersionWhenSuffixHasMultipleLines()
     {
-        $suffixFile = $this->createTempSuffixFile("abc123\nsecond-line");
-        $resolver = new VersionDisplayResolver($suffixFile);
+        $suffixFile = $this->createTempMetadataFile("abc123\nsecond-line");
+        $resolver = new VersionDisplayResolver($suffixFile, self::MISSING_CUSTOM_VERSION_FILE);
 
         $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
 
-        $this->assertEquals(self::BASE_VERSION, $displayVersion);
+        $this->assertEquals('v4.1.0', $displayVersion);
     }
 
     public function testReturnsBaseVersionWhenSuffixExceedsFortyCharacters()
     {
-        $suffixFile = $this->createTempSuffixFile(str_repeat('a', 41));
-        $resolver = new VersionDisplayResolver($suffixFile);
+        $suffixFile = $this->createTempMetadataFile(str_repeat('a', 41));
+        $resolver = new VersionDisplayResolver($suffixFile, self::MISSING_CUSTOM_VERSION_FILE);
 
         $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
 
-        $this->assertEquals(self::BASE_VERSION, $displayVersion);
+        $this->assertEquals('v4.1.0', $displayVersion);
     }
 
     public function testReturnsBaseVersionWhenSuffixContainsInvalidCharacters()
     {
-        $suffixFile = $this->createTempSuffixFile('abc/123');
-        $resolver = new VersionDisplayResolver($suffixFile);
+        $suffixFile = $this->createTempMetadataFile('abc/123');
+        $resolver = new VersionDisplayResolver($suffixFile, self::MISSING_CUSTOM_VERSION_FILE);
 
         $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
 
-        $this->assertEquals(self::BASE_VERSION, $displayVersion);
+        $this->assertEquals('v4.1.0', $displayVersion);
+    }
+
+    public function testUsesCustomVersionWhenValid()
+    {
+        $customVersionFile = $this->createTempMetadataFile('v4.2.0-36-ge81f46586');
+        $resolver = new VersionDisplayResolver(self::MISSING_SUFFIX_FILE, $customVersionFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals('v4.2.0-36-ge81f46586 (custom)', $displayVersion);
+    }
+
+    public function testCustomVersionAllowsSingleTrailingNewline()
+    {
+        $customVersionFile = $this->createTempMetadataFile("v4.2.0-36-ge81f46586\n");
+        $resolver = new VersionDisplayResolver(self::MISSING_SUFFIX_FILE, $customVersionFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals('v4.2.0-36-ge81f46586 (custom)', $displayVersion);
+    }
+
+    public function testFallsBackToSuffixWhenCustomVersionHasMultipleLines()
+    {
+        $suffixFile = $this->createTempMetadataFile('abc123');
+        $customVersionFile = $this->createTempMetadataFile("v4.2.0-36-ge81f46586\nsecond-line");
+        $resolver = new VersionDisplayResolver($suffixFile, $customVersionFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals('v4.1.0-abc123', $displayVersion);
+    }
+
+    public function testFallsBackToSuffixWhenCustomVersionExceedsFortyCharacters()
+    {
+        $suffixFile = $this->createTempMetadataFile('abc123');
+        $customVersionFile = $this->createTempMetadataFile(str_repeat('a', 41));
+        $resolver = new VersionDisplayResolver($suffixFile, $customVersionFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals('v4.1.0-abc123', $displayVersion);
+    }
+
+    public function testFallsBackToSuffixWhenCustomVersionContainsInvalidCharacters()
+    {
+        $suffixFile = $this->createTempMetadataFile('abc123');
+        $customVersionFile = $this->createTempMetadataFile('release candidate');
+        $resolver = new VersionDisplayResolver($suffixFile, $customVersionFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals('v4.1.0-abc123', $displayVersion);
+    }
+
+    public function testCustomVersionOverridesSuffixWhenBothAreValid()
+    {
+        $suffixFile = $this->createTempMetadataFile('abc123');
+        $customVersionFile = $this->createTempMetadataFile('v4.2.0-36-ge81f46586');
+        $resolver = new VersionDisplayResolver($suffixFile, $customVersionFile);
+
+        $displayVersion = $resolver->GetDisplayVersion(self::BASE_VERSION);
+
+        $this->assertEquals('v4.2.0-36-ge81f46586 (custom)', $displayVersion);
     }
 
     public function tearDown(): void
@@ -82,11 +148,11 @@ class VersionDisplayResolverTest extends TestBase
         parent::tearDown();
     }
 
-    private function createTempSuffixFile(string $contents): string
+    private function createTempMetadataFile(string $contents): string
     {
-        $tempFile = tempnam(sys_get_temp_dir(), 'lb-version-suffix-');
+        $tempFile = tempnam(sys_get_temp_dir(), 'lb-version-meta-');
         if ($tempFile === false) {
-            throw new RuntimeException('Failed to create temporary version suffix file');
+            throw new RuntimeException('Failed to create temporary version metadata file');
         }
 
         file_put_contents($tempFile, $contents);

--- a/tpl/globalfooter.tpl
+++ b/tpl/globalfooter.tpl
@@ -4,8 +4,8 @@
 	</div>
 	<footer class="bg-light border-top text-center pt-2">
 		<div><a class="link-primary" href="{$CompanyUrl}">{$CompanyName}</a></div>
-		<div><a class="link-primary" href="https://github.com/LibreBooking/librebooking">LibreBooking - GPLv3
-				v{$DisplayVersion}</a></div>
+		<div><a class="link-primary" href="https://github.com/LibreBooking/librebooking">LibreBooking - GPLv3 -
+				{$DisplayVersion}</a></div>
 	</footer>
 
 	<script type="text/javascript">


### PR DESCRIPTION
Add support for config/custom-version.txt to override the footer display version.

When custom-version.txt contains a valid value, the footer shows that value formatted as <value> (custom). If config/version-suffix.txt also exists, it is ignored and an error is logged. Invalid custom version values also log an error, and the resolver falls back to the existing suffix behavior.

Also update the footer formatting to render LibreBooking - GPLv3 - <version>, add config/custom-version.txt to .gitignore, expand resolver tests, and document the new configuration including the 40-character maximum and typical git describe --tags --long usage.