### PR TITLE
fix(config): preserve existing config values when merging new keys fr…

### DIFF
--- a/lib/Config/Configurator.php
+++ b/lib/Config/Configurator.php
@@ -17,10 +17,17 @@ interface IConfigurationSettings
      *
      * @param array $currentSettings
      * @param array $newSettings
-     * @param bool $keepMissingKeys  If true, retains keys that exist only in current config.
+     * @param bool $keepMissingKeys   If true, retains keys that exist only in current config.
+     * @param bool $preserveExisting  If true, keeps existing values in $currentSettings for keys that are also present in $newSettings,
+     *                                adding only new keys from $newSettings without overwriting user-defined values.
      * @return array
      */
-    public function BuildConfig($currentSettings, $newSettings, $keepMissingKeys = false);
+    public function BuildConfig(
+        array $currentSettings,
+        array $newSettings,
+        bool $keepMissingKeys = false,
+        bool $preserveExisting = false
+    );
 
     /**
      * Writes the given configuration array to a PHP config file.
@@ -149,7 +156,12 @@ class Configurator implements IConfigurationSettings
     {
         $currentSettings = $this->GetSettings($configPhp);
         $newSettings = $this->GetSettings($distPhp);
-        $settings = $this->BuildConfig($currentSettings, $newSettings, true);
+        $settings = $this->BuildConfig(
+            currentSettings: $currentSettings,
+            newSettings: $newSettings,
+            keepMissingKeys: true,
+            preserveExisting: true
+        );
         return [Configuration::SETTINGS => $settings];
     }
 
@@ -195,33 +207,60 @@ class Configurator implements IConfigurationSettings
      * @param array $currentSettings Existing settings from config file.
      * @param array $newSettings New settings from form submission.
      * @param bool $keepMissingKeys Whether to preserve keys missing in new settings.
+     * @param bool $preserveExisting If true, keeps existing values without overwriting.
      * @return array Final merged config with preserved order and special handling.
      */
-    public function BuildConfig($currentSettings, $newSettings, $keepMissingKeys = false)
-    {
-        return $this->MergeArrays($currentSettings, $newSettings, $keepMissingKeys);
+    public function BuildConfig(
+        array $currentSettings,
+        array $newSettings,
+        bool $keepMissingKeys = false,
+        bool $preserveExisting = false
+    ) {
+        return $this->MergeArrays(
+            current: $currentSettings,
+            newSettings: $newSettings,
+            keepMissing: $keepMissingKeys,
+            keyPrefix: '',
+            preserveExisting: $preserveExisting
+        );
     }
 
     /**
      * Recursively merges two arrays, preserving order and applying special logic.
      */
-    private function MergeArrays($current, $new, $keepMissing = false, $keyPrefix = '')
-    {
+    private function MergeArrays(
+        array $current,
+        array $newSettings,
+        bool $keepMissing = false,
+        string $keyPrefix = '',
+        bool $preserveExisting = false
+    ) {
         $result = [];
 
         // Process all current keys first to preserve order
         foreach ($current as $key => $currentValue) {
             $fullKey = $keyPrefix ? "$keyPrefix.$key" : $key;
 
-            if (array_key_exists($key, $new)) {
-                $newValue = $new[$key];
+            if (array_key_exists($key, $newSettings)) {
+                $newValue = $newSettings[$key];
 
                 if (is_array($currentValue) && is_array($newValue)) {
                     // Recursively merge nested arrays
-                    $result[$key] = $this->MergeArrays($currentValue, $newValue, true, $fullKey);
+                    $result[$key] = $this->MergeArrays(
+                        current: $currentValue,
+                        newSettings: $newValue,
+                        keepMissing: true,
+                        keyPrefix: $fullKey,
+                        preserveExisting: $preserveExisting
+                    );
                 } else {
                     // Decide whether to use current or new value
-                    $result[$key] = $this->MergeValue($fullKey, $currentValue, $newValue);
+                    $result[$key] = $this->MergeValue(
+                        key: $fullKey,
+                        currentValue: $currentValue,
+                        newValue: $newValue,
+                        preserveExisting: $preserveExisting
+                    );
                 }
             } elseif ($keepMissing) {
                 // Keep existing keys that aren't in new settings
@@ -230,7 +269,7 @@ class Configurator implements IConfigurationSettings
         }
 
         // Add any completely new keys at the end
-        foreach ($new as $key => $newValue) {
+        foreach ($newSettings as $key => $newValue) {
             if (!array_key_exists($key, $current)) {
                 $result[$key] = $newValue;
             }
@@ -242,8 +281,11 @@ class Configurator implements IConfigurationSettings
     /**
      * Chooses between current and new value based on environment variables and private field rules.
      */
-    private function MergeValue($key, $currentValue, $newValue)
+    private function MergeValue(string $key, $currentValue, $newValue, bool $preserveExisting = false)
     {
+        if ($preserveExisting) {
+            return $currentValue;
+        }
         $meta = $this->GetKeyMetadata($key);
 
         if (!$meta) {
@@ -337,7 +379,7 @@ class Configurator implements IConfigurationSettings
         $currentSettings = $this->GetSettings($configPhp);
         $newSettings = $this->GetSettings($distPhp);
 
-        if ($this->AreKeysTheSame($currentSettings, $newSettings)) {
+        if ($this->AreKeysTheSame(currentSettings: $currentSettings, newSettings: $newSettings)) {
             Log::Debug('Config file is already up to date. Skipping config merge.');
             return false;
         }
@@ -349,15 +391,22 @@ class Configurator implements IConfigurationSettings
     /**
      * Recursively compares config keys between two arrays.
      *
-     * @param array $current The current config.
-     * @param array $new The new (template) config.
+     * @param array $currentSettings The current config.
+     * @param array $newSettings The new (template) config.
      * @return bool True if structure is identical.
      */
-    private function AreKeysTheSame($current, $new)
+    private function AreKeysTheSame($currentSettings, $newSettings)
     {
-        foreach ($new as $key => $val) {
-            if (!array_key_exists($key, $current) || (is_array($new[$key]) && is_array($current[$key]) && !$this->AreKeysTheSame($current[$key], $new[$key]))) {
+        foreach ($newSettings as $key => $val) {
+            if (!array_key_exists($key, $currentSettings)) {
                 Log::Debug('Could not find key in config file: %s', $key);
+                return false;
+            }
+
+            if (is_array($newSettings[$key]) && is_array($currentSettings[$key])
+                && !$this->AreKeysTheSame(currentSettings: $currentSettings[$key], newSettings: $newSettings[$key])
+            ) {
+                Log::Debug('Nested keys differ in config file at: %s', $key);
                 return false;
             }
         }

--- a/tests/lib/Config/ConfiguratorTest.php
+++ b/tests/lib/Config/ConfiguratorTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
+require_once(ROOT_DIR . 'lib/Config/Configurator.php');
+
+class ConfiguratorTest extends TestBase
+{
+    private Configurator $configurator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->configurator = new Configurator();
+    }
+
+    public function testBuildConfigReturnsNewValuesWhenPreserveExistingIsFalse(): void
+    {
+        $current = [
+            'test.title' => 'My Custom Title',
+            'test.email' => 'me@example.com',
+        ];
+        $new = [
+            'test.title' => 'Default Title',
+            'test.email' => 'default@example.com',
+        ];
+
+        $result = $this->configurator->BuildConfig(
+            currentSettings: $current,
+            newSettings: $new,
+            preserveExisting: false
+        );
+
+        $this->assertEquals('Default Title', $result['test.title']);
+        $this->assertEquals('default@example.com', $result['test.email']);
+    }
+
+    public function testBuildConfigPreservesExistingValuesWhenPreserveExistingIsTrue(): void
+    {
+        $current = [
+            'test.title' => 'My Custom Title',
+            'test.email' => 'me@example.com',
+        ];
+        $new = [
+            'test.title' => 'Default Title',
+            'test.email' => 'default@example.com',
+        ];
+
+        $result = $this->configurator->BuildConfig(
+            currentSettings: $current,
+            newSettings: $new,
+            preserveExisting: true
+        );
+
+        $this->assertEquals('My Custom Title', $result['test.title']);
+        $this->assertEquals('me@example.com', $result['test.email']);
+    }
+
+    public function testBuildConfigAddsNewKeysWhenPreserveExistingIsTrue(): void
+    {
+        $current = [
+            'test.title' => 'My Custom Title',
+        ];
+        $new = [
+            'test.title' => 'Default Title',
+            'test.newkey' => 'new-default-value',
+        ];
+
+        $result = $this->configurator->BuildConfig(
+            currentSettings: $current,
+            newSettings: $new,
+            preserveExisting: true
+        );
+
+        $this->assertEquals('My Custom Title', $result['test.title']);
+        $this->assertEquals('new-default-value', $result['test.newkey']);
+    }
+
+    public function testBuildConfigPreservesExistingNestedValuesWhenPreserveExistingIsTrue(): void
+    {
+        $current = [
+            'test.section' => [
+                'type' => 'mysql',
+                'host' => 'my-db-server',
+                'name' => 'my_database',
+            ],
+        ];
+        $new = [
+            'test.section' => [
+                'type' => 'mysql',
+                'host' => 'localhost',
+                'name' => 'librebooking',
+                'port' => '3306',
+            ],
+        ];
+
+        $result = $this->configurator->BuildConfig(
+            currentSettings: $current,
+            newSettings: $new,
+            preserveExisting: true
+        );
+
+        $this->assertEquals('my-db-server', $result['test.section']['host']);
+        $this->assertEquals('my_database', $result['test.section']['name']);
+        $this->assertEquals('3306', $result['test.section']['port'], 'New nested key should be added');
+    }
+
+    public function testBuildConfigKeepsMissingKeysFromCurrentSettings(): void
+    {
+        $current = [
+            'test.title' => 'My Title',
+            'test.custom' => 'custom-value',
+        ];
+        $new = [
+            'test.title' => 'Default Title',
+        ];
+
+        $result = $this->configurator->BuildConfig(
+            currentSettings: $current,
+            newSettings: $new,
+            keepMissingKeys: true,
+            preserveExisting: true
+        );
+
+        $this->assertEquals('My Title', $result['test.title']);
+        $this->assertEquals('custom-value', $result['test.custom'], 'Keys only in current should be kept');
+    }
+
+    public function testBuildConfigDropsMissingKeysWhenKeepMissingIsFalse(): void
+    {
+        $current = [
+            'test.title' => 'My Title',
+            'test.custom' => 'custom-value',
+        ];
+        $new = [
+            'test.title' => 'Default Title',
+        ];
+
+        $result = $this->configurator->BuildConfig(
+            currentSettings: $current,
+            newSettings: $new,
+            keepMissingKeys: false,
+            preserveExisting: true
+        );
+
+        $this->assertEquals('My Title', $result['test.title']);
+        $this->assertArrayNotHasKey('test.custom', $result, 'Keys only in current should be dropped');
+    }
+
+    /**
+     * Reproduces the bug from issue #1222: visiting manage_configuration.php
+     * overwrites all config values with defaults when config.dist.php has a
+     * new key not present in config.php.
+     */
+    public function testBuildConfigDoesNotOverwriteExistingValuesWhenNewKeyIsAdded(): void
+    {
+        $current = [
+            'test.title' => 'My Company Booking',
+            'test.email' => 'admin@mycompany.com',
+            'test.section' => [
+                'type' => 'mysql',
+                'host' => 'db.mycompany.com',
+            ],
+        ];
+        $dist = [
+            'test.title' => 'Default Title',
+            'test.email' => 'default@example.com',
+            'test.section' => [
+                'type' => 'mysql',
+                'host' => 'localhost',
+            ],
+            'test.brand.new' => 'default-value',
+        ];
+
+        // This is what GetMerged() does internally
+        $result = $this->configurator->BuildConfig(
+            currentSettings: $current,
+            newSettings: $dist,
+            keepMissingKeys: true,
+            preserveExisting: true
+        );
+
+        $this->assertEquals('My Company Booking', $result['test.title'], 'Existing title must not be overwritten');
+        $this->assertEquals('admin@mycompany.com', $result['test.email'], 'Existing email must not be overwritten');
+        $this->assertEquals('db.mycompany.com', $result['test.section']['host'], 'Existing nested value must not be overwritten');
+        $this->assertEquals('default-value', $result['test.brand.new'], 'New key from dist should be added');
+    }
+}


### PR DESCRIPTION
…om config.dist.php

BringConfigFileUpToDate() was calling BuildConfig() which used MergeValue() to return $newValue as the default for all keys, causing every existing config value to be overwritten with dist defaults whenever a new key was added to config.dist.php.

Added a $preserveExisting parameter (default false) to BuildConfig(), MergeArrays(), and MergeValue(). When true, MergeValue() always returns $currentValue, ensuring existing values are preserved during automatic config file updates. The form save path is unaffected since it uses the default value of false.

GetMerged() now passes $preserveExisting = true to BuildConfig() so that BringConfigFileUpToDate() only adds missing keys without touching existing values.

Closes: #1222