### PR TITLE
refactor(domain): rename User::GetAllowedViewResourceIds() to GetViewAccessResourceIds()

### DIFF
--- a/Domain/User.php
+++ b/Domain/User.php
@@ -432,7 +432,7 @@ class User
     /**
      * @return int[]
      */
-    public function GetAllowedViewResourceIds()
+    public function GetViewAccessResourceIds()
     {
         return $this->viewableResourceIds;
     }

--- a/Presenters/Admin/ManageUsersPresenter.php
+++ b/Presenters/Admin/ManageUsersPresenter.php
@@ -325,7 +325,7 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
         );
         $user->ChangeViewPermissions(
             $this->resourcePermissionService->MergeWithPreservedPermissions(
-                existingIds: $user->GetAllowedViewResourceIds(),
+                existingIds: $user->GetViewAccessResourceIds(),
                 managedResourceIds: $managedResourceIds,
                 submittedIds: $permissionsByType['view'],
             )
@@ -374,12 +374,12 @@ class ManageUsersPresenter extends ActionPresenter implements IManageUsersPresen
     }
 
     /**
-     * @return int[] all resource ids the user has permission to
+     * @return array{full: int[], view: int[]}
      */
     public function GetUserResourcePermissions()
     {
         $user = $this->userRepository->LoadById($this->page->GetUserId());
-        return ['full' => $user->GetFullAccessResourceIds(), 'view' => $user->GetAllowedViewResourceIds()];
+        return ['full' => $user->GetFullAccessResourceIds(), 'view' => $user->GetViewAccessResourceIds()];
     }
 
     /**

--- a/tests/Presenters/Admin/ManageUsersPresenterTest.php
+++ b/tests/Presenters/Admin/ManageUsersPresenterTest.php
@@ -194,7 +194,7 @@ class ManageUsersPresenterTest extends TestBase
         $this->presenter->ChangePermissions();
 
         $actualFull = $user->GetFullAccessResourceIds();
-        $actualView = $user->GetAllowedViewResourceIds();
+        $actualView = $user->GetViewAccessResourceIds();
         sort($actualFull);
         sort($actualView);
         $this->assertEquals([1, 5], $actualFull);


### PR DESCRIPTION
Pairs with the earlier rename of GetAllowedResourceIds() to
GetFullAccessResourceIds(). The new names clearly distinguish the two
permission levels: GetFullAccessResourceIds() and
GetViewAccessResourceIds().
