### PR TITLE
fix(js): add no-unused-vars rule, remove dead code, and fix bugs

### DIFF
--- a/Web/scripts/admin/group.js
+++ b/Web/scripts/admin/group.js
@@ -57,7 +57,7 @@ function GroupManagement(opt) {
   };
 
   var bindEventListeners = function () {
-    const { groupList, groupUserList, browseUserDialog, addDialog, importGroupsDialog } = elements;
+    const { groupList, browseUserDialog, addDialog } = elements;
 
     groupList.on('click', 'a.update', (e) => {
       e.preventDefault();
@@ -158,21 +158,6 @@ function GroupManagement(opt) {
   };
 
   var configureAsyncForms = function () {
-    const {
-      addUserForm,
-      removeUserForm,
-      permissionsForm,
-      editGroupForm,
-      deleteGroupForm,
-      addForm,
-      rolesForm,
-      groupAdminForm,
-      changeAdminGroupsForm,
-      changeAdminResourcesForm,
-      changeAdminSchedulesForm,
-      importGroupsForm,
-    } = elements;
-
     var hidePermissionsDialog = function () {
       elements.permissionsDialog.modal('hide');
     };

--- a/Web/scripts/admin/payments.js
+++ b/Web/scripts/admin/payments.js
@@ -11,9 +11,6 @@ function Payments(opts) {
     refundAmount: $('#refundAmount'),
   };
 
-  var lastPage = 0;
-  var lastPageSize = 0;
-
   Payments.prototype.init = function () {
     $('.save').click(function (e) {
       e.preventDefault();
@@ -106,9 +103,6 @@ function Payments(opts) {
   };
 
   function loadTransactionLog(page, pageSize) {
-    lastPage = page;
-    lastPageSize = pageSize;
-
     elements.transactionLogIndicator.removeClass('no-show');
 
     ajaxGet(opts.transactionLogUrl.replace('[page]', page).replace('[pageSize]', pageSize), null, function (data) {

--- a/Web/scripts/admin/reminder.js
+++ b/Web/scripts/admin/reminder.js
@@ -68,19 +68,11 @@ function ReminderManagement(opts) {
   }
 
   var editReminder = function () {
-    var reminder = getActiveReminder();
-    //elements.editAddress.val(reminder.address);
-    //elements.editMessage.val(reminder.message);
-    //elements.editSendtime.val(reminder.sendtime);
     elements.editDialog.dialog('open');
   };
 
   var deleteReminder = function () {
     elements.deleteDialog.dialog('open');
-  };
-
-  var getActiveReminder = function () {
-    return reminders[getActiveId()];
   };
 
   ReminderManagement.prototype.addReminder = function (id, userid, address, message, sendtime, refnumber) {

--- a/Web/scripts/admin/reservations.js
+++ b/Web/scripts/admin/reservations.js
@@ -141,7 +141,6 @@ function ReservationManagement(opts, approval) {
     });
 
     elements.reservationTable.find('tr.editable').each(function () {
-      var seriesId = $(this).attr('data-seriesId');
       var refNum = $(this).attr('data-refnum');
       $(this).attachReservationPopup(refNum, options.popupUrl);
 
@@ -455,12 +454,6 @@ function ReservationManagement(opts, approval) {
       } else {
         $('#tos_reservation').click();
       }
-    });
-  }
-
-  function deleteTerms() {
-    ajaxGet(options.deleteTermsOfServiceUrl, null, function () {
-      elements.termsOfServiceDialog.modal('hide');
     });
   }
 }

--- a/Web/scripts/admin/resource-groups.js
+++ b/Web/scripts/admin/resource-groups.js
@@ -310,6 +310,4 @@ function ResourceGroupManagement(opts) {
       return options.submitUrl + '?action=' + form.attr('ajaxAction') + '&nid=' + elements.activeId.val();
     };
   };
-
-  var handleAddError = function (result) {};
 }

--- a/Web/scripts/admin/resource.js
+++ b/Web/scripts/admin/resource.js
@@ -112,10 +112,6 @@ function ResourceManagement(opts) {
   var resources = {};
   var reasons = [];
 
-  function initializeResourceUI(id, details) {
-    // no-op
-  }
-
   ResourceManagement.prototype.init = function () {
     this.bindEventListeners();
     this.configureAsyncForms();

--- a/Web/scripts/admin/schedule.js
+++ b/Web/scripts/admin/schedule.js
@@ -630,8 +630,6 @@ function ScheduleManagement(opts) {
 
   var _fullCalendar = null;
   var showChangeCustomLayout = function (scheduleId) {
-    var customLayoutScheduleId = scheduleId;
-
     $('#customLayoutDialog').unbind();
 
     function updateEvent(event) {

--- a/Web/scripts/admin/user.js
+++ b/Web/scripts/admin/user.js
@@ -384,13 +384,6 @@ function UserManagement(opts) {
     elements.groupsDialog.modal('show');
   };
 
-  var changeGroup = function (action, groupId) {
-    var url = opts.groupManagementUrl + '?action=' + action + '&gid=' + groupId;
-
-    var data = { userId: getActiveUserId() };
-    $.post(url, data);
-  };
-
   var changePermissions = function () {
     var user = getActiveUser();
     var data = { dr: 'permissions', uid: user.id };
@@ -407,12 +400,6 @@ function UserManagement(opts) {
 
       elements.permissionsDialog.modal('show');
     });
-  };
-
-  var changeColor = function () {
-    var user = getActiveUser();
-    var data = { dr: 'color', uid: user.id };
-    $.get(opts.colorUrl, data, function (colorIds) {});
   };
 
   var changeUserInfo = function () {

--- a/Web/scripts/ajax-helpers.js
+++ b/Web/scripts/ajax-helpers.js
@@ -1,3 +1,4 @@
+/* exported ajaxPost, ajaxGet, ajaxPagination */
 function ajaxPost(formElement, url, onBefore, onAfter) {
   BeforeSerialize(formElement);
 

--- a/Web/scripts/date-helper.js
+++ b/Web/scripts/date-helper.js
@@ -1,3 +1,4 @@
+/* exported dateHelper */
 /**
  * dateHelper
  * -----------

--- a/Web/scripts/menubar.js
+++ b/Web/scripts/menubar.js
@@ -1,3 +1,4 @@
+/* exported mopen, mclosetimer */
 // javascript for enabling drop down sub menus in main navigation
 
 var timeout = 500;

--- a/Web/scripts/phpscheduleit.js
+++ b/Web/scripts/phpscheduleit.js
@@ -1,3 +1,4 @@
+/* exported eraseCookie, getQueryStringValue, init, validateEmail, cookies */
 // Cookie functions from http://www.quirksmode.org/js/cookies.html //
 
 function startsWith(haystack, needle) {

--- a/Web/scripts/reservation-reminder.js
+++ b/Web/scripts/reservation-reminder.js
@@ -1,6 +1,4 @@
 function Reminder(opts) {
-  var options = opts;
-
   var elements = {
     startDiv: $('#reminderOptionsStart'),
     endDiv: $('#reminderOptionsEnd'),

--- a/Web/scripts/reservation-search.js
+++ b/Web/scripts/reservation-search.js
@@ -63,7 +63,6 @@ function ReservationSearch(options) {
     elements.reservationResults.empty().html(data);
 
     elements.reservationResults.find('tr.editable').each(function () {
-      var seriesId = $(this).attr('data-seriesId');
       var refNum = $(this).attr('data-refnum');
       $(this).attachReservationPopup(refNum, options.popupUrl);
     });

--- a/Web/scripts/reservation.js
+++ b/Web/scripts/reservation.js
@@ -82,12 +82,10 @@ function Reservation(opts) {
 
   var _ownerId;
   var _startDate;
-  var _endDate;
 
   Reservation.prototype.init = function (ownerId, startDateString, endDateString) {
     _ownerId = ownerId;
     _startDate = moment(startDateString, 'YYYY-MM-DD HH:mm');
-    _endDate = moment(endDateString, 'YYYY-MM-DD HH:mm');
     participation.addedUsers.push(ownerId);
 
     SetUpAdHocEmail();
@@ -466,7 +464,6 @@ function Reservation(opts) {
 
     var primaryResourceContainer = $('#primaryResourceContainer');
     var resourceIdHdn = primaryResourceContainer.find('.resourceId');
-    var resourceId = resourceIdHdn.val();
 
     var allCheckboxes = elements.resourceGroupsDialog.find('.additionalResourceCheckbox:checked');
 
@@ -575,7 +572,6 @@ function Reservation(opts) {
   var handleAdditionalResourceChecked = function (checkbox, event) {
     var isChecked = checkbox.is(':checked');
 
-    const resourceCheckboxes = elements.groupDiv.find('[resource-id]');
     if (opts.maximumResources && elements.groupDiv.find(':checked').length >= opts.maximumResources) {
       elements.groupDiv.find(':not(:checked)').attr('disabled', true);
     } else {

--- a/Web/scripts/resourceDisplay.js
+++ b/Web/scripts/resourceDisplay.js
@@ -1,6 +1,4 @@
 function ResourceDisplay(opts) {
-  var options = opts;
-
   var elements = {
     loginForm: $('#loginForm'),
     loginButton: $('#loginButton'),

--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -1,9 +1,9 @@
+/* exported dpDateChanged */
 let scheduleSpecificDates = [];
 
 function Schedule(opts, resourceGroups) {
   let options = opts;
   let groupDiv = $('#resourceGroups');
-  let scheduleId = $('#scheduleId');
   let multidateselect = $('#multidateselect');
   let renderingEvents = false;
 
@@ -338,7 +338,7 @@ function Schedule(opts, resourceGroups) {
                 const tr_slots = $(this);
                 let resourceId = tr_slots.data('resourceid');
                 if (resourceIdMap.has(resourceId)) {
-                  for (reservation of resourceIdMap.get(resourceId)) {
+                  for (const reservation of resourceIdMap.get(resourceId)) {
                     if (isReservationInTable(reservation, t)) {
                       if (reservation.IsBuffer) {
                         // buffers are added dynamically in grid views
@@ -1233,7 +1233,7 @@ function RemoveResourceId(url) {
   if (!url) {
     url = window.location.href;
   }
-  return url.replace(/&*rid[]=\d+/i, '');
+  return url.replace(/&*rid\[\]=\d+/i, '');
 }
 
 function RemoveGroupId(url) {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,7 +86,6 @@ export default [
         scheduleSpecificDates: 'readonly',
         resourceOrder: 'readonly',
         filterResources: 'readonly',
-        reservation: 'readonly',
 
         // Calendar globals (calendar.js)
         rebindSubscriptionData: 'readonly',
@@ -118,6 +117,7 @@ export default [
       'valid-typeof': 'error',
       'no-unsafe-negation': 'error',
       'no-sparse-arrays': 'error',
+      'no-unused-vars': ['error', { args: 'none', varsIgnorePattern: '^[A-Z]' }],
     },
   },
   eslintConfigPrettier,


### PR DESCRIPTION
Enable ESLint no-unused-vars rule (args: "none", varsIgnorePattern: "^[A-Z]") to catch unused local variables while ignoring callback parameters and PascalCase constructors used from Smarty templates.

Add /* exported */ comments to 5 files declaring cross-file globals that are used from templates or other scripts: ajax-helpers.js, date-helper.js, menubar.js, phpscheduleit.js, schedule.js.

Remove dead code from 12 files: unused variable assignments, empty no-op functions, and orphaned function definitions.

Fix two pre-existing bugs in schedule.js:
- Escape brackets in regex /rid[]=/ which was an invalid empty character class (now /rid\[\]=/)
- Add const to for-of loop variable to prevent implicit global