### PR TITLE
feat(install): add option to load large sample data in web installer

### DIFF
--- a/Pages/Install/InstallPage.php
+++ b/Pages/Install/InstallPage.php
@@ -68,16 +68,14 @@ interface IInstallPage
      */
     public function GetShouldCreateUser();
 
-    /**
-     * @return bool
-     */
-    public function GetShouldCreateSampleData();
+    public function GetShouldCreateSampleData(): bool;
+
+    public function GetShouldCreateLargeSampleData(): bool;
 
     /**
      * @param $results array|InstallationResult[]
-     * @return void
      */
-    public function SetInstallResults($results);
+    public function SetInstallResults($results): void;
 
     /**
      * @param $results array|InstallationResult[]
@@ -226,17 +224,22 @@ class InstallPage extends Page implements IInstallPage
         return isset($x) && $x == true;
     }
 
-    public function GetShouldCreateSampleData()
+    public function GetShouldCreateSampleData(): bool
     {
         $x = $this->GetForm('create_sample_data');
         return isset($x) && $x == true;
     }
 
+    public function GetShouldCreateLargeSampleData(): bool
+    {
+        $x = $this->GetForm('create_large_sample_data');
+        return isset($x) && $x == true;
+    }
+
     /**
      * @param $results array|InstallationResult[]
-     * @return void
      */
-    public function SetInstallResults($results)
+    public function SetInstallResults($results): void
     {
         $failure = false;
         foreach ($results as $result) {

--- a/Presenters/Install/InstallPresenter.php
+++ b/Presenters/Install/InstallPresenter.php
@@ -98,7 +98,12 @@ class InstallPresenter
     {
         $install = new Installer($this->page->GetInstallUser(), $this->page->GetInstallUserPassword());
 
-        $results = $install->InstallFresh($this->page->GetShouldCreateDatabase(), $this->page->GetShouldCreateUser(), $this->page->GetShouldCreateSampleData());
+        $results = $install->InstallFresh(
+            should_create_db: $this->page->GetShouldCreateDatabase(),
+            should_create_user: $this->page->GetShouldCreateUser(),
+            should_create_sample_data: $this->page->GetShouldCreateSampleData(),
+            should_create_large_sample_data: $this->page->GetShouldCreateLargeSampleData(),
+        );
         $install->ClearCachedTemplates();
 
         $this->page->SetInstallResults($results);

--- a/Presenters/Install/Installer.php
+++ b/Presenters/Install/Installer.php
@@ -19,13 +19,14 @@ class Installer
     }
 
     /**
-     * @param $should_create_db bool
-     * @param $should_create_user bool
-     * @param $should_create_sample_data bool
      * @return array|InstallationResult[]
      */
-    public function InstallFresh($should_create_db, $should_create_user, $should_create_sample_data)
-    {
+    public function InstallFresh(
+        bool $should_create_db,
+        bool $should_create_user,
+        bool $should_create_sample_data,
+        bool $should_create_large_sample_data = false,
+    ) {
         $results = [];
         $config = Configuration::Instance();
 
@@ -47,6 +48,9 @@ class Installer
         $populate_sample_data = new MySqlScript(ROOT_DIR . 'database_schema/sample-data-utf8.sql');
         $populate_sample_data->Replace('librebooking', $database_name);
 
+        $populate_large_sample_data = new MySqlScript(ROOT_DIR . 'database_schema/sample-data-large-utf8.sql');
+        $populate_large_sample_data->Replace('librebooking', $database_name);
+
         $create_schema = new MySqlScript(ROOT_DIR . 'database_schema/create-schema.sql');
         $populate_data = new MySqlScript(ROOT_DIR . 'database_schema/create-data.sql');
         $populate_data->Replace('America/New_York', $timezone);
@@ -65,11 +69,13 @@ class Installer
 
         $results[] = $this->ExecuteScript($hostname, $database_name, $this->user, $this->password, $populate_data);
 
-        /**
-         * Populate sample data given in /LibreBooking/database_schema/sample-data-utf8.sql
-         */
-        if ($should_create_sample_data) {
+        // Large sample data requires the small sample data to be installed first
+        if ($should_create_sample_data || $should_create_large_sample_data) {
             $results[] = $this->ExecuteScript($hostname, $database_name, $this->user, $this->password, $populate_sample_data);
+        }
+
+        if ($should_create_large_sample_data) {
+            $results[] = $this->ExecuteScript($hostname, $database_name, $this->user, $this->password, $populate_large_sample_data);
         }
 
         $results = array_merge($results, $upgradeResults);

--- a/database_schema/sample-data-large-utf8.sql
+++ b/database_schema/sample-data-large-utf8.sql
@@ -53,7 +53,7 @@ VALUES
 
 -- =============================================================================
 -- 3. User-Group Assignments
---    Each user in 1-2 groups; existing admin (id=2) added to Management
+--    Each user in 1-2 groups, existing admin (id=2) added to Management
 -- =============================================================================
 
 INSERT INTO `user_groups` (`user_id`, `group_id`) VALUES

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -820,6 +820,7 @@ class en_us extends Language
         $strings['CreateDatabase'] = 'Create the database';
         $strings['CreateDatabaseUser'] = 'Create the database user';
         $strings['PopulateExampleData'] = 'Import sample data. Creates admin account: admin/password and user account: user/password';
+        $strings['PopulateLargeExampleData'] = 'Also import large sample data. Adds more users, resources, groups, and reservations for realistic testing';
         $strings['DataWipeWarning'] = 'Warning: This will delete any existing data';
         $strings['RunInstallation'] = 'Run Installation';
         $strings['UpgradeNotice'] = 'You are upgrading from version <b>%s</b> to version <b>%s</b>';

--- a/tpl/Install/install.tpl
+++ b/tpl/Install/install.tpl
@@ -90,6 +90,12 @@
 											<label class="form-check-label" for="create_sample_data">
 												{translate key=PopulateExampleData}</label>
 										</div>
+										<div class="form-check ms-4">
+											<input class="form-check-input" type="checkbox" id="create_large_sample_data"
+												name="create_large_sample_data" />
+											<label class="form-check-label" for="create_large_sample_data">
+												{translate key=PopulateLargeExampleData}</label>
+										</div>
 									</div>
 								</li>
 								<div>
@@ -164,4 +170,22 @@
 </div>
 
 {include file="javascript-includes.tpl"}
+<script>
+	document.addEventListener('DOMContentLoaded', function () {
+		const sampleData = document.getElementById('create_sample_data');
+		const largeSampleData = document.getElementById('create_large_sample_data');
+		if (sampleData && largeSampleData) {
+			largeSampleData.addEventListener('change', function () {
+				if (this.checked) {
+					sampleData.checked = true;
+				}
+			});
+			sampleData.addEventListener('change', function () {
+				if (!this.checked) {
+					largeSampleData.checked = false;
+				}
+			});
+		}
+	});
+</script>
 {include file='globalfooter.tpl'}


### PR DESCRIPTION
Add a "large sample data" checkbox to the web install page, indented below the existing sample data checkbox. Checking it auto-checks the small sample data (which is a prerequisite); unchecking small sample data auto-unchecks large sample data.

Wire the new option through IInstallPage, InstallPresenter, and Installer so that sample-data-large-utf8.sql is executed after sample-data-utf8.sql when selected.

Fix a semicolon inside a SQL comment in sample-data-large-utf8.sql that broke the web installer's naive statement splitter.