### PR TITLE
docs(api): correct the responses for account actions

### DIFF
--- a/WebServices/AccountWebService.php
+++ b/WebServices/AccountWebService.php
@@ -45,7 +45,7 @@ class AccountWebService
      * @name CreateAccount
      * @description Creates a user account. This does not authenticate
      * @request CreateAccountRequest
-     * @response AccountCreatedResponse
+     * @response AccountActionResponse
      * @return void
      */
     public function Create()
@@ -86,7 +86,7 @@ class AccountWebService
      * @name UpdateAccount
      * @description Updates an existing user account
      * @request UpdateAccountRequest
-     * @response AccountUpdatedResponse
+     * @response AccountActionResponse
      * @return void
      */
     public function Update($userId)
@@ -119,7 +119,7 @@ class AccountWebService
      * @name UpdatePassword
      * @description Updates the password for an existing user
      * @request UpdateAccountPasswordRequest
-     * @response AccountUpdatedResponse
+     * @response AccountActionResponse
      * @return void
      */
     public function UpdatePassword($userId)

--- a/WebServices/Responses/Account/AccountActionResponse.php
+++ b/WebServices/Responses/Account/AccountActionResponse.php
@@ -20,6 +20,7 @@ class ExampleAccountActionResponse extends AccountActionResponse
 {
     public function __construct()
     {
+        $this->userId = 1;
         $this->AddLink('http://url/to/account', WebServices::GetAccount);
         $this->AddLink('http://url/to/update/account', WebServices::UpdateAccount);
     }

--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -230,7 +230,22 @@ CreateAccount
 
 **Response:**
 
-Unstructured response of type *AccountCreatedResponse*
+.. code:: json
+
+   {
+       "userId": 1,
+       "links": [
+           {
+               "href": "http://url/to/account",
+               "title": "get_user_account"
+           },
+           {
+               "href": "http://url/to/update/account",
+               "title": "update_user_account"
+           }
+       ],
+       "message": null
+   }
 
 **curl example:**
 
@@ -281,8 +296,24 @@ UpdateAccount
        ]
    }
 
-| **Response:**
-| Unstructured response of type *AccountUpdatedResponse*
+**Response:**
+
+.. code:: json
+
+   {
+       "userId": 1,
+       "links": [
+           {
+               "href": "http://url/to/account",
+               "title": "get_user_account"
+           },
+           {
+               "href": "http://url/to/update/account",
+               "title": "update_user_account"
+           }
+       ],
+       "message": null
+   }
 
 **curl example:**
 
@@ -323,7 +354,22 @@ Updates the password for an existing user
 
 **Response:**
 
-Unstructured response of type *AccountUpdatedResponse*
+.. code:: json
+
+   {
+       "userId": 1,
+       "links": [
+           {
+               "href": "http://url/to/account",
+               "title": "get_user_account"
+           },
+           {
+               "href": "http://url/to/update/account",
+               "title": "update_user_account"
+           }
+       ],
+       "message": null
+   }
 
 **curl example:**
 


### PR DESCRIPTION
Update the account web service response annotations to use the real `AccountActionResponse` type for create, update, and password update operations.