### PR TITLE
feat(i18n): add enabled.languages config to restrict language selector

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -47,6 +47,15 @@ return [
         # Options: Find your language in the lang directory
         'default.language' => 'en_us',
 
+        # Restrict which languages appear in the language selector.
+        # Comma-separated list of language codes (e.g. 'en_us,fr_fr,de_de').
+        # Languages appear in the selector in the order listed.
+        # Leave empty to show all supported languages.
+        # Language codes must match those defined in lang/AvailableLanguages.php.
+        # If the value of `default.language` is not included in this list, the
+        # application will fall back to 'en_us' and log an error.
+        'enabled.languages' => '',
+
 
         ##########################
         # Frontend

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -202,27 +202,24 @@ switch the UI language. The dropdown lists all languages defined in
 ``lang/AvailableLanguages.php``.
 
 **Limiting available languages**
-  To offer only a subset of languages (for example, only Spanish and English),
-  edit ``lang/AvailableLanguages.php`` and comment out the languages you do not
-  need:
+  Use the ``enabled.languages`` setting in ``config/config.php`` to restrict
+  which languages appear in the selector. Provide a comma-separated list of
+  language codes. Languages appear in the selector in the order listed:
 
   .. code-block:: php
 
-     return [
-         // 'de_de' => new AvailableLanguage('de_de', 'de_de.php', 'Deutsch'),
-         'en_us' => new AvailableLanguage('en_us', 'en_us.php', 'English US'),
-         'es' => new AvailableLanguage('es', 'es.php', 'Español'),
-         // 'fr_fr' => new AvailableLanguage('fr_fr', 'fr_fr.php', 'Français'),
-         // ...
-     ];
+     # Show only English, Spanish, and French
+     'enabled.languages' => 'en_us,es,fr_fr',
+
+  Leave the value empty (the default) to show all supported languages.
+  Language codes must match those defined in ``lang/AvailableLanguages.php``.
+  Any unrecognized codes will be logged as errors and ignored.
 
 .. important::
 
-   The ``default.language`` value in ``config/config.php`` must be one of the
-   languages listed in ``lang/AvailableLanguages.php``. If you comment out a
-   language from that file, make sure it is not set as the default language in
-   your configuration. Otherwise translated strings are likely to display as
-   ``?``.
+   The ``default.language`` value in ``config/config.php`` must be included in
+   the ``enabled.languages`` list. If it is not, the application will fall back
+   to ``en_us`` and log an error.
 
 **Hiding the language selector entirely**
   If only one language remains in the list, the language selector is

--- a/docs/source/BASIC-CONFIGURATION.rst
+++ b/docs/source/BASIC-CONFIGURATION.rst
@@ -103,6 +103,22 @@ Time and Language
 
      'default.language' => 'en_us',
 
+**enabled.languages**
+  Comma-separated list of language codes to show in the language selector.
+  Languages appear in the order listed. Leave empty to show all supported
+  languages. Language codes must match those defined in
+  ``lang/AvailableLanguages.php``. If the value of ``default.language``
+  is not included in this list, the application will fall back to ``en_us`` and
+  log an error.
+
+  .. code-block:: php
+
+     # Show only English, French, and German
+     'enabled.languages' => 'en_us,fr_fr,de_de',
+
+     # Show all supported languages (default)
+     'enabled.languages' => '',
+
 Database Configuration
 ----------------------
 

--- a/lib/Common/Resources.php
+++ b/lib/Common/Resources.php
@@ -130,6 +130,8 @@ class Resources implements IResourceLocalization
      */
     public function IsLanguageSupported($languageCode)
     {
+        $languageCode = strtolower(trim($languageCode ?? ''));
+
         return !empty($languageCode) &&
             (array_key_exists($languageCode, $this->AvailableLanguages) &&
                 file_exists($this->LanguageDirectory . $this->AvailableLanguages[$languageCode]->LanguageFile));
@@ -255,7 +257,7 @@ class Resources implements IResourceLocalization
     private function GetLanguageCode()
     {
         $cookie = ServiceLocator::GetServer()->GetCookie(CookieKeys::LANGUAGE);
-        if ($cookie != null) {
+        if ($cookie != null && $this->IsLanguageSupported($cookie)) {
             return $cookie;
         }
 
@@ -264,12 +266,66 @@ class Resources implements IResourceLocalization
             return $userSession->LanguageCode;
         }
 
-        return Configuration::Instance()->GetKey(ConfigKeys::DEFAULT_LANGUAGE);
+        $configDefault = Configuration::Instance()->GetKey(ConfigKeys::DEFAULT_LANGUAGE);
+        if ($this->IsLanguageSupported($configDefault)) {
+            return $configDefault;
+        }
+
+        // Fall back to hardcoded default (currently 'en_us')
+        return ConfigKeys::DEFAULT_LANGUAGE['default'];
     }
 
     private function LoadAvailableLanguages()
     {
-        $this->AvailableLanguages = AvailableLanguages::GetAvailableLanguages();
+        $allLanguages = AvailableLanguages::GetAvailableLanguages();
+        $enabledConfig = Configuration::Instance()->GetKey(ConfigKeys::ENABLED_LANGUAGES);
+
+        // If no enabled.languages configured, all supported languages are available
+        if (empty($enabledConfig)) {
+            $this->AvailableLanguages = $allLanguages;
+            return;
+        }
+
+        // Filter to only the languages specified in the config
+        $enabledCodes = array_map('trim', explode(',', $enabledConfig));
+        $filtered = [];
+
+        foreach ($enabledCodes as $code) {
+            $code = strtolower($code);
+            if ($code === '') {
+                continue;
+            }
+            if (array_key_exists($code, $allLanguages)) {
+                $filtered[$code] = $allLanguages[$code];
+            } else {
+                Log::Error('Unknown language code in enabled.languages config: %s', $code);
+            }
+        }
+
+        // If every code was invalid, fall back to all languages to avoid breaking the app
+        if (empty($filtered)) {
+            Log::Error('All language codes in enabled.languages are invalid, falling back to all languages');
+            $this->AvailableLanguages = $allLanguages;
+            return;
+        }
+
+        // Ensure default.language is in the enabled set. If not, force the
+        // hardcoded default (currently 'en_us') so the misconfiguration is
+        // visible to the admin — the app appearing in English is an obvious
+        // signal that something is wrong.
+        $defaultLanguage = strtolower(trim(Configuration::Instance()->GetKey(ConfigKeys::DEFAULT_LANGUAGE)));
+        if (!array_key_exists($defaultLanguage, $filtered)) {
+            $defaultFallback = ConfigKeys::DEFAULT_LANGUAGE['default'];
+            Log::Error(
+                'default.language "%s" is not in enabled.languages list, falling back to "%s"',
+                $defaultLanguage,
+                $defaultFallback
+            );
+            $filtered[$defaultFallback] = $allLanguages[$defaultFallback];
+        }
+
+        // Use the order specified in the config so admins control display order
+        $this->AvailableLanguages = $filtered;
     }
 
     private function LoadOverrides()

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -86,6 +86,14 @@ class ConfigKeys
         'description' => 'Default language for the application'
     ];
 
+    public const ENABLED_LANGUAGES = [
+        'key' => 'enabled.languages',
+        'type' => 'string',
+        'default' => '',
+        'label' => 'Enabled Languages',
+        'description' => 'Comma-separated list of language codes to show in the language selector (e.g. "en_us,fr_fr,de_de"). Languages appear in the order listed. If empty, all supported languages are shown. Language codes must match those defined in lang/AvailableLanguages.php. If the value of default.language is not included in this list, the application will fall back to en_us and log an error.'
+    ];
+
     // Frontend
 
     # previously INSTALLATION_PASSWORD

--- a/tests/Domain/Resource/ResourcesTest.php
+++ b/tests/Domain/Resource/ResourcesTest.php
@@ -104,4 +104,135 @@ class ResourcesTest extends TestBase
         $this->assertEquals($lang, $this->Resources->CurrentLanguage);
         $this->assertEquals($langFile, $this->Resources->LanguageFile);
     }
+
+    public function testEmptyEnabledLanguagesShowsAll()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, '');
+
+        $this->Resources = Resources::GetInstance();
+
+        $allLanguages = AvailableLanguages::GetAvailableLanguages();
+        $this->assertEquals(array_keys($allLanguages), array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testEnabledLanguagesFiltersToConfiguredSubset()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'en_us,fr_fr,de_de');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'en_us');
+
+        $this->Resources = Resources::GetInstance();
+
+        $this->assertEquals(['en_us', 'fr_fr', 'de_de'], array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testEnabledLanguagesPreservesConfigOrder()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'fr_fr,en_us,de_de');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'en_us');
+
+        $this->Resources = Resources::GetInstance();
+
+        // Order should match the config value
+        $this->assertEquals(['fr_fr', 'en_us', 'de_de'], array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testEnabledLanguagesIgnoresUnknownCodesAndLogsError()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'en_us,xx_invalid');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'en_us');
+
+        $this->Resources = Resources::GetInstance();
+
+        $this->assertEquals(['en_us'], array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testAllInvalidEnabledLanguagesFallsBackToAll()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'xx_bad,yy_worse');
+
+        $this->Resources = Resources::GetInstance();
+
+        $allLanguages = AvailableLanguages::GetAvailableLanguages();
+        $this->assertEquals(array_keys($allLanguages), array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testDefaultLanguageNotInEnabledListFallsBackToEnUs()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'fr_fr,de_de');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'es');
+
+        $this->Resources = Resources::GetInstance();
+
+        // en_us should be forced into the list as the fallback, appended at the end
+        $this->assertArrayHasKey('en_us', $this->Resources->AvailableLanguages);
+        $this->assertEquals(['fr_fr', 'de_de', 'en_us'], array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testEnabledLanguagesHandlesWhitespace()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, ' en_us , fr_fr ');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'en_us');
+
+        $this->Resources = Resources::GetInstance();
+
+        $this->assertEquals(['en_us', 'fr_fr'], array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testEnabledLanguagesIsCaseInsensitive()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'EN_US,FR_FR');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'en_us');
+
+        $this->Resources = Resources::GetInstance();
+
+        $this->assertEquals(['en_us', 'fr_fr'], array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testDefaultLanguageNotInEnabledListActuallyInitializesWithFallback()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'fr_fr,de_de');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'es');
+
+        $this->Resources = Resources::GetInstance();
+
+        // The app should initialize with en_us, not crash
+        $this->assertEquals('en_us', $this->Resources->CurrentLanguage);
+        $this->assertEquals('en_us.php', $this->Resources->LanguageFile);
+    }
+
+    public function testCookieLanguageNotInEnabledListFallsBackToDefault()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'en_us,fr_fr');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'en_us');
+
+        $langCookie = new Cookie(CookieKeys::LANGUAGE, 'de_de', time(), '/');
+        $this->fakeServer->SetCookie($langCookie);
+
+        $this->Resources = Resources::GetInstance();
+
+        // de_de is not in enabled list, should fall back to config default
+        $this->assertEquals('en_us', $this->Resources->CurrentLanguage);
+    }
+
+    public function testEnabledLanguagesIgnoresBlankEntries()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'en_us,,fr_fr,');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'en_us');
+
+        $this->Resources = Resources::GetInstance();
+
+        $this->assertEquals(['en_us', 'fr_fr'], array_keys($this->Resources->AvailableLanguages));
+    }
+
+    public function testDefaultLanguageMatchesEnabledListCaseInsensitively()
+    {
+        $this->fakeConfig->SetKey(ConfigKeys::ENABLED_LANGUAGES, 'fr_fr,de_de');
+        $this->fakeConfig->SetKey(ConfigKeys::DEFAULT_LANGUAGE, 'FR_FR');
+
+        $this->Resources = Resources::GetInstance();
+
+        // Should not trigger fallback — FR_FR matches fr_fr after normalization
+        // If fallback triggered, en_us would appear in the list
+        $this->assertEquals(['fr_fr', 'de_de'], array_keys($this->Resources->AvailableLanguages));
+    }
 }

--- a/tpl/login.tpl
+++ b/tpl/login.tpl
@@ -135,6 +135,7 @@
                                 {translate key='ForgotMyPassword'}</a>
                         </div>
                     {/if}
+                    {if count($Languages) > 1}
                     <div id="change-language" class="text-end">
                         <a type="button" class="link-primary" data-bs-toggle="collapse"
                             data-bs-target="#change-language-options"><span><i class="bi bi-globe-americas"></i></span>
@@ -146,6 +147,7 @@
                             </select>
                         </div>
                     </div>
+                    {/if}
                 </div>
             </div>
 


### PR DESCRIPTION
Add a new config key `enabled.languages` that allows administrators to restrict which languages appear in the language selector dropdown via config.php, without editing source files.

When set to a comma-separated list of language codes (e.g. "en_us,fr_fr,de_de"), only those languages are shown. When empty (the default), all supported languages are shown.

Error handling:
- Unknown language codes are logged as errors and ignored
- If all codes are invalid, falls back to all languages
- If default.language is not in the enabled list, falls back to en_us and logs an error

Also fixes a pre-existing bug where GetLanguageCode() did not validate the cookie or config default language against the supported language list, which could crash the app if either was invalid.

Closes: #1213