### PR TITLE
fix(schedule): use correct StartDate field in reservation sort

### DIFF
--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -284,7 +284,7 @@ function Schedule(opts, resourceGroups) {
             reservationList.sort((r1, r2) => {
                 const resourceOrder = options.resourceOrder[r1.ResourceId] - options.resourceOrder[r2.ResourceId];
                 if (resourceOrder === 0) {
-                    return r1.StartDate - r2.startDate;
+                    return r1.StartDate - r2.StartDate;
                 }
 
                 return resourceOrder;


### PR DESCRIPTION
The schedule reservation sort in Web/scripts/schedule.js referenced r2.startDate instead of r2.StartDate.

The AJAX payload uses ReservationListItemDto field names, so the lowercase property is undefined and can destabilize same-resource reservation ordering in the client-side renderer. This change uses the correct StartDate property to keep sorting consistent.