### PR TITLE
fix(translation): Fix date formats for italian

### DIFF
--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -1,47 +1,13 @@
 <?php
 
 require_once('Language.php');
-require_once('en_us.php');
+require_once('en_gb.php');
 
-class it_it extends en_us
+class it_it extends en_gb
 {
     public function __construct()
     {
         parent::__construct();
-    }
-
-    /**
-     * @return array
-     */
-
-    protected function _LoadDates()
-    {
-        $dates = parent::_LoadDates();
-
-        setlocale(LC_ALL, 'it_IT.UTF-8');
-
-        // change defaults here
-        $dates['general_date'] = 'd/m/Y';
-        $dates['general_datetime'] = 'd/m/Y H:i:s';
-        $dates['schedule_daily'] = 'l, d/m/Y';
-        $dates['reservation_email'] = 'd/m/Y @ H:i (e)';
-        $dates['res_popup'] = 'd/m/Y H:i';
-        $dates['dashboard'] = 'l, d/m/Y H:i';
-        $dates['period_time'] = 'H:i';
-        $dates['general_date_js'] = 'dd/mm/yy';
-        $dates['short_datetime'] = 'j/n/y H:i';
-        $dates['schedule_daily'] = 'l, d/m/Y';
-        $dates['res_popup_time'] = 'D, d/n H:i';
-        $dates['short_reservation_date'] = 'j/n/y H:i';
-        $dates['mobile_reservation_date'] = 'j/n H:i';
-        $dates['general_time_js'] = 'H:mm';
-        $dates['momentjs_datetime'] = 'D/M/YY H:mm';
-        $dates['calendar_time'] = 'H:mm';
-        $dates['calendar_dates'] = 'd ' . (preg_replace('/(.)(.)(.)/i', '\$1\$2\$3', date('M')));
-        $dates['report_date'] = '%d/%m';
-
-        $this->Dates = $dates;
-        return $this->Dates;
     }
 
     protected function _LoadStrings()


### PR DESCRIPTION
The en_gb is now used as the default instead of en_us to correctly set the date formats. _loadDates() is removed from the italian translation since it's a duplicate of the one set in en_gb.

Closes: #1158