### PR TITLE
fix(reservation): Resolve a crash when the email field is not an array

### DIFF
--- a/Pages/Ajax/ReservationEmailPage.php
+++ b/Pages/Ajax/ReservationEmailPage.php
@@ -52,7 +52,15 @@ class ReservationEmailPage extends Page implements IReservationEmailPage
 
     public function GetEmailAddresses()
     {
-        $email = implode(',', $this->GetForm('email'));
-        return preg_split('/, ?/', $email);
+        $email = $this->GetForm('email');
+
+        if (empty($email)) {
+            return [];
+        }
+
+        $list = is_array($email) ? $email : preg_split('/,/', $email, -1, PREG_SPLIT_NO_EMPTY);
+
+        return array_filter(array_map('trim', $list));
     }
+
 }


### PR DESCRIPTION
This addresses a potential crash by implementing a type-check for the email input before processing. The previous logic assumed the input was always an array, which caused errors when receiving strings or null values. The updated function now handles pre-formatted arrays, comma-separated strings (CSV) and a string. It also adds a guard clause for empty inputs.

Closes: #1182