### PR TITLE
chore(api): remove trailing slash in Authentication POSTs

### DIFF
--- a/Web/Services/index.php
+++ b/Web/Services/index.php
@@ -122,8 +122,8 @@ function RegisterAuthentication(SlimServer $server, SlimWebServiceRegistry $regi
     );
 
     $category = new SlimWebServiceRegistryCategory('Authentication');
-    $category->AddPost('SignOut/', [$webService, 'SignOut'], WebServices::Logout);
-    $category->AddPost('Authenticate/', [$webService, 'Authenticate'], WebServices::Login);
+    $category->AddPost('SignOut', [$webService, 'SignOut'], WebServices::Logout);
+    $category->AddPost('Authenticate', [$webService, 'Authenticate'], WebServices::Login);
     $registry->AddCategory($category);
 }
 


### PR DESCRIPTION
The AddPost() calls were using trailing slashes, which was confusing because the trailing slash would get trimmed off in SlimServiceRegistration. Remove the slashes.