### PR TITLE
fix(admin): prevent permission loss when DataTables paginates resources

### DIFF
--- a/Pages/Admin/ManageUsersPage.php
+++ b/Pages/Admin/ManageUsersPage.php
@@ -34,7 +34,7 @@ interface IManageUsersPage extends IPageable, IActionPage
     public function SetJsonResponse($objectToSerialize);
 
     /**
-     * @return int[] resource ids the user has permission to
+     * @return string[]|null resource ids with permission type (e.g. "1_0" for full, "2_1" for view)
      */
     public function GetAllowedResourceIds();
 
@@ -299,7 +299,7 @@ class ManageUsersPage extends ActionPage implements IManageUsersPage
     }
 
     /**
-     * @return int[] resource ids the user has permission to
+     * @return string[]|null resource ids with permission type (e.g. "1_0" for full, "2_1" for view)
      */
     public function GetAllowedResourceIds()
     {

--- a/Presenters/Admin/ManageGroupsPresenter.php
+++ b/Presenters/Admin/ManageGroupsPresenter.php
@@ -5,6 +5,7 @@ require_once(ROOT_DIR . 'Presenters/ActionPresenter.php');
 require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Admin/GroupImportCsv.php');
 require_once(ROOT_DIR . 'lib/Application/Admin/CsvImportResult.php');
+require_once(ROOT_DIR . 'lib/Application/Admin/ResourcePermissionService.php');
 require_once(ROOT_DIR . 'Pages/Admin/ManageGroupsPage.php');
 
 class ManageGroupsActions
@@ -48,6 +49,10 @@ class ManageGroupsPresenter extends ActionPresenter
      * @var IUserRepository
      */
     private $userRepository;
+    /**
+     * @var IResourcePermissionService
+     */
+    private $resourcePermissionService;
 
     /**
      * @param IManageGroupsPage $page
@@ -55,13 +60,15 @@ class ManageGroupsPresenter extends ActionPresenter
      * @param IResourceRepository $resourceRepository
      * @param IScheduleRepository $scheduleRepository
      * @param IUserRepository $userRepository
+     * @param IResourcePermissionService|null $resourcePermissionService
      */
     public function __construct(
         IManageGroupsPage $page,
         IGroupRepository&IGroupViewRepository $groupRepository,
         IResourceRepository $resourceRepository,
         IScheduleRepository $scheduleRepository,
-        IUserRepository $userRepository
+        IUserRepository $userRepository,
+        ?IResourcePermissionService $resourcePermissionService = null,
     ) {
         parent::__construct($page);
 
@@ -70,6 +77,7 @@ class ManageGroupsPresenter extends ActionPresenter
         $this->resourceRepository = $resourceRepository;
         $this->scheduleRepository = $scheduleRepository;
         $this->userRepository = $userRepository;
+        $this->resourcePermissionService = $resourcePermissionService ?? new ResourcePermissionService($resourceRepository);
 
         $this->AddAction(ManageGroupsActions::AddUser, 'AddUser');
         $this->AddAction(ManageGroupsActions::RemoveUser, 'RemoveUser');
@@ -124,31 +132,31 @@ class ManageGroupsPresenter extends ActionPresenter
 
     public function ChangePermissions()
     {
+        $currentUser = $this->userRepository->LoadById(ServiceLocator::GetServer()->GetUserSession()->UserId);
+        $managedResourceIds = $this->resourcePermissionService->GetResourceIdsThatUserCanAdminister($currentUser);
+
         $group = $this->groupRepository->LoadById($this->page->GetGroupId());
-        $resources = [];
-        $allowed = [];
-        $view = [];
 
-        if (is_array($this->page->GetAllowedResourceIds())) {
-            $resources = $this->page->GetAllowedResourceIds();
-        }
+        $permissionsByType = $this->resourcePermissionService->ParseSubmittedPermissions(
+            $this->page->GetAllowedResourceIds(),
+            $managedResourceIds,
+        );
 
-        foreach ($resources as $resource) {
-            $split = explode('_', $resource);
-            $resourceId = $split[0];
-            $permissionType = $split[1];
+        $group->ChangeAllowedPermissions(
+            $this->resourcePermissionService->MergeWithPreservedPermissions(
+                existingIds: $group->AllowedResourceIds(),
+                managedResourceIds: $managedResourceIds,
+                submittedIds: $permissionsByType['full'],
+            )
+        );
+        $group->ChangeViewPermissions(
+            $this->resourcePermissionService->MergeWithPreservedPermissions(
+                existingIds: $group->AllowedViewResourceIds(),
+                managedResourceIds: $managedResourceIds,
+                submittedIds: $permissionsByType['view'],
+            )
+        );
 
-            if ($permissionType === ResourcePermissionType::Full . '') {
-                $allowed[] = $resourceId;
-            } else {
-                if ($permissionType === ResourcePermissionType::View . '') {
-                    $view[] = $resourceId;
-                }
-            }
-        }
-
-        $group->ChangeViewPermissions($view);
-        $group->ChangeAllowedPermissions($allowed);
         $this->groupRepository->Update($group);
     }
 

--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -6,6 +6,7 @@ require_once(ROOT_DIR . 'lib/Application/Authentication/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/User/namespace.php');
 require_once(ROOT_DIR . 'lib/Application/Admin/UserImportCsv.php');
 require_once(ROOT_DIR . 'lib/Application/Admin/CsvImportResult.php');
+require_once(ROOT_DIR . 'lib/Application/Admin/ResourcePermissionService.php');
 require_once(ROOT_DIR . 'lib/Email/Messages/InviteUserEmail.php');
 require_once(ROOT_DIR . 'lib/Email/Messages/AccountCreationForUserEmail.php');
 
@@ -76,6 +77,11 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
     private $groupViewRepository;
 
     /**
+     * @var IResourcePermissionService
+     */
+    private $resourcePermissionService;
+
+    /**
      * @param IGroupRepository $groupRepository
      */
     public function SetGroupRepository($groupRepository)
@@ -132,6 +138,7 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
      * @param IAttributeService $attributeService
      * @param IGroupRepository $groupRepository
      * @param IGroupViewRepository $groupViewRepository
+     * @param IResourcePermissionService|null $resourcePermissionService
      */
     public function __construct(
         IManageUsersPage $page,
@@ -141,7 +148,8 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
         IManageUsersService $manageUsersService,
         IAttributeService $attributeService,
         IGroupRepository $groupRepository,
-        IGroupViewRepository $groupViewRepository
+        IGroupViewRepository $groupViewRepository,
+        ?IResourcePermissionService $resourcePermissionService = null,
     ) {
         parent::__construct($page);
 
@@ -153,6 +161,7 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
         $this->attributeService = $attributeService;
         $this->groupRepository = $groupRepository;
         $this->groupViewRepository = $groupViewRepository;
+        $this->resourcePermissionService = $resourcePermissionService ?? new ResourcePermissionService($resourceRepository);
 
         $this->AddAction(ManageUsersActions::Activate, 'Activate');
         $this->AddAction(ManageUsersActions::AddUser, 'AddUser');
@@ -298,42 +307,30 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
     public function ChangePermissions()
     {
         $currentUser = $this->userRepository->LoadById(ServiceLocator::GetServer()->GetUserSession()->UserId);
-        $resources = $this->GetResourcesThatCurrentUserCanAdminister($currentUser);
-
-        $acceptableResourceIds = [];
-
-        foreach ($resources as $resource) {
-            $acceptableResourceIds[] = $resource->GetId();
-        }
+        $managedResourceIds = $this->resourcePermissionService->GetResourceIdsThatUserCanAdminister($currentUser);
 
         $user = $this->userRepository->LoadById($this->page->GetUserId());
-        $allowedResources = [];
 
-        if (is_array($this->page->GetAllowedResourceIds())) {
-            $allowedResources = $this->page->GetAllowedResourceIds();
-        }
+        $permissionsByType = $this->resourcePermissionService->ParseSubmittedPermissions(
+            $this->page->GetAllowedResourceIds(),
+            $managedResourceIds,
+        );
 
-        $allowed = [];
-        $view = [];
-        foreach ($allowedResources as $resource) {
-            $split = explode('_', $resource);
-            $resourceId = $split[0];
-            $permissionType = $split[1];
+        $user->ChangeAllowedPermissions(
+            $this->resourcePermissionService->MergeWithPreservedPermissions(
+                existingIds: $user->GetAllowedResourceIds(),
+                managedResourceIds: $managedResourceIds,
+                submittedIds: $permissionsByType['full'],
+            )
+        );
+        $user->ChangeViewPermissions(
+            $this->resourcePermissionService->MergeWithPreservedPermissions(
+                existingIds: $user->GetAllowedViewResourceIds(),
+                managedResourceIds: $managedResourceIds,
+                submittedIds: $permissionsByType['view'],
+            )
+        );
 
-            if ($permissionType === ResourcePermissionType::Full . '') {
-                $allowed[] = $resourceId;
-            } else {
-                if ($permissionType === ResourcePermissionType::View . '') {
-                    $view[] = $resourceId;
-                }
-            }
-        }
-
-        $currentResources = $user->GetAllowedResourceIds();
-        $toRemainUnchanged = array_diff($currentResources, $acceptableResourceIds);
-
-        $user->ChangeAllowedPermissions(array_merge($toRemainUnchanged, $allowed));
-        $user->ChangeViewPermissions(array_merge($toRemainUnchanged, $view));
         $this->userRepository->Update($user);
     }
 

--- a/Web/scripts/admin/group.js
+++ b/Web/scripts/admin/group.js
@@ -2,6 +2,16 @@ function GroupManagement(opt) {
   var options = opt;
   var activeId = null;
   var allUserList = null;
+  // DataTables pagination physically removes non-visible rows from the DOM,
+  // so <select> elements on other pages don't exist when the form is serialized.
+  // This object tracks permission state for all resources in memory, ensuring
+  // permissions on non-visible pages aren't lost on save.
+  // Keys are resource IDs (e.g. "1", "37"). Values use the format
+  // "{resourceId}_{permissionType}" matching the <select> option values:
+  //   "1_0" = Full Access (for resource ID 1)
+  //   "2_1" = View Only (for resource ID 2)
+  //   "37_none" = None (for resource ID 37)
+  var permissionState = {};
 
   var elements = {
     groupList: $('#groupList'),
@@ -104,19 +114,31 @@ function GroupManagement(opt) {
     });
 
     //ressource selection
+    // Handle click to set all resources to "Full Access"
     elements.checkAllResourcesFull.click((e) => {
       e.preventDefault();
-      elements.permissionsDialog.find('.full').prop('selected', true);
+      for (var rid in permissionState) {
+        permissionState[rid] = rid + '_0';
+      }
+      syncSelectsFromState();
     });
 
+    // Handle click to set all resources to "View Only"
     elements.checkAllResourcesView.click((e) => {
       e.preventDefault();
-      elements.permissionsDialog.find('.view').prop('selected', true);
+      for (var rid in permissionState) {
+        permissionState[rid] = rid + '_1';
+      }
+      syncSelectsFromState();
     });
 
+    // Handle click to set all resources to "None"
     elements.checkNoResources.click((e) => {
       e.preventDefault();
-      elements.permissionsDialog.find('.none').prop('selected', true);
+      for (var rid in permissionState) {
+        permissionState[rid] = rid + '_none';
+      }
+      syncSelectsFromState();
     });
 
     //group role
@@ -158,9 +180,25 @@ function GroupManagement(opt) {
   };
 
   var configureAsyncForms = function () {
+    var cleanupPermissionsForm = function () {
+      elements.permissionsForm.find('select.resourceId').attr('name', 'resourceId[]');
+      elements.permissionsForm.find('.injected-permission').remove();
+    };
+
     var hidePermissionsDialog = function () {
       elements.permissionsDialog.modal('hide');
     };
+
+    elements.permissionsDialog.on('hidden.bs.modal', cleanupPermissionsForm);
+
+    elements.permissionsForm.on('change', 'select.resourceId', function () {
+      var rid = $(this).attr('id').replace('permission_', '');
+      permissionState[rid] = $(this).val();
+    });
+
+    $('#permissionsDialogtable').on('draw.dt', function () {
+      syncSelectsFromState();
+    });
 
     var error = function (errorText) {
       alert(errorText);
@@ -183,11 +221,31 @@ function GroupManagement(opt) {
 
     ConfigureAsyncForm(elements.addUserForm, getSubmitCallback(options.actions.addUser), changeMembers, error);
     ConfigureAsyncForm(elements.removeUserForm, getSubmitCallback(options.actions.removeUser), changeMembers, error);
+    // Inject hidden inputs for all resources before form serialization.
+    // DataTables pagination removes non-visible <select> elements from the DOM,
+    // so we must submit permissions via hidden inputs from permissionState instead.
+    var permissionsBeforeSerialize = function (jqForm) {
+      // Remove any previously injected inputs (e.g. from a failed submission retry)
+      jqForm.find('.injected-permission').remove();
+      // Add a hidden input for each resource that has a permission (skip "None")
+      for (var rid in permissionState) {
+        var val = permissionState[rid];
+        if (val.indexOf('_none') === -1) {
+          jqForm.append(
+            $('<input>', { type: 'hidden', class: 'injected-permission', name: 'resourceId[]', value: val })
+          );
+        }
+      }
+      // Prevent visible <select> elements from also submitting, which would cause duplicates
+      jqForm.find('select.resourceId').attr('name', '');
+    };
+
     ConfigureAsyncForm(
       elements.permissionsForm,
       getSubmitCallback(options.actions.permissions),
       hidePermissionsDialog,
-      error
+      error,
+      { onBeforeSerialize: permissionsBeforeSerialize }
     );
     ConfigureAsyncForm(elements.editGroupForm, getSubmitCallback(options.actions.updateGroup), null, error);
     ConfigureAsyncForm(elements.deleteGroupForm, getSubmitCallback(options.actions.deleteGroup), null, error);
@@ -310,19 +368,46 @@ function GroupManagement(opt) {
     elements.browseUserDialog.modal('show');
   };
 
+  // Update visible <select> dropdowns on the current DataTable page to match permissionState.
+  // Each select has an id like "permission_37" — the resource ID is extracted by stripping
+  // the "permission_" prefix (e.g. "permission_37" → "37"), then used to look up the value
+  // in permissionState.
+  var syncSelectsFromState = function () {
+    var table = $('#permissionsDialogtable').DataTable();
+    table.rows({ page: 'current' }).every(function () {
+      var select = $(this.node()).find('select.resourceId');
+      if (select.length) {
+        var rid = select.attr('id').replace('permission_', '');
+        if (permissionState[rid] !== undefined) {
+          select.val(permissionState[rid]);
+        }
+      }
+    });
+  };
+
   //change group ressource permission
   var changePermissions = function () {
     $.get(options.permissionsUrl, { dr: options.dataRequests.permissions, gid: activeId }, (permissions) => {
-      elements.permissionsForm.find('.none').prop('selected', true);
+      permissionState = {};
+
+      var table = $('#permissionsDialogtable').DataTable();
+      table.rows({ search: 'none' }).every(function () {
+        var select = $(this.node()).find('select.resourceId');
+        if (select.length) {
+          var rid = select.attr('id').replace('permission_', '');
+          permissionState[rid] = rid + '_none';
+        }
+      });
 
       (permissions.full || []).forEach((id) => {
-        elements.permissionsForm.find(`#permission_${id}`).val(`${id}_0`);
+        permissionState[id] = id + '_0';
       });
 
       (permissions.view || []).forEach((id) => {
-        elements.permissionsForm.find(`#permission_${id}`).val(`${id}_1`);
+        permissionState[id] = id + '_1';
       });
 
+      syncSelectsFromState();
       elements.permissionsDialog.modal('show');
     });
   };

--- a/Web/scripts/admin/user.js
+++ b/Web/scripts/admin/user.js
@@ -58,6 +58,16 @@ function UserManagement(opts) {
   };
 
   var users = {};
+  // DataTables pagination physically removes non-visible rows from the DOM,
+  // so <select> elements on other pages don't exist when the form is serialized.
+  // This object tracks permission state for all resources in memory, ensuring
+  // permissions on non-visible pages aren't lost on save.
+  // Keys are resource IDs (e.g. "1", "37"). Values use the format
+  // "{resourceId}_{permissionType}" matching the <select> option values:
+  //   "1_0" = Full Access (for resource ID 1)
+  //   "2_1" = View Only (for resource ID 2)
+  //   "37_none" = None (for resource ID 37)
+  var permissionState = {};
 
   UserManagement.prototype.init = function () {
     elements.userList.on('click', '.update', function (e) {
@@ -147,19 +157,31 @@ function UserManagement(opts) {
       $(this).appendTo(elements.addedGroups);
     });
 
+    // Handle click to set all resources to "Full Access"
     elements.checkAllResourcesFull.click(function (e) {
       e.preventDefault();
-      elements.permissionsDialog.find('.full').prop('selected', true);
+      for (var rid in permissionState) {
+        permissionState[rid] = rid + '_0';
+      }
+      syncSelectsFromState();
     });
 
+    // Handle click to set all resources to "View Only"
     elements.checkAllResourcesView.click(function (e) {
       e.preventDefault();
-      elements.permissionsDialog.find('.view').prop('selected', true);
+      for (var rid in permissionState) {
+        permissionState[rid] = rid + '_1';
+      }
+      syncSelectsFromState();
     });
 
+    // Handle click to set all resources to "None"
     elements.checkNoResources.click(function (e) {
       e.preventDefault();
-      elements.permissionsDialog.find('.none').prop('selected', true);
+      for (var rid in permissionState) {
+        permissionState[rid] = rid + '_none';
+      }
+      syncSelectsFromState();
     });
 
     $('.save').click(function () {
@@ -215,9 +237,25 @@ function UserManagement(opts) {
       elements.deleteMultiplePrompt.toggleClass('d-none', numberChecked == 0);
     });
 
+    var cleanupPermissionsForm = function () {
+      elements.permissionsForm.find('select.resourceId').attr('name', 'resourceId[]');
+      elements.permissionsForm.find('.injected-permission').remove();
+    };
+
     var hidePermissionsDialog = function () {
       hideDialog(elements.permissionsDialog);
     };
+
+    elements.permissionsDialog.on('hidden.bs.modal', cleanupPermissionsForm);
+
+    elements.permissionsForm.on('change', 'select.resourceId', function () {
+      var rid = $(this).attr('id').replace('permission_', '');
+      permissionState[rid] = $(this).val();
+    });
+
+    $('#permissionsFormFilter').on('draw.dt', function () {
+      syncSelectsFromState();
+    });
 
     var hidePasswordDialog = function () {
       hideDialog(elements.passwordDialog);
@@ -263,11 +301,31 @@ function UserManagement(opts) {
     $('#addOrganization').orgAutoComplete(options.orgAutoCompleteUrl);
     $('#organization').orgAutoComplete(options.orgAutoCompleteUrl);
 
+    // Inject hidden inputs for all resources before form serialization.
+    // DataTables pagination removes non-visible <select> elements from the DOM,
+    // so we must submit permissions via hidden inputs from permissionState instead.
+    var permissionsBeforeSerialize = function (jqForm) {
+      // Remove any previously injected inputs (e.g. from a failed submission retry)
+      jqForm.find('.injected-permission').remove();
+      // Add a hidden input for each resource that has a permission (skip "None")
+      for (var rid in permissionState) {
+        var val = permissionState[rid];
+        if (val.indexOf('_none') === -1) {
+          jqForm.append(
+            $('<input>', { type: 'hidden', class: 'injected-permission', name: 'resourceId[]', value: val })
+          );
+        }
+      }
+      // Prevent visible <select> elements from also submitting, which would cause duplicates
+      jqForm.find('select.resourceId').attr('name', '');
+    };
+
     ConfigureAsyncForm(
       elements.permissionsForm,
       defaultSubmitCallback(elements.permissionsForm),
       hidePermissionsDialog,
-      error
+      error,
+      { onBeforeSerialize: permissionsBeforeSerialize }
     );
     ConfigureAsyncForm(elements.passwordForm, defaultSubmitCallback(elements.passwordForm), hidePasswordDialog, error);
     ConfigureAsyncForm(
@@ -384,20 +442,47 @@ function UserManagement(opts) {
     elements.groupsDialog.modal('show');
   };
 
+  // Update visible <select> dropdowns on the current DataTable page to match permissionState.
+  // Each select has an id like "permission_37" — the resource ID is extracted by stripping
+  // the "permission_" prefix (e.g. "permission_37" → "37"), then used to look up the value
+  // in permissionState.
+  var syncSelectsFromState = function () {
+    var table = $('#permissionsFormFilter').DataTable();
+    table.rows({ page: 'current' }).every(function () {
+      var select = $(this.node()).find('select.resourceId');
+      if (select.length) {
+        var rid = select.attr('id').replace('permission_', '');
+        if (permissionState[rid] !== undefined) {
+          select.val(permissionState[rid]);
+        }
+      }
+    });
+  };
+
   var changePermissions = function () {
     var user = getActiveUser();
     var data = { dr: 'permissions', uid: user.id };
     $.get(opts.permissionsUrl, data, function (permissions) {
-      elements.permissionsForm.find('.none').prop('selected', true);
+      permissionState = {};
 
-      $.each(permissions.full, function (index, value) {
-        elements.permissionsForm.find('#permission_' + value).val(value + '_0');
+      var table = $('#permissionsFormFilter').DataTable();
+      table.rows({ search: 'none' }).every(function () {
+        var select = $(this.node()).find('select.resourceId');
+        if (select.length) {
+          var rid = select.attr('id').replace('permission_', '');
+          permissionState[rid] = rid + '_none';
+        }
       });
 
-      $.each(permissions.view, function (index, value) {
-        elements.permissionsForm.find('#permission_' + value).val(value + '_1');
+      (permissions.full || []).forEach(function (value) {
+        permissionState[value] = value + '_0';
       });
 
+      (permissions.view || []).forEach(function (value) {
+        permissionState[value] = value + '_1';
+      });
+
+      syncSelectsFromState();
       elements.permissionsDialog.modal('show');
     });
   };

--- a/lib/Application/Admin/ResourcePermissionService.php
+++ b/lib/Application/Admin/ResourcePermissionService.php
@@ -1,0 +1,132 @@
+<?php
+
+require_once(ROOT_DIR . 'Domain/Values/ResourcePermissionType.php');
+
+interface IResourcePermissionService
+{
+    /**
+     * Get the resource IDs that the given user is allowed to administer.
+     *
+     * @return int[]
+     */
+    public function GetResourceIdsThatUserCanAdminister(User $adminUser): array;
+
+    /**
+     * Parse submitted permission strings (e.g. "1_0", "2_1") into separate
+     * full-access and view-only resource ID arrays, filtering to only resources
+     * the admin can manage.
+     *
+     * @param string[]|null $submittedPermissions raw form data
+     * @param int[] $managedResourceIds resources the admin can manage
+     * @return array{full: int[], view: int[]}
+     */
+    public function ParseSubmittedPermissions(
+        ?array $submittedPermissions,
+        array $managedResourceIds,
+    ): array;
+
+    /**
+     * Compute the complete permission lists by merging admin-submitted permissions
+     * with existing permissions on resources outside the admin's scope.
+     *
+     * @param int[] $existingIds current permission IDs (full or view)
+     * @param int[] $managedResourceIds resources the admin can manage
+     * @param int[] $submittedIds IDs the admin submitted for this permission type
+     * @return int[]
+     */
+    public function MergeWithPreservedPermissions(
+        array $existingIds,
+        array $managedResourceIds,
+        array $submittedIds,
+    ): array;
+}
+
+class ResourcePermissionService implements IResourcePermissionService
+{
+    public function __construct(
+        private IResourceRepository $resourceRepository,
+    ) {
+    }
+
+    public function GetResourceIdsThatUserCanAdminister(User $adminUser): array
+    {
+        $managedResourceIds = [];
+        $allResources = $this->resourceRepository->GetResourceList();
+        foreach ($allResources as $resource) {
+            if ($adminUser->IsResourceAdminFor($resource)) {
+                $managedResourceIds[] = (int) $resource->GetId();
+            }
+        }
+        return $managedResourceIds;
+    }
+
+    // The permissions form submits an array of strings like "1_0", "2_1", "3_none"
+    // where the first part is the resource ID and the second is the permission type
+    // (0 = Full Access, 1 = View Only, "none" = no permission).
+    // This method parses those strings, discards any resources the admin cannot
+    // manage, rejects malformed input, and returns the resource IDs grouped by type.
+    public function ParseSubmittedPermissions(
+        ?array $submittedPermissions,
+        array $managedResourceIds,
+    ): array {
+        $fullAccessResourceIds = [];
+        $viewOnlyResourceIds = [];
+
+        if (!is_array($submittedPermissions)) {
+            return ['full' => $fullAccessResourceIds, 'view' => $viewOnlyResourceIds];
+        }
+
+        // Each entry is "{resourceId}_{permissionType}" e.g. "1_0" for full, "2_1" for view
+        foreach ($submittedPermissions as $permissionString) {
+            if (!is_scalar($permissionString)) {
+                continue;
+            }
+            $split = explode('_', (string) $permissionString);
+            $resourceId = (int) $split[0];
+            $permissionType = (string) ($split[1] ?? 'none');
+
+            // Only allow changes to resources the current admin can administer
+            if (!in_array($resourceId, $managedResourceIds, true)) {
+                continue;
+            }
+
+            // Only accept valid numeric permission types; ignore malformed input
+            // (e.g. "abc" would cast to 0 via (int), falsely matching Full Access)
+            if (!ctype_digit($permissionType)) {
+                continue;
+            }
+
+            $permissionType = (int) $permissionType;
+
+            if ($permissionType === ResourcePermissionType::Full) {
+                $fullAccessResourceIds[] = $resourceId;
+            } elseif ($permissionType === ResourcePermissionType::View) {
+                $viewOnlyResourceIds[] = $resourceId;
+            }
+        }
+
+        return ['full' => $fullAccessResourceIds, 'view' => $viewOnlyResourceIds];
+    }
+
+    // An admin can only change permissions for resources they manage.
+    // Existing permissions on resources outside their scope must be kept as-is.
+    // This method combines those preserved permissions with the admin's new
+    // submissions to produce the complete permission list for a given type
+    // (full or view).
+    //
+    // Example: admin manages [1, 2, 3], user has full access to [1, 5, 10],
+    // admin submits [1, 3]:
+    //   $existingIds = [1, 5, 10]
+    //   $managedResourceIds = [1, 2, 3]
+    //   $submittedIds = [1, 3]
+    //   $outsideAdminScope = [5, 10]  (admin can't touch these, preserved)
+    //   result = [5, 10, 1, 3]
+    public function MergeWithPreservedPermissions(
+        array $existingIds,
+        array $managedResourceIds,
+        array $submittedIds,
+    ): array {
+        $outsideAdminScope = array_diff($existingIds, $managedResourceIds);
+        return array_unique(array_merge($outsideAdminScope, $submittedIds));
+    }
+}

--- a/lib/Application/Admin/namespace.php
+++ b/lib/Application/Admin/namespace.php
@@ -11,3 +11,4 @@ require_once(ROOT_DIR . 'lib/Application/Admin/GroupAdminManageReservationsServi
 require_once(ROOT_DIR . 'lib/Application/Admin/GroupAdminGroupRepository.php');
 require_once(ROOT_DIR . 'lib/Application/Admin/ImageUploadDirectory.php');
 require_once(ROOT_DIR . 'lib/Application/Admin/TemplateCacheDirectory.php');
+require_once(ROOT_DIR . 'lib/Application/Admin/ResourcePermissionService.php');

--- a/tests/Application/Admin/ResourcePermissionServiceTest.php
+++ b/tests/Application/Admin/ResourcePermissionServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Application/Admin/ResourcePermissionService.php');
+
+class ResourcePermissionServiceTest extends TestBase
+{
+    private FakeResourceRepository $resourceRepo;
+    private ResourcePermissionService $service;
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $this->resourceRepo = new FakeResourceRepository();
+        $this->service = new ResourcePermissionService($this->resourceRepo);
+    }
+
+    public function testGetResourceIdsThatUserCanAdminister()
+    {
+        $this->resourceRepo->_ResourceList = [
+            new FakeBookableResource(1),
+            new FakeBookableResource(2),
+            new FakeBookableResource(3),
+        ];
+
+        $adminUser = new FakeUser();
+        $adminUser->_ResourceAdminResourceIds = [1, 3];
+        $adminUser->_IsResourceAdmin = false;
+
+        $result = $this->service->GetResourceIdsThatUserCanAdminister($adminUser);
+
+        sort($result);
+        $this->assertEquals([1, 3], $result);
+    }
+
+    public function testParseSubmittedPermissionsFiltersToAdminScope()
+    {
+        $submitted = ['1_0', '2_1', '99_0'];
+        $adminManagedIds = [1, 2];
+
+        $result = $this->service->ParseSubmittedPermissions($submitted, $adminManagedIds);
+
+        $this->assertEquals([1], $result['full']);
+        $this->assertEquals([2], $result['view']);
+    }
+
+    public function testParseSubmittedPermissionsSkipsNone()
+    {
+        $submitted = ['1_none', '2_0'];
+        $adminManagedIds = [1, 2];
+
+        $result = $this->service->ParseSubmittedPermissions($submitted, $adminManagedIds);
+
+        $this->assertEquals([2], $result['full']);
+        $this->assertEquals([], $result['view']);
+    }
+
+    public function testParseSubmittedPermissionsHandlesNull()
+    {
+        $result = $this->service->ParseSubmittedPermissions(null, [1, 2]);
+
+        $this->assertEquals([], $result['full']);
+        $this->assertEquals([], $result['view']);
+    }
+
+    public function testParseSubmittedPermissionsHandlesMalformedInput()
+    {
+        $submitted = ['1'];  // Missing permission type
+        $adminManagedIds = [1];
+
+        $result = $this->service->ParseSubmittedPermissions($submitted, $adminManagedIds);
+
+        // "1" splits to ["1"], $split[1] is undefined, defaults to 'none', skipped
+        $this->assertEquals([], $result['full']);
+        $this->assertEquals([], $result['view']);
+    }
+
+    public function testParseSubmittedPermissionsRejectsNonNumericPermissionType()
+    {
+        // "abc" would cast to 0 via (int), falsely matching Full Access
+        $submitted = ['1_abc', '2_0'];
+        $adminManagedIds = [1, 2];
+
+        $result = $this->service->ParseSubmittedPermissions($submitted, $adminManagedIds);
+
+        $this->assertEquals([2], $result['full']);
+        $this->assertEquals([], $result['view']);
+    }
+
+    public function testParseSubmittedPermissionsSkipsNonScalarEntries()
+    {
+        // A crafted POST can send nested arrays instead of strings
+        $submitted = [['nested', 'array'], '2_0', ['0' => ['x' => '1']]];
+        $adminManagedIds = [1, 2];
+
+        $result = $this->service->ParseSubmittedPermissions($submitted, $adminManagedIds);
+
+        $this->assertEquals([2], $result['full']);
+        $this->assertEquals([], $result['view']);
+    }
+
+    public function testMergeWithPreservedPermissions()
+    {
+        $existingIds = [1, 5, 10];
+        $adminManagedIds = [1, 2, 3];
+        $submittedIds = [1, 3];
+
+        $result = $this->service->MergeWithPreservedPermissions(
+            existingIds: $existingIds,
+            managedResourceIds: $adminManagedIds,
+            submittedIds: $submittedIds,
+        );
+
+        sort($result);
+        // 5 and 10 are outside admin scope (preserved), 1 and 3 are submitted
+        $this->assertEquals([1, 3, 5, 10], $result);
+    }
+
+    public function testMergeWithPreservedPermissionsNoDuplicates()
+    {
+        $existingIds = [1, 5];
+        $adminManagedIds = [1, 2];
+        $submittedIds = [1];  // Resource 1 is both existing and submitted
+
+        $result = $this->service->MergeWithPreservedPermissions(
+            existingIds: $existingIds,
+            managedResourceIds: $adminManagedIds,
+            submittedIds: $submittedIds,
+        );
+
+        sort($result);
+        $this->assertEquals([1, 5], $result);
+    }
+}

--- a/tests/Presenters/Admin/ManageGroupsPresenterTest.php
+++ b/tests/Presenters/Admin/ManageGroupsPresenterTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'Presenters/Admin/ManageGroupsPresenter.php');
+require_once(ROOT_DIR . 'Pages/Admin/ManageGroupsPage.php');
+
+class ManageGroupsPresenterTest extends TestBase
+{
+    private FakeManageGroupsPage $page;
+    private FakeUserRepository $userRepo;
+    private FakeResourceRepository $resourceRepo;
+    private IGroupRepository&IGroupViewRepository&\PHPUnit\Framework\MockObject\MockObject $groupRepository;
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
+    private ManageGroupsPresenter $presenter;
+
+    public function setUp(): void
+    {
+        parent::setup();
+
+        $this->page = new FakeManageGroupsPage();
+        $this->userRepo = new FakeUserRepository();
+        $this->resourceRepo = new FakeResourceRepository();
+        $this->groupRepository = $this->createMockForIntersectionOfInterfaces([IGroupRepository::class, IGroupViewRepository::class]);
+        $this->scheduleRepository = $this->createMock(IScheduleRepository::class);
+
+        $this->presenter = new ManageGroupsPresenter(
+            $this->page,
+            $this->groupRepository,
+            $this->resourceRepo,
+            $this->scheduleRepository,
+            $this->userRepo,
+        );
+    }
+
+    public function testChangePermissionsWithAdminScopeCheck()
+    {
+        // Admin can manage resources [1, 2, 3]
+        // Group has full=[1, 5], view=[2, 6]
+        // Admin submits full=[1], view=[3]
+        // Expected: full=[1, 5], view=[3, 6]
+        $adminManageableIds = [1, 2, 3];
+        $submittedResourceIds = ['1_0', '3_1'];
+
+        $allResourceIds = [1, 2, 3, 5, 6];
+        $resources = [];
+        foreach ($allResourceIds as $rid) {
+            $resources[] = new FakeBookableResource($rid);
+        }
+
+        $groupId = 100;
+        $adminUserId = $this->fakeUser->UserId;
+
+        $group = new Group(0, 'test group');
+        $group->WithId($groupId);
+        $group->WithFullPermission(1);
+        $group->WithFullPermission(5);
+        $group->WithViewablePermission(2);
+        $group->WithViewablePermission(6);
+
+        $adminUser = new FakeUser();
+        $adminUser->_ResourceAdminResourceIds = $adminManageableIds;
+        $adminUser->_IsResourceAdmin = false;
+
+        $this->page->_GroupId = $groupId;
+        $this->page->_AllowedResourceIds = $submittedResourceIds;
+
+        $this->resourceRepo->_ResourceList = $resources;
+
+        $this->userRepo->_UserById[$adminUserId] = $adminUser;
+
+        $this->groupRepository
+            ->expects($this->once())
+            ->method('LoadById')
+            ->with($groupId)
+            ->willReturn($group);
+
+        $this->groupRepository
+            ->expects($this->once())
+            ->method('Update')
+            ->with($group);
+
+        $this->presenter->ChangePermissions();
+
+        $actualFull = $group->AllowedResourceIds();
+        $actualView = $group->AllowedViewResourceIds();
+        sort($actualFull);
+        sort($actualView);
+        $this->assertEquals([1, 5], $actualFull);
+        $this->assertEquals([3, 6], $actualView);
+    }
+
+    public function testChangePermissionsRejectsResourcesOutsideAdminScope()
+    {
+        // Admin can manage resources [1, 2]
+        // Admin tries to submit permissions for resource 99 (outside scope)
+        // Group has no existing permissions
+        // Expected: no permissions set (resource 99 rejected)
+        $adminManageableIds = [1, 2];
+        $submittedResourceIds = ['99_0'];
+
+        $resources = [
+            new FakeBookableResource(1),
+            new FakeBookableResource(2),
+            new FakeBookableResource(99),
+        ];
+
+        $groupId = 200;
+        $adminUserId = $this->fakeUser->UserId;
+
+        $group = new Group(0, 'test group');
+        $group->WithId($groupId);
+
+        $adminUser = new FakeUser();
+        $adminUser->_ResourceAdminResourceIds = $adminManageableIds;
+        $adminUser->_IsResourceAdmin = false;
+
+        $this->page->_GroupId = $groupId;
+        $this->page->_AllowedResourceIds = $submittedResourceIds;
+
+        $this->resourceRepo->_ResourceList = $resources;
+
+        $this->userRepo->_UserById[$adminUserId] = $adminUser;
+
+        $this->groupRepository
+            ->method('LoadById')
+            ->willReturn($group);
+
+        $this->groupRepository
+            ->expects($this->once())
+            ->method('Update')
+            ->with($group);
+
+        $this->presenter->ChangePermissions();
+
+        $this->assertEquals([], $group->AllowedResourceIds());
+        $this->assertEquals([], $group->AllowedViewResourceIds());
+    }
+}
+
+class FakeManageGroupsPage extends FakeActionPageBase implements IManageGroupsPage
+{
+    public ?int $_GroupId = null;
+    /** @var string[]|null */
+    public ?array $_AllowedResourceIds = null;
+
+    public function GetGroupId()
+    {
+        return $this->_GroupId;
+    }
+
+    public function BindGroups($groups)
+    {
+    }
+
+    public function BindPageInfo(PageInfo $pageInfo)
+    {
+    }
+
+    public function GetPageNumber()
+    {
+        return 1;
+    }
+
+    public function GetPageSize()
+    {
+        return 10;
+    }
+
+    public function SetJsonResponse($response)
+    {
+    }
+
+    public function GetUserId()
+    {
+        return 0;
+    }
+
+    public function BindResources($resources)
+    {
+    }
+
+    public function BindSchedules($schedules)
+    {
+    }
+
+    public function BindRoles($roles)
+    {
+    }
+
+    public function GetAllowedResourceIds()
+    {
+        return $this->_AllowedResourceIds;
+    }
+
+    public function GetGroupName()
+    {
+        return '';
+    }
+
+    public function GetRoleIds()
+    {
+        return [];
+    }
+
+    public function BindAdminGroups($adminGroups)
+    {
+    }
+
+    public function GetAdminGroupId()
+    {
+        return 0;
+    }
+
+    public function AutomaticallyAddToGroup()
+    {
+        return false;
+    }
+
+    public function GetUserIds()
+    {
+        return [];
+    }
+
+    public function GetGroupAdminIds()
+    {
+        return [];
+    }
+
+    public function GetResourceAdminIds()
+    {
+        return [];
+    }
+
+    public function GetScheduleAdminIds()
+    {
+        return [];
+    }
+
+    public function Export($groups, $users, $permissionsWrite, $permissionsRead)
+    {
+    }
+
+    public function GetImportFile()
+    {
+        return new UploadedFile([]);
+    }
+
+    public function ShowTemplateCsv()
+    {
+    }
+
+    public function SetImportResult($importResult)
+    {
+    }
+
+    public function GetUpdateOnImport()
+    {
+        return false;
+    }
+
+    public function GetSortField()
+    {
+        return null;
+    }
+
+    public function GetSortDirection()
+    {
+        return null;
+    }
+}

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -117,13 +117,13 @@ class ManageUsersPresenterTest extends TestBase
     public function testGetsSelectedResourcesFromPageAndAssignsPermission()
     {
         $resourcesThatShouldRemainUnchanged = [5, 10];
-        $allowedResourceIds = [1, 2, 4, 20, 30];
-        $submittedResourceIds = [1, 4];
-        $currentResourceIds = [1, 20, 30];
+        $adminManageableIds = [1, 2, 4, 20, 30];
+        $submittedResourceIds = ['1_0', '4_0'];
+        $currentFullAccessIds = [1, 20, 30];
 
-        $expectedResourceIds = [1, 4, 5, 10];
+        $expectedFullAccessIds = [1, 4, 5, 10];
 
-        $allResourceIds = array_unique(array_merge($resourcesThatShouldRemainUnchanged, $allowedResourceIds, $submittedResourceIds, $currentResourceIds));
+        $allResourceIds = array_unique(array_merge($resourcesThatShouldRemainUnchanged, $adminManageableIds, [1, 4], $currentFullAccessIds));
 
         $resources = [];
         foreach ($allResourceIds as $rid) {
@@ -134,10 +134,10 @@ class ManageUsersPresenterTest extends TestBase
         $adminUserId = $this->fakeUser->UserId;
 
         $user = new FakeUser();
-        $user->WithAllowedPermissions(array_merge($resourcesThatShouldRemainUnchanged, $currentResourceIds));
+        $user->WithAllowedPermissions(array_merge($resourcesThatShouldRemainUnchanged, $currentFullAccessIds));
 
         $adminUser = new FakeUser();
-        $adminUser->_ResourceAdminResourceIds = $allowedResourceIds;
+        $adminUser->_ResourceAdminResourceIds = $adminManageableIds;
         $adminUser->_IsResourceAdmin = false;
 
         $this->page->_UserId = $userId;
@@ -150,8 +150,55 @@ class ManageUsersPresenterTest extends TestBase
 
         $this->presenter->ChangePermissions();
 
-        $actual = $user->GetAllowedResourceIds();
-        $this->assertEquals(sort($expectedResourceIds), sort($actual));
+        $actualFullAccess = $user->GetAllowedResourceIds();
+        sort($expectedFullAccessIds);
+        sort($actualFullAccess);
+        $this->assertEquals($expectedFullAccessIds, $actualFullAccess);
+        $this->assertEquals($this->userRepo->_UpdatedUser, $user);
+    }
+
+    public function testViewPermissionsPreservedSeparatelyFromFullPermissions()
+    {
+        // Admin can manage resources [1, 2, 3]
+        // User has full=[1, 5], view=[2, 6]
+        // Admin submits full=[1], view=[3]
+        // Expected: full=[1, 5], view=[3, 6]
+        $adminManageableIds = [1, 2, 3];
+        $submittedResourceIds = ['1_0', '3_1'];
+
+        $allResourceIds = [1, 2, 3, 5, 6];
+        $resources = [];
+        foreach ($allResourceIds as $rid) {
+            $resources[] = new FakeBookableResource($rid);
+        }
+
+        $userId = 9928;
+        $adminUserId = $this->fakeUser->UserId;
+
+        $user = new FakeUser();
+        $user->WithAllowedPermissions([1, 5]);
+        $user->WithViewablePermission([2, 6]);
+
+        $adminUser = new FakeUser();
+        $adminUser->_ResourceAdminResourceIds = $adminManageableIds;
+        $adminUser->_IsResourceAdmin = false;
+
+        $this->page->_UserId = $userId;
+        $this->page->_AllowedResourceIds = $submittedResourceIds;
+
+        $this->resourceRepo->_ResourceList = $resources;
+
+        $this->userRepo->_UserById[$adminUserId] = $adminUser;
+        $this->userRepo->_UserById[$userId] = $user;
+
+        $this->presenter->ChangePermissions();
+
+        $actualFull = $user->GetAllowedResourceIds();
+        $actualView = $user->GetAllowedViewResourceIds();
+        sort($actualFull);
+        sort($actualView);
+        $this->assertEquals([1, 5], $actualFull);
+        $this->assertEquals([3, 6], $actualView);
         $this->assertEquals($this->userRepo->_UpdatedUser, $user);
     }
 
@@ -482,7 +529,7 @@ class FakeManageUsersPage extends FakeActionPageBase implements IManageUsersPage
      */
     public $_FilterStatusId;
     /**
-     * @var int[]
+     * @var string[]
      */
     public $_AllowedResourceIds;
     /**
@@ -579,6 +626,9 @@ class FakeManageUsersPage extends FakeActionPageBase implements IManageUsersPage
         $this->_JsonResponse = $objectToSerialize;
     }
 
+    /**
+     * @return string[]|null
+     */
     public function GetAllowedResourceIds()
     {
         return $this->_AllowedResourceIds;


### PR DESCRIPTION
The user and group permissions modals use DataTables with 25-row pagination, which physically removes non-visible rows from the DOM. This caused two bugs:

1. When loading or saving permissions, only page-1 resources were affected — permissions for resources on page 2+ were silently reset to "none" on save, and not displayed on load.

2. The presenter used GetAllowedResourceIds() (full-access only) to preserve permissions outside the admin's scope for both full and view types, causing view-only permissions to be incorrectly lost or merged.

Fix Bug 1 by maintaining a JavaScript state object for all permissions regardless of which DataTable page is visible. State is synced to visible selects on page change, and injected as hidden inputs before form serialization. Bulk buttons (None/Full/View) now update all entries in state, not just DOM-present ones. Applied to both user.js and group.js.

Fix Bug 2 by computing preserved permissions separately for full and view types using GetAllowedViewResourceIds(). 

Closes: #990