### PR TITLE
fix(auth): use per-user database language when no language cookie is set

### DIFF
--- a/lib/Common/Resources.php
+++ b/lib/Common/Resources.php
@@ -257,9 +257,14 @@ class Resources implements IResourceLocalization
         $cookie = ServiceLocator::GetServer()->GetCookie(CookieKeys::LANGUAGE);
         if ($cookie != null) {
             return $cookie;
-        } else {
-            return Configuration::Instance()->GetKey(ConfigKeys::DEFAULT_LANGUAGE);
         }
+
+        $userSession = ServiceLocator::GetServer()->GetUserSession();
+        if ($this->IsLanguageSupported($userSession->LanguageCode)) {
+            return $userSession->LanguageCode;
+        }
+
+        return Configuration::Instance()->GetKey(ConfigKeys::DEFAULT_LANGUAGE);
     }
 
     private function LoadAvailableLanguages()

--- a/tests/Domain/Resource/ResourcesTest.php
+++ b/tests/Domain/Resource/ResourcesTest.php
@@ -48,6 +48,51 @@ class ResourcesTest extends TestBase
         $this->assertEquals($langFile, $this->Resources->LanguageFile);
     }
 
+    public function testLanguageIsLoadedFromUserSessionWhenNoCookie()
+    {
+        $lang = 'de_de';
+        $langFile = 'de_de.php';
+
+        $userSession = new FakeUserSession();
+        $userSession->LanguageCode = $lang;
+        $this->fakeServer->SetUserSession($userSession);
+
+        $this->Resources = Resources::GetInstance();
+
+        $this->assertEquals($lang, $this->Resources->CurrentLanguage);
+        $this->assertEquals($langFile, $this->Resources->LanguageFile);
+    }
+
+    public function testCookieLanguageTakesPriorityOverUserSession()
+    {
+        $cookieLang = 'en_us';
+
+        $langCookie = new Cookie(CookieKeys::LANGUAGE, $cookieLang, time(), '/');
+        $this->fakeServer->SetCookie($langCookie);
+
+        $userSession = new FakeUserSession();
+        $userSession->LanguageCode = 'de_de';
+        $this->fakeServer->SetUserSession($userSession);
+
+        $this->Resources = Resources::GetInstance();
+
+        $this->assertEquals($cookieLang, $this->Resources->CurrentLanguage);
+    }
+
+    public function testUnsupportedSessionLanguageFallsBackToConfigDefault()
+    {
+        $defaultLang = 'en_us';
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, $defaultLang);
+
+        $userSession = new FakeUserSession();
+        $userSession->LanguageCode = 'xx_invalid';
+        $this->fakeServer->SetUserSession($userSession);
+
+        $this->Resources = Resources::GetInstance();
+
+        $this->assertEquals($defaultLang, $this->Resources->CurrentLanguage);
+    }
+
     public function testLanguageIsLoadedCorrectlyWhenSet()
     {
         $langFile = 'en_us.php';


### PR DESCRIPTION
Resources::GetLanguageCode() only checked the language cookie and the config default when determining the UI language. The user's language preference from the database was loaded into UserSession->LanguageCode during login but never consulted by Resources.

This meant SSO users (Shibboleth, CAS, SAML, etc.) who bypass the login page never had a language cookie set, so their per-user database language preference was ignored.

Add the user session's LanguageCode as a fallback in GetLanguageCode(), between the cookie and the config default. The value is validated with IsLanguageSupported() so unsupported or legacy values in the database fall through to the config default safely.

Precedence: cookie (explicit user choice) > session/DB > config default.

Closes: #1027