### PR TITLE
feat(i18n): add language selector to navbar

### DIFF
--- a/Pages/Ajax/ChangeLanguagePage.php
+++ b/Pages/Ajax/ChangeLanguagePage.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once(ROOT_DIR . 'Pages/SecurePage.php');
+require_once(ROOT_DIR . 'Presenters/ChangeLanguagePresenter.php');
+
+class ChangeLanguagePage extends SecurePage implements IChangeLanguagePage
+{
+    private ChangeLanguagePresenter $presenter;
+
+    public function __construct()
+    {
+        parent::__construct('', 1);
+
+        $this->presenter = new ChangeLanguagePresenter(
+            page: $this,
+            userRepository: new UserRepository(),
+        );
+    }
+
+    public function PageLoad(): void
+    {
+        $this->EnforceCSRFCheck();
+        $this->presenter->PageLoad();
+    }
+
+    public function GetLanguageCode(): ?string
+    {
+        return $this->GetForm(FormKeys::LANGUAGE);
+    }
+
+    public function SetSuccessResponse(): void
+    {
+        $this->SetJson(['success' => true]);
+    }
+
+    public function SetErrorResponse(string $message): void
+    {
+        $this->SetJson(['success' => false], [$message]);
+    }
+}

--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -46,6 +46,7 @@ abstract class Page implements IPage
         $this->smarty->assign('Timezone', $userSession->Timezone);
         $this->smarty->assign('Charset', $resources->Charset);
         $this->smarty->assign('CurrentLanguage', $resources->CurrentLanguage);
+        $this->smarty->assign('AvailableLanguages', $resources->AvailableLanguages);
         $this->smarty->assign('HtmlLang', $resources->HtmlLang);
         $this->smarty->assign('HtmlTextDirection', $resources->TextDirection);
         $appTitle = Configuration::Instance()->GetKey(ConfigKeys::APP_TITLE);
@@ -59,6 +60,7 @@ abstract class Page implements IPage
         $this->smarty->assign('CalendarJSFile', $resources->CalendarLanguageFile);
 
         $this->smarty->assign('LoggedIn', $userSession->IsLoggedIn());
+        $this->smarty->assign('CSRFToken', $userSession->CSRFToken);
         $this->smarty->assign('Version', Configuration::VERSION);
         $this->smarty->assign('DisplayVersion', $this->GetDisplayVersion());
         $this->smarty->assign('Path', $this->path);

--- a/Presenters/ChangeLanguagePresenter.php
+++ b/Presenters/ChangeLanguagePresenter.php
@@ -1,0 +1,53 @@
+<?php
+
+require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+require_once(ROOT_DIR . 'lib/Common/namespace.php');
+
+interface IChangeLanguagePage
+{
+    public function GetLanguageCode(): ?string;
+
+    public function SetSuccessResponse(): void;
+
+    public function SetErrorResponse(string $message): void;
+}
+
+class ChangeLanguagePresenter
+{
+    public function __construct(
+        private IChangeLanguagePage $page,
+        private IUserRepository $userRepository,
+    ) {
+    }
+
+    public function PageLoad(): void
+    {
+        $languageCode = $this->page->GetLanguageCode();
+        $resources = Resources::GetInstance();
+
+        if (empty($languageCode) || !$resources->IsLanguageSupported($languageCode)) {
+            $this->page->SetErrorResponse('Invalid language');
+            return;
+        }
+
+        $resources->SetLanguage($languageCode);
+
+        ServiceLocator::GetServer()->SetCookie(
+            new Cookie(CookieKeys::LANGUAGE, $languageCode, secure: false)
+        );
+
+        $server = ServiceLocator::GetServer();
+        $userSession = $server->GetUserSession();
+
+        if ($userSession->IsLoggedIn()) {
+            $userSession->LanguageCode = $languageCode;
+            $server->SetUserSession($userSession);
+
+            $user = $this->userRepository->LoadById($userSession->UserId);
+            $user->ChangeLanguage($languageCode);
+            $this->userRepository->Update($user);
+        }
+
+        $this->page->SetSuccessResponse();
+    }
+}

--- a/Web/ajax/change_language.php
+++ b/Web/ajax/change_language.php
@@ -1,0 +1,8 @@
+<?php
+
+define('ROOT_DIR', '../../');
+
+require_once(ROOT_DIR . 'Pages/Ajax/ChangeLanguagePage.php');
+
+$page = new ChangeLanguagePage();
+$page->PageLoad();

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -194,6 +194,40 @@ Frontend Advanced Settings
 
      'name.format' => '{first} {last}',
 
+Language Selector
+~~~~~~~~~~~~~~~~~
+
+When logged in, users see a globe icon in the navigation bar that lets them
+switch the UI language. The dropdown lists all languages defined in
+``lang/AvailableLanguages.php``.
+
+**Limiting available languages**
+  To offer only a subset of languages (for example, only Spanish and English),
+  edit ``lang/AvailableLanguages.php`` and comment out the languages you do not
+  need:
+
+  .. code-block:: php
+
+     return [
+         // 'de_de' => new AvailableLanguage('de_de', 'de_de.php', 'Deutsch'),
+         'en_us' => new AvailableLanguage('en_us', 'en_us.php', 'English US'),
+         'es' => new AvailableLanguage('es', 'es.php', 'Español'),
+         // 'fr_fr' => new AvailableLanguage('fr_fr', 'fr_fr.php', 'Français'),
+         // ...
+     ];
+
+.. important::
+
+   The ``default.language`` value in ``config/config.php`` must be one of the
+   languages listed in ``lang/AvailableLanguages.php``. If you comment out a
+   language from that file, make sure it is not set as the default language in
+   your configuration. Otherwise translated strings are likely to display as
+   ``?``.
+
+**Hiding the language selector entirely**
+  If only one language remains in the list, the language selector is
+  automatically hidden from the navigation bar.
+
 Page Control
 ~~~~~~~~~~~~
 

--- a/tests/Presenters/ChangeLanguagePresenterTest.php
+++ b/tests/Presenters/ChangeLanguagePresenterTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'Presenters/ChangeLanguagePresenter.php');
+require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+
+class ChangeLanguagePresenterTest extends TestBase
+{
+    private FakeChangeLanguagePage $page;
+    private FakeUserRepository $userRepository;
+    private ChangeLanguagePresenter $presenter;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->fakeResources->AvailableLanguages = [
+            'en_us' => new AvailableLanguage('en_us', 'en_us.php', 'English US'),
+            'de_de' => new AvailableLanguage('de_de', 'de_de.php', 'Deutsch'),
+            'fr_fr' => new AvailableLanguage('fr_fr', 'fr_fr.php', 'Français'),
+        ];
+
+        $this->page = new FakeChangeLanguagePage();
+        $this->userRepository = new FakeUserRepository();
+        $this->presenter = new ChangeLanguagePresenter(
+            page: $this->page,
+            userRepository: $this->userRepository,
+        );
+    }
+
+    public function testChangesLanguageCookieAndSessionAndPersistsToDatabase()
+    {
+        $userId = 42;
+        $newLang = 'de_de';
+
+        $userSession = new FakeUserSession();
+        $userSession->UserId = $userId;
+        $this->fakeServer->SetUserSession($userSession);
+
+        $fakeUser = new FakeUser($userId);
+        $this->userRepository->_User = $fakeUser;
+
+        $this->page->_LanguageCode = $newLang;
+
+        $this->presenter->PageLoad();
+
+        $this->assertTrue($this->page->_SuccessCalled);
+        $this->assertFalse($this->page->_ErrorCalled);
+
+        $cookie = $this->fakeServer->GetCookie(CookieKeys::LANGUAGE);
+        $this->assertEquals($newLang, $cookie);
+
+        $updatedSession = $this->fakeServer->GetUserSession();
+        $this->assertEquals($newLang, $updatedSession->LanguageCode);
+
+        $this->assertNotNull($this->userRepository->_UpdatedUser);
+        $this->assertEquals($newLang, $this->userRepository->_UpdatedUser->Language());
+    }
+
+    public function testReturnsErrorForUnsupportedLanguage()
+    {
+        $this->page->_LanguageCode = 'xx_xx';
+
+        $this->presenter->PageLoad();
+
+        $this->assertTrue($this->page->_ErrorCalled);
+        $this->assertFalse($this->page->_SuccessCalled);
+        $this->assertNull($this->userRepository->_UpdatedUser);
+    }
+
+    public function testReturnsErrorForEmptyLanguage()
+    {
+        $this->page->_LanguageCode = '';
+
+        $this->presenter->PageLoad();
+
+        $this->assertTrue($this->page->_ErrorCalled);
+        $this->assertFalse($this->page->_SuccessCalled);
+    }
+
+    public function testReturnsErrorForNullLanguage()
+    {
+        $this->page->_LanguageCode = null;
+
+        $this->presenter->PageLoad();
+
+        $this->assertTrue($this->page->_ErrorCalled);
+        $this->assertFalse($this->page->_SuccessCalled);
+    }
+}
+
+class FakeChangeLanguagePage implements IChangeLanguagePage
+{
+    public ?string $_LanguageCode = null;
+    public bool $_SuccessCalled = false;
+    public bool $_ErrorCalled = false;
+    public ?string $_ErrorMessage = null;
+
+    public function GetLanguageCode(): ?string
+    {
+        return $this->_LanguageCode;
+    }
+
+    public function SetSuccessResponse(): void
+    {
+        $this->_SuccessCalled = true;
+    }
+
+    public function SetErrorResponse(string $message): void
+    {
+        $this->_ErrorCalled = true;
+        $this->_ErrorMessage = $message;
+    }
+}

--- a/tests/fakes/FakeResources.php
+++ b/tests/fakes/FakeResources.php
@@ -56,4 +56,9 @@ class FakeResources extends Resources
         }
         return $this->_SetCurrentLanguageResult;
     }
+
+    public function IsLanguageSupported($languageCode)
+    {
+        return !empty($languageCode) && array_key_exists($languageCode, $this->AvailableLanguages);
+    }
 }

--- a/tpl/globalfooter.tpl
+++ b/tpl/globalfooter.tpl
@@ -10,6 +10,26 @@
 
 	<script type="text/javascript">
 		init();
+
+		{if isset($LoggedIn) && $LoggedIn && count($AvailableLanguages) > 1}
+			$('#languageDropdownMenu').on('click', 'a[data-lang-code]', function(e) {
+				e.preventDefault();
+				var langCode = $(this).data('lang-code');
+				var csrfToken = '{$CSRFToken|escape:'javascript'}';
+				$.post('{$Path|escape:'javascript'}ajax/change_language.php', {
+					'{FormKeys::LANGUAGE}': langCode,
+					'{FormKeys::CSRF_TOKEN}': csrfToken
+				}, 'json').done(function(data) {
+					if (data && data.success) {
+						window.location.reload();
+					} else {
+						console.error('Language change failed', data);
+					}
+				}).fail(function(jqXHR, textStatus, errorThrown) {
+					console.error('Language change request failed', textStatus, errorThrown);
+				});
+			});
+		{/if}
 	</script>
 
 	{if !empty($GoogleAnalyticsTrackingId)}

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -386,6 +386,25 @@
                                 </ul>
                             </li>
                         {/if}
+                        {if isset($LoggedIn) && $LoggedIn && count($AvailableLanguages) > 1}
+                            <li class="nav-item dropdown" id="navLanguageDropdown">
+                                <a href="#" class="nav-link link-primary dropdown-toggle" role="button"
+                                    data-bs-toggle="dropdown" aria-label="{translate key=ChangeLanguage}" title="{translate key=ChangeLanguage}">
+                                    <span class="visually-hidden">{translate key=ChangeLanguage}</span>
+                                    <i class="bi bi-globe-americas" aria-hidden="true"></i>
+                                </a>
+                                <ul class="dropdown-menu dropdown-menu-end" id="languageDropdownMenu" style="max-height: 70vh; overflow-y: auto; min-width: 14rem;">
+                                    {foreach from=$AvailableLanguages item=lang}
+                                        <li>
+                                            <a class="dropdown-item {if $CurrentLanguage == $lang->GetLanguageCode()}active{/if}"
+                                                href="#" data-lang-code="{$lang->GetLanguageCode()}">
+                                                {$lang->GetDisplayName()}
+                                            </a>
+                                        </li>
+                                    {/foreach}
+                                </ul>
+                            </li>
+                        {/if}
                         <li class="nav-item dropdown" id="navHelpDropdown">
                             <a href="#" class="nav-link link-primary dropdown-toggle" role="button"
                                 data-bs-toggle="dropdown">{translate key="Help"}</a>


### PR DESCRIPTION
Add a globe icon dropdown to the navigation bar that allows logged-in users to change their UI language from any page, not just the login page. This is especially useful for SSO users who bypass the login page and previously had no way to change their language.

When a language is selected:
- The language cookie is set (immediate effect)
- The user session is updated in memory
- The preference is persisted to the database
- The page reloads to apply the new language

Closes: #1210

Looks like this:
<img width="478" height="759" alt="image" src="https://github.com/user-attachments/assets/8f0d042b-6566-4e64-97f5-ff7573856520" />
