### PR TITLE
fix(email): populate resource custom attribute values when loading re…

### DIFF
--- a/Domain/Access/ReservationRepository.php
+++ b/Domain/Access/ReservationRepository.php
@@ -351,7 +351,7 @@ class ReservationRepository implements IReservationRepository
             $resources[] = $resource;
         }
         $reader->Free();
-        
+
         // get all reservation resources attributes
         foreach ($resources as $resource) {
             $attributeCommand = new GetAttributeValuesCommand(

--- a/Domain/Access/ReservationRepository.php
+++ b/Domain/Access/ReservationRepository.php
@@ -340,7 +340,7 @@ class ReservationRepository implements IReservationRepository
         // get all reservation resources
         $getResourcesCommand = new GetReservationResourcesCommand($series->SeriesId());
         $reader = ServiceLocator::GetDatabase()->Query($getResourcesCommand);
-        $resources = [];
+
         while ($row = $reader->GetRow()) {
             $resource = BookableResource::Create($row);
             if ($row[ColumnNames::RESOURCE_LEVEL_ID] == ResourceLevel::Primary) {
@@ -348,12 +348,6 @@ class ReservationRepository implements IReservationRepository
             } else {
                 $series->WithResource($resource);
             }
-            $resources[] = $resource;
-        }
-        $reader->Free();
-
-        // get all reservation resources attributes
-        foreach ($resources as $resource) {
             $attributeCommand = new GetAttributeValuesCommand(
                 $resource->GetId(),
                 CustomAttributeCategory::RESOURCE
@@ -367,6 +361,7 @@ class ReservationRepository implements IReservationRepository
             }
             $attributeReader->Free();
         }
+        $reader->Free();
     }
 
     private function PopulateParticipants(ExistingReservationSeries $series)

--- a/Domain/Access/ReservationRepository.php
+++ b/Domain/Access/ReservationRepository.php
@@ -340,6 +340,7 @@ class ReservationRepository implements IReservationRepository
         // get all reservation resources
         $getResourcesCommand = new GetReservationResourcesCommand($series->SeriesId());
         $reader = ServiceLocator::GetDatabase()->Query($getResourcesCommand);
+        $resources = [];
         while ($row = $reader->GetRow()) {
             $resource = BookableResource::Create($row);
             if ($row[ColumnNames::RESOURCE_LEVEL_ID] == ResourceLevel::Primary) {
@@ -347,8 +348,25 @@ class ReservationRepository implements IReservationRepository
             } else {
                 $series->WithResource($resource);
             }
+            $resources[] = $resource;
         }
         $reader->Free();
+        
+        // get all reservation resources attributes
+        foreach ($resources as $resource) {
+            $attributeCommand = new GetAttributeValuesCommand(
+                $resource->GetId(),
+                CustomAttributeCategory::RESOURCE
+            );
+            $attributeReader = ServiceLocator::GetDatabase()->Query($attributeCommand);
+            while ($attributeRow = $attributeReader->GetRow()) {
+                $resource->WithAttribute(new AttributeValue(
+                    $attributeRow[ColumnNames::ATTRIBUTE_ID],
+                    $attributeRow[ColumnNames::ATTRIBUTE_VALUE]
+                ));
+            }
+            $attributeReader->Free();
+        }
     }
 
     private function PopulateParticipants(ExistingReservationSeries $series)

--- a/tests/Domain/Reservation/ReservationRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationRepositoryTest.php
@@ -560,9 +560,18 @@ class ReservationRepositoryTest extends TestBase
         $resourceAttrValue = 'resource-attr-value';
 
         $reservationRow = new ReservationRow(
-            $reservationId, $begin, $end, 'title', 'desc',
-            RepeatType::None, '', $referenceNumber, $seriesId,
-            $ownerId, ReservationStatus::Created, true
+            $reservationId,
+            $begin,
+            $end,
+            'title',
+            'desc',
+            RepeatType::None,
+            '',
+            $referenceNumber,
+            $seriesId,
+            $ownerId,
+            ReservationStatus::Created,
+            true
         );
 
         $reservationInstanceRow = new ReservationInstanceRow($seriesId);

--- a/tests/Domain/Reservation/ReservationRepositoryTest.php
+++ b/tests/Domain/Reservation/ReservationRepositoryTest.php
@@ -502,12 +502,16 @@ class ReservationRepositoryTest extends TestBase
         $this->db->SetRow(0, $reservationRow->Rows());
         $this->db->SetRow(1, $reservationInstanceRow->Rows());
         $this->db->SetRow(2, $reservationResourceRow->Rows());
-        $this->db->SetRow(3, $reservationUserRow->Rows());
-        $this->db->SetRow(4, $reservationAccessoryRow->Rows());
-        $this->db->SetRow(5, $attributeValueRow->Rows());
-        $this->db->SetRow(6, $attachmentRow->Rows());
-        $this->db->SetRow(7, $reminderRow->Rows());
-        $this->db->SetRow(8, $guestRow->Rows());
+        // Rows 3-5: resource attribute value queries (one per resource, empty results)
+        $this->db->SetRow(3, []);
+        $this->db->SetRow(4, []);
+        $this->db->SetRow(5, []);
+        $this->db->SetRow(6, $reservationUserRow->Rows());
+        $this->db->SetRow(7, $reservationAccessoryRow->Rows());
+        $this->db->SetRow(8, $attributeValueRow->Rows());
+        $this->db->SetRow(9, $attachmentRow->Rows());
+        $this->db->SetRow(10, $reminderRow->Rows());
+        $this->db->SetRow(11, $guestRow->Rows());
 
         $actualReservation = $this->repository->LoadById($reservationId);
 
@@ -516,6 +520,9 @@ class ReservationRepositoryTest extends TestBase
         $getReservation = new GetReservationByIdCommand($reservationId);
         $getInstances = new GetReservationSeriesInstances($seriesId);
         $getResources = new GetReservationResourcesCommand($seriesId);
+        $getResourceAttributes1 = new GetAttributeValuesCommand($resourceId, CustomAttributeCategory::RESOURCE);
+        $getResourceAttributes2 = new GetAttributeValuesCommand($resourceId1, CustomAttributeCategory::RESOURCE);
+        $getResourceAttributes3 = new GetAttributeValuesCommand($resourceId2, CustomAttributeCategory::RESOURCE);
         $getParticipants = new GetReservationSeriesParticipantsCommand($seriesId);
         $getAccessories = new GetReservationAccessoriesCommand($seriesId);
         $getAttributeValues = new GetAttributeValuesCommand($seriesId, CustomAttributeCategory::RESERVATION);
@@ -526,12 +533,62 @@ class ReservationRepositoryTest extends TestBase
         $this->assertTrue($this->db->ContainsCommand($getReservation));
         $this->assertTrue($this->db->ContainsCommand($getInstances));
         $this->assertTrue($this->db->ContainsCommand($getResources));
+        $this->assertTrue($this->db->ContainsCommand($getResourceAttributes1));
+        $this->assertTrue($this->db->ContainsCommand($getResourceAttributes2));
+        $this->assertTrue($this->db->ContainsCommand($getResourceAttributes3));
         $this->assertTrue($this->db->ContainsCommand($getParticipants));
         $this->assertTrue($this->db->ContainsCommand($getAccessories));
         $this->assertTrue($this->db->ContainsCommand($getAttributeValues));
         $this->assertTrue($this->db->ContainsCommand($getAttachments));
         $this->assertTrue($this->db->ContainsCommand($getReminders));
         $this->assertTrue($this->db->ContainsCommand($getGuests));
+    }
+
+    public function testLoadByIdPopulatesResourceCustomAttributeValues()
+    {
+        $seriesId = 10;
+        $reservationId = 1;
+        $referenceNumber = 'refnum';
+        $ownerId = 10;
+        $resourceId = 100;
+        $scheduleId = 1000;
+        $begin = '2010-01-05 12:30:00';
+        $end = '2010-01-05 18:30:00';
+        $duration = DateRange::Create($begin, $end, 'UTC');
+
+        $resourceAttrId = 50;
+        $resourceAttrValue = 'resource-attr-value';
+
+        $reservationRow = new ReservationRow(
+            $reservationId, $begin, $end, 'title', 'desc',
+            RepeatType::None, '', $referenceNumber, $seriesId,
+            $ownerId, ReservationStatus::Created, true
+        );
+
+        $reservationInstanceRow = new ReservationInstanceRow($seriesId);
+        $reservationInstanceRow->WithInstance($reservationId, $referenceNumber, $duration);
+
+        $reservationResourceRow = new ReservationResourceRow($reservationId, scheduleId: $scheduleId);
+        $reservationResourceRow->WithPrimary($resourceId);
+
+        $resourceAttributeRow = new CustomAttributeValueRow();
+        $resourceAttributeRow->With($resourceAttrId, $resourceAttrValue);
+
+        $this->db->SetRow(0, $reservationRow->Rows());
+        $this->db->SetRow(1, $reservationInstanceRow->Rows());
+        $this->db->SetRow(2, $reservationResourceRow->Rows());
+        $this->db->SetRow(3, $resourceAttributeRow->Rows()); // resource attribute values
+        $this->db->SetRow(4, []); // participants
+        $this->db->SetRow(5, []); // accessories
+        $this->db->SetRow(6, []); // reservation attribute values
+        $this->db->SetRow(7, []); // attachments
+        $this->db->SetRow(8, []); // reminders
+        $this->db->SetRow(9, []); // guests
+
+        $actualReservation = $this->repository->LoadById($reservationId);
+
+        $primaryResource = $actualReservation->Resource();
+        $this->assertEquals($resourceAttrValue, $primaryResource->GetAttributeValue($resourceAttrId));
     }
 
     public function testChangingOnlySharedInformationForFullSeriesJustUpdatesSeriesTable()


### PR DESCRIPTION
…servation from DB

When loading an existing reservation series via ReservationRepository (e.g. the Email button flow), BookableResource objects were created with empty attributes. This caused all resource custom attribute values to appear blank in reservation emails, even though the attribute labels were visible.

Fix: collect resources in PopulateResources() and run GetAttributeValuesCommand for each one, mirroring the logic already used in ResourceRepository::LoadById(). This ensures attribute values are populated.

Closes: #1194