### PR TITLE
fix(i18n): add English fallback for 8 languages missing parent transl…

### DIFF
--- a/lang/ee_ee.php
+++ b/lang/ee_ee.php
@@ -14,7 +14,7 @@ class ee_ee extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'Eesnimi';
         $strings['LastName'] = 'Perekonnanimi';
@@ -806,7 +806,7 @@ class ee_ee extends en_gb
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
          * DAY NAMES
@@ -832,7 +832,7 @@ class ee_ee extends en_gb
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
          * MONTH NAMES

--- a/lang/el_gr.php
+++ b/lang/el_gr.php
@@ -15,7 +15,7 @@ class el_gr extends en_gb
      */
     protected function _LoadDates()
     {
-        $dates = [];
+        $dates = parent::_LoadDates();
 
         $dates['general_date'] = 'd/m/Y';
         $dates['general_datetime'] = 'd/m/Y g:i:s A';
@@ -48,7 +48,7 @@ class el_gr extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'Όνομα';
         $strings['LastName'] = 'Επώνυμο';
@@ -1061,7 +1061,7 @@ class el_gr extends en_gb
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
          * DAY NAMES
@@ -1087,7 +1087,7 @@ class el_gr extends en_gb
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
          * MONTH NAMES

--- a/lang/ru_ru.php
+++ b/lang/ru_ru.php
@@ -19,7 +19,7 @@ class ru_ru extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'Имя';
         $strings['LastName'] = 'Фамилия';
@@ -853,7 +853,7 @@ class ru_ru extends en_gb
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
         DAY NAMES
@@ -879,7 +879,7 @@ class ru_ru extends en_gb
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
         MONTH NAMES

--- a/lang/si_si.php
+++ b/lang/si_si.php
@@ -20,7 +20,7 @@ class si_si extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'Ime';
         $strings['LastName'] = 'Priimek';
@@ -693,7 +693,7 @@ class si_si extends en_gb
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
         DAY NAMES
@@ -719,7 +719,7 @@ class si_si extends en_gb
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
         MONTH NAMES

--- a/lang/sk.php
+++ b/lang/sk.php
@@ -18,7 +18,7 @@ class sk extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'Meno';
         $strings['LastName'] = 'Priezvisko';
@@ -679,7 +679,7 @@ class sk extends en_gb
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
         DAY NAMES
@@ -705,7 +705,7 @@ class sk extends en_gb
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
         MONTH NAMES

--- a/lang/th_th.php
+++ b/lang/th_th.php
@@ -15,7 +15,7 @@ class th_th extends en_gb
      */
     protected function _LoadDates()
     {
-        $dates = [];
+        $dates = parent::_LoadDates();
 
         /**
             * Additional code to support the Thai and Buddhist calendar year
@@ -67,7 +67,7 @@ class th_th extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'ชื่อ';
         $strings['LastName'] = 'นามสกุล';
@@ -885,7 +885,7 @@ class th_th extends en_gb
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
          * DAY NAMES
@@ -911,7 +911,7 @@ class th_th extends en_gb
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
          * MONTH NAMES

--- a/lang/tr_tr.php
+++ b/lang/tr_tr.php
@@ -14,7 +14,7 @@ class tr_tr extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'İsim';
         $strings['LastName'] = 'Soyisim';
@@ -825,7 +825,7 @@ class tr_tr extends en_gb
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
          * DAY NAMES
@@ -851,7 +851,7 @@ class tr_tr extends en_gb
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
          * MONTH NAMES

--- a/lang/vn_vn.php
+++ b/lang/vn_vn.php
@@ -14,7 +14,7 @@ class vn_vn extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'Họ';
         $strings['LastName'] = 'Tên';
@@ -782,7 +782,7 @@ class vn_vn extends en_gb
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
          * DAY NAMES
@@ -808,7 +808,7 @@ class vn_vn extends en_gb
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
          * MONTH NAMES


### PR DESCRIPTION
…ation calls

Several language files initialized their translation arrays from scratch ($strings = []) instead of calling parent::_LoadStrings() first. This meant any key not explicitly translated in that language was missing entirely, causing Resources::GetString() to return "?" instead of falling back to the English string.

The fix changes each affected _Load* method to call its parent first (e.g. $strings = parent::_LoadStrings()) so untranslated keys inherit the English value. _LoadLetters was left unchanged since alphabets are intentionally language-specific replacements.

Affected languages and methods:
- ee_ee (Estonian): _LoadStrings, _LoadDays, _LoadMonths
- el_gr (Greek): _LoadDates, _LoadStrings, _LoadDays, _LoadMonths
- ru_ru (Russian): _LoadStrings, _LoadDays, _LoadMonths
- si_si (Slovenian): _LoadStrings, _LoadDays, _LoadMonths
- sk (Slovak): _LoadStrings, _LoadDays, _LoadMonths
- th_th (Thai): _LoadDates, _LoadStrings, _LoadDays, _LoadMonths
- tr_tr (Turkish): _LoadStrings, _LoadDays, _LoadMonths
- vn_vn (Vietnamese): _LoadStrings, _LoadDays, _LoadMonths