### PR TITLE
chore(phpcsfixer): add 'node_modules/' to the ignore list

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,7 +11,7 @@ try {
 // https://symfony.com/doc/current/components/finder.html
 $finder = new PhpCsFixer\Finder();
 
-$finder->exclude(['.git', 'tpl_c', 'build', '.phpdoc', 'var', 'tools', 'vendor'])
+$finder->exclude(['.git', '.phpdoc', 'build', 'node_modules', 'tools', 'tpl_c', 'var', 'vendor'])
     ->notPath(['lib/external'])
     ->in(__DIR__);
 


### PR DESCRIPTION
Don't attempt to format files in the 'node_modules/' directory.