### PR TITLE
refactor(domain): rename User::GetAllowedResourceIds() to GetFullAcce…

### DIFF
--- a/Domain/User.php
+++ b/Domain/User.php
@@ -397,7 +397,7 @@ class User
     /**
      * @return int[]
      */
-    public function GetAllowedResourceIds()
+    public function GetFullAccessResourceIds()
     {
         return $this->allowedResourceIds;
     }

--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -318,7 +318,7 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
 
         $user->ChangeAllowedPermissions(
             $this->resourcePermissionService->MergeWithPreservedPermissions(
-                existingIds: $user->GetAllowedResourceIds(),
+                existingIds: $user->GetFullAccessResourceIds(),
                 managedResourceIds: $managedResourceIds,
                 submittedIds: $permissionsByType['full'],
             )
@@ -379,7 +379,7 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
     public function GetUserResourcePermissions()
     {
         $user = $this->userRepository->LoadById($this->page->GetUserId());
-        return ['full' => $user->GetAllowedResourceIds(), 'view' => $user->GetAllowedViewResourceIds()];
+        return ['full' => $user->GetFullAccessResourceIds(), 'view' => $user->GetAllowedViewResourceIds()];
     }
 
     /**

--- a/WebServices/Responses/UserResponse.php
+++ b/WebServices/Responses/UserResponse.php
@@ -57,7 +57,7 @@ class UserResponse extends RestResponse
             }
         }
 
-        foreach ($user->GetAllowedResourceIds() as $allowedResourceId) {
+        foreach ($user->GetFullAccessResourceIds() as $allowedResourceId) {
             $this->permissions[] = new ResourceItemResponse($server, $allowedResourceId, '');
         }
 

--- a/tests/Domain/User/UserRepositoryTest.php
+++ b/tests/Domain/User/UserRepositoryTest.php
@@ -89,7 +89,7 @@ class UserRepositoryTest extends TestBase
 
         $this->assertEquals($row[ColumnNames::FIRST_NAME], $user->FirstName());
         $this->assertTrue($user->WantsEventEmail(new ReservationCreatedEvent()));
-        $this->assertContains($permissionsRows[1][ColumnNames::RESOURCE_ID], $user->GetAllowedResourceIds());
+        $this->assertContains($permissionsRows[1][ColumnNames::RESOURCE_ID], $user->GetFullAccessResourceIds());
         $this->assertEquals($row[ColumnNames::PHONE_NUMBER], $user->GetAttribute(UserAttribute::Phone));
 
         $row1 = $groupsRows[0];

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -150,7 +150,7 @@ class ManageUsersPresenterTest extends TestBase
 
         $this->presenter->ChangePermissions();
 
-        $actualFullAccess = $user->GetAllowedResourceIds();
+        $actualFullAccess = $user->GetFullAccessResourceIds();
         sort($expectedFullAccessIds);
         sort($actualFullAccess);
         $this->assertEquals($expectedFullAccessIds, $actualFullAccess);
@@ -193,7 +193,7 @@ class ManageUsersPresenterTest extends TestBase
 
         $this->presenter->ChangePermissions();
 
-        $actualFull = $user->GetAllowedResourceIds();
+        $actualFull = $user->GetFullAccessResourceIds();
         $actualView = $user->GetAllowedViewResourceIds();
         sort($actualFull);
         sort($actualView);


### PR DESCRIPTION
…ssResourceIds()

The old name was ambiguous since both full-access and view-only permissions are "allowed" in a sense. The new name clearly distinguishes it from GetAllowedViewResourceIds().

Only the User domain method and its callers were renamed. Page and controller methods with the same name were left unchanged as they serve a different purpose (reading form/API input).