### PR TITLE
fix(email): restore submitter language after sending approval notific…

### DIFF
--- a/lib/Application/Reservation/Notification/AdminEmailNotification.php
+++ b/lib/Application/Reservation/Notification/AdminEmailNotification.php
@@ -73,9 +73,10 @@ abstract class AdminEmailNotification implements IReservationNotification
                 continue;
             }
             $adminIds[$id] = true;
-
+            $originalLanguage = Resources::GetInstance()->CurrentLanguage;
             $message = $this->GetMessage($admin, $owner, $reservationSeries, $resource);
             ServiceLocator::GetEmailService()->Send($message);
+            Resources::GetInstance()->SetLanguage($originalLanguage);
         }
     }
 

--- a/lib/Application/Reservation/Notification/AdminEmailNotification.php
+++ b/lib/Application/Reservation/Notification/AdminEmailNotification.php
@@ -65,9 +65,9 @@ abstract class AdminEmailNotification implements IReservationNotification
         $resource = $reservationSeries->Resource();
 
         $adminIds = [];
-        /** @var UserDto $admin */
         $resources = Resources::GetInstance();
         $originalLanguage = Resources::GetInstance()->CurrentLanguage;
+        /** @var UserDto $admin */
         foreach ($admins as $admin) {
             $id = $admin->Id();
             if (array_key_exists($id, $adminIds) || $id == $owner->Id()) {

--- a/lib/Application/Reservation/Notification/AdminEmailNotification.php
+++ b/lib/Application/Reservation/Notification/AdminEmailNotification.php
@@ -66,6 +66,7 @@ abstract class AdminEmailNotification implements IReservationNotification
 
         $adminIds = [];
         /** @var UserDto $admin */
+        $resources = Resources::GetInstance();
         $originalLanguage = Resources::GetInstance()->CurrentLanguage;
         foreach ($admins as $admin) {
             $id = $admin->Id();
@@ -79,7 +80,7 @@ abstract class AdminEmailNotification implements IReservationNotification
                 $message = $this->GetMessage($admin, $owner, $reservationSeries, $resource);
                 ServiceLocator::GetEmailService()->Send($message);
             } finally {
-                Resources::GetInstance()->SetLanguage($originalLanguage);
+                $resources->SetLanguage($originalLanguage);
             }
 
         }

--- a/lib/Application/Reservation/Notification/AdminEmailNotification.php
+++ b/lib/Application/Reservation/Notification/AdminEmailNotification.php
@@ -66,7 +66,7 @@ abstract class AdminEmailNotification implements IReservationNotification
 
         $adminIds = [];
         $resources = Resources::GetInstance();
-        $originalLanguage = Resources::GetInstance()->CurrentLanguage;
+        $originalLanguage = $resources->CurrentLanguage;
         /** @var UserDto $admin */
         foreach ($admins as $admin) {
             $id = $admin->Id();

--- a/lib/Application/Reservation/Notification/AdminEmailNotification.php
+++ b/lib/Application/Reservation/Notification/AdminEmailNotification.php
@@ -66,6 +66,7 @@ abstract class AdminEmailNotification implements IReservationNotification
 
         $adminIds = [];
         /** @var UserDto $admin */
+        $originalLanguage = Resources::GetInstance()->CurrentLanguage;
         foreach ($admins as $admin) {
             $id = $admin->Id();
             if (array_key_exists($id, $adminIds) || $id == $owner->Id()) {
@@ -73,10 +74,14 @@ abstract class AdminEmailNotification implements IReservationNotification
                 continue;
             }
             $adminIds[$id] = true;
-            $originalLanguage = Resources::GetInstance()->CurrentLanguage;
-            $message = $this->GetMessage($admin, $owner, $reservationSeries, $resource);
-            ServiceLocator::GetEmailService()->Send($message);
-            Resources::GetInstance()->SetLanguage($originalLanguage);
+
+            try {
+                $message = $this->GetMessage($admin, $owner, $reservationSeries, $resource);
+                ServiceLocator::GetEmailService()->Send($message);
+            } finally {
+                Resources::GetInstance()->SetLanguage($originalLanguage);
+            }
+
         }
     }
 

--- a/lib/Email/EmailMessage.php
+++ b/lib/Email/EmailMessage.php
@@ -26,7 +26,7 @@ abstract class EmailMessage implements IEmailMessage
         }
         $this->email = new SmartyPage($resources); // now picks up correct language directory
         if (!empty($languageCode)) {
-            $this->Set('CurrentLanguage', $languageCode); // Set() only called AFTER $this->email exists
+            $this->Set('CurrentLanguage', $resources->CurrentLanguage);
         }
         $this->Set('ScriptUrl', Configuration::Instance()->GetScriptUrl());
         $this->Set('Charset', $resources->Charset);

--- a/lib/Email/EmailMessage.php
+++ b/lib/Email/EmailMessage.php
@@ -21,12 +21,13 @@ abstract class EmailMessage implements IEmailMessage
     {
         $this->enforceCustomTemplate = Configuration::Instance()->GetKey(ConfigKeys::EMAIL_ENFORCE_CUSTOM_TEMPLATE, new BooleanConverter());
         $resources = Resources::GetInstance();
-        $this->email = new SmartyPage($resources);
         if (!empty($languageCode)) {
-            $resources->SetLanguage($languageCode);
-            $this->Set('CurrentLanguage', $languageCode);
+            $resources->SetLanguage($languageCode); // switch BEFORE SmartyPage is created
         }
-
+        $this->email = new SmartyPage($resources); // now picks up correct language directory
+        if (!empty($languageCode)) {
+            $this->Set('CurrentLanguage', $languageCode); // Set() only called AFTER $this->email exists
+        }
         $this->Set('ScriptUrl', Configuration::Instance()->GetScriptUrl());
         $this->Set('Charset', $resources->Charset);
         $appTitle = Configuration::Instance()->GetKey(ConfigKeys::APP_TITLE);

--- a/tests/fakes/FakeResources.php
+++ b/tests/fakes/FakeResources.php
@@ -51,6 +51,9 @@ class FakeResources extends Resources
 
     public function SetLanguage($languageCode)
     {
+        if (!empty($languageCode)) {
+            $this->CurrentLanguage = strtolower($languageCode);
+        }
         return $this->_SetCurrentLanguageResult;
     }
 }


### PR DESCRIPTION
…ation emails

Two issues caused the confirmation modal and approval emails to render in the wrong language when resource approval notifications are enabled:

1. EmailMessage::__construct() was creating SmartyPage before calling SetLanguage(), so the template directory was locked to the submitter's language regardless of the recipient's language. Fixed by calling SetLanguage() before instantiating SmartyPage, ensuring the correct language directory is used for the email body.

2. EmailMessage::__construct() was changing the Resources language but never restoring it. Fixed by saving and restoring the submitter's language around each admin email send in AdminEmailNotification::Notify(), ensuring the confirmation modal renders in the submitter's language after the notification loop.

Closes: #701