### PR TITLE
fix(webservice): respect configured inactivity timeout per session

### DIFF
--- a/Domain/Values/WebService/WebServiceExpiration.php
+++ b/Domain/Values/WebService/WebServiceExpiration.php
@@ -2,18 +2,11 @@
 
 class WebServiceExpiration
 {
-    private static $SESSION_LENGTH_IN_MINUTES = 30;
-
-    public function __construct()
-    {
-        self::$SESSION_LENGTH_IN_MINUTES = Configuration::Instance()->GetKey(ConfigKeys::INACTIVITY_TIMEOUT, new IntConverter());
-    }
-
     /**
      * @param string $expirationTime
      * @return bool
      */
-    public static function IsExpired($expirationTime)
+    public static function IsExpired(string $expirationTime): bool
     {
         return Date::Parse($expirationTime, 'UTC')->LessThan(Date::Now());
     }
@@ -21,8 +14,14 @@ class WebServiceExpiration
     /**
      * @return string
      */
-    public static function Create()
+    public static function Create(): string
     {
-        return Date::Now()->AddMinutes(self::$SESSION_LENGTH_IN_MINUTES)->ToUtc()->ToIso();
+        $minutes = Configuration::Instance()->GetKey(ConfigKeys::INACTIVITY_TIMEOUT, new IntConverter());
+        if ($minutes <= 0) {
+            Log::Error('Invalid inactivity.timeout value: %d. Falling back to default: %d', $minutes, ConfigKeys::INACTIVITY_TIMEOUT['default']);
+            $minutes = ConfigKeys::INACTIVITY_TIMEOUT['default'];
+        }
+
+        return Date::Now()->AddMinutes($minutes)->ToUtc()->ToIso();
     }
 }

--- a/tests/WebService/WebServiceUserSessionTest.php
+++ b/tests/WebService/WebServiceUserSessionTest.php
@@ -9,15 +9,21 @@ class WebServiceUserSessionTest extends TestBase
     public function setUp(): void
     {
         parent::setup();
+        $this->fakeConfig->SetKey(ConfigKeys::INACTIVITY_TIMEOUT, ConfigKeys::INACTIVITY_TIMEOUT['default']);
     }
 
     public function testExtendsSession()
     {
+        $now = Date::Create(2026, 3, 20, 12, 0, 0, 'UTC');
+        Date::_SetNow($now);
+
         $session = new WebServiceUserSession(123);
         $session->SessionExpiration = '2012-05-01';
         $session->ExtendSession();
 
-        $this->assertEquals(WebServiceExpiration::Create(), $session->SessionExpiration);
+        $expected = $now->AddMinutes(ConfigKeys::INACTIVITY_TIMEOUT['default'])->ToUtc()->ToIso();
+
+        $this->assertEquals($expected, $session->SessionExpiration);
     }
 
     public function testIsExpired()
@@ -35,4 +41,18 @@ class WebServiceUserSessionTest extends TestBase
 
         $this->assertFalse($session->IsExpired());
     }
+
+    public function testCreateUsesConfiguredTimeout()
+    {
+        $timeoutMinutes = 10080; // 7 days
+        $this->fakeConfig->SetKey(ConfigKeys::INACTIVITY_TIMEOUT, $timeoutMinutes);
+        $now = Date::Create(2026, 3, 20, 12, 0, 0, 'UTC');
+        Date::_SetNow($now);
+
+        $expiration = WebServiceExpiration::Create();
+        $expected = $now->AddMinutes($timeoutMinutes)->ToUtc()->ToIso();
+
+        $this->assertEquals($expected, $expiration);
+    }
+
 }


### PR DESCRIPTION
Compute web service session expiration from the current inactivity timeout configuration on each call instead of relying on mutable static state.

Add tests covering both configured and default timeout behavior for web service session expiration.