### PR TITLE
docs(config): document admin exemption from start.time.constraint

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -325,6 +325,10 @@ return [
             'allow.wait.list' => false,
 
             # Restrict start times (e.g., 'future', 'none', 'current')
+            # Note: In the standard reservation create/update flow, exemptions from this constraint apply only in specific cases:
+            #   - Application admins are always exempt.
+            #   - Group admins are exempt only when acting as admin for the reservation user.
+            #   - Resource and schedule admins are exempt only when they administer all resources in the reservation.
             'start.time.constraint' => 'future',
 
             # Require approval when an existing reservation is updated (true/false)

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -434,6 +434,10 @@ Reservation Behavior
 
 **reservation.start.time.constraint**
   Restrictions on when reservations can be made: 'none', 'current', 'future'.
+  Note: In the standard reservation create/update flow, application admins are
+  always exempt from this constraint. Group admins are exempt when they
+  administer the reservation owner (user), while resource and schedule admins
+  are exempt only when they administer all resources in the reservation.
 
 **reservation.updates.require.approval**
   Require approval when editing existing approved reservations.

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -747,7 +747,7 @@ class ConfigKeys
             'current' => 'Current'
         ],
         'label' => 'Start Time Constraint',
-        'description' => 'Restrict start times. Options: future, none, current',
+        'description' => 'Restrict start times. Options: future, none, current. In the standard reservation create/update flow, application admins are always exempt. Group admins are exempt only when they administer the reservation user. Resource and schedule admins are exempt only when they administer all resources in the reservation.',
         'section' => 'reservation'
     ];
     public const RESERVATION_UPDATES_REQUIRE_APPROVAL = [


### PR DESCRIPTION
Clarify that application, group, resource, and schedule admins are exempt from the reservation.start.time.constraint setting.

Related: #1225