### PR TITLE
feat: OAuth trailing slash variable

### DIFF
--- a/Presenters/LoginPresenter.php
+++ b/Presenters/LoginPresenter.php
@@ -385,7 +385,11 @@ class LoginPresenter
     public function GetOauth2Url()
     {
         // Retrieve Oauth2 configuration values
-        $baseUrl = rtrim(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_URL_AUTHORIZE), '/');
+        $removeTrailingSlash = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_STRIP_TRAILING_SLASH);
+        $baseUrl = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_URL_AUTHORIZE);
+        if ($removeTrailingSlash) {
+            $baseUrl = rtrim($baseUrl, '/');
+        }
         $clientId = Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_CLIENT_ID);
         $redirectUri = $this->buildRedirectUri(Configuration::Instance()->GetKey(ConfigKeys::AUTHENTICATION_OAUTH2_REDIRECT_URI));
 

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -709,6 +709,8 @@ return [
             'oauth2.name' => 'OAuth2',
 
             # OAuth2 endpoint URLs and client credentials
+            # If true, the configured authorize URL's trailing slash is removed
+            'oauth2.strip.trailing.slash' => true,
             'oauth2.url.authorize' => '',
             'oauth2.url.token' => '',
             'oauth2.url.userinfo' => '',

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1491,6 +1491,14 @@ class ConfigKeys
         'description' => 'Display name for OAuth2 login',
         'section' => 'authentication'
     ];
+    public const AUTHENTICATION_OAUTH2_STRIP_TRAILING_SLASH = [
+        'key' => 'authentication.oauth2.strip.trailing.slash',
+        'type' => 'boolean',
+        'default' => true,
+        'label' => 'Removes authorize URL trailing slash',
+        'description' => 'When enabled, removes any trailing slash on the OAuth2 authorize URL; when disabled, preserves a trailing slash if present. Does not affect token or userinfo URLs.',
+        'section' => 'authentication'
+    ];
     public const AUTHENTICATION_OAUTH2_URL_AUTHORIZE = [
         'key' => 'authentication.oauth2.url.authorize',
         'type' => 'string',


### PR DESCRIPTION
Some OAuth2 provider need a trailing slash in the authorization URL. This changes let you choose if you want to cut or keep the trailing slash in oauth2 authorize URL.