### PR TITLE
refactor(tooltips): standardize popup template names and update refer…

### DIFF
--- a/Pages/Ajax/ReservationPopupPage.php
+++ b/Pages/Ajax/ReservationPopupPage.php
@@ -209,7 +209,7 @@ class ReservationPopupPage extends Page implements IReservationPopupPage
 
         $this->Set('ReservationId', $this->GetReservationId());
 
-        $this->Display('Ajax/respopup.tpl');
+        $this->Display('Ajax/reservation_popup.tpl');
     }
 
     /**

--- a/Pages/Ajax/ResourceDetailsPage.php
+++ b/Pages/Ajax/ResourceDetailsPage.php
@@ -21,7 +21,7 @@ class ResourceDetailsPage extends Page implements IResourceDetailsPage
     {
         $this->presenter->PageLoad();
 
-        $this->smarty->display('Ajax/resourcedetails.tpl');
+        $this->smarty->display('Ajax/resource_popup.tpl');
     }
 
     public function BindResource(BookableResource $resource)

--- a/Pages/Ajax/UserDetailsPopupPage.php
+++ b/Pages/Ajax/UserDetailsPopupPage.php
@@ -43,7 +43,7 @@ class UserDetailsPopupPage extends Page implements IUserDetailsPopupPage
     public function PageLoad()
     {
         $this->presenter->PageLoad(ServiceLocator::GetServer()->GetUserSession());
-        $this->Display('Ajax/user_details.tpl');
+        $this->Display('Ajax/user_popup.tpl');
     }
 
     public function SetCanViewUser($canView)

--- a/tpl/Ajax/reservation_popup.tpl
+++ b/tpl/Ajax/reservation_popup.tpl
@@ -4,9 +4,9 @@
     {foreach from=$resources item=checkResourcePermission}
         {if in_array($checkResourcePermission->Id(), $CanViewResourceReservations)}
             {assign var=isResourcePermitted value=true}
-            {break};
+            {break}
         {/if}
-    {{/foreach}}
+    {/foreach}
     {*HOWEVER THE USER CAN SEE THE RESERVATION IF HE IS A OWNER, PARTICIPANT OR INVITEE*}
     {if $isResourcePermitted == false}
         {if $UserId == $OwnerId || $IAmParticipating || $IAmInvited}
@@ -107,7 +107,8 @@
         {capture "description"}
             {if !$hideDetails && $isResourcePermitted}
                 <div class="summary">
-                    {if $summary neq ''}{$summary|truncate:300:"..."|escape:'html'|nl2br}{else}{translate key=NoDescriptionLabel}{/if}</div>
+                    {if $summary neq ''}{$summary|truncate:300:"..."|escape:'html'|nl2br}{else}{translate key=NoDescriptionLabel}{/if}
+                </div>
             {/if}
         {/capture}
         {$formatter->Add('description', $smarty.capture.description)}
@@ -119,7 +120,7 @@
                     {foreach from=$attributes item=attribute}
                         {assign var=attr value="att`$attribute->Id()`"}
                         {capture name="attr"}
-                            <div>{control type="AttributeControl" attribute=$attribute readonly=true}</div>
+                            <div>{control type="AttributeControl" attribute=$attribute readonly=true tooltip=true}</div>
                         {/capture}
                         {$smarty.capture.attr}
                         {$formatter->Add($attr, $smarty.capture.attr)}

--- a/tpl/Ajax/resource_popup.tpl
+++ b/tpl/Ajax/resource_popup.tpl
@@ -67,14 +67,14 @@
                 {if $Attributes|default:array()|count > 0}
                     {foreach from=$Attributes item=attribute}
                         <div>
-                            {control type="AttributeControl" attribute=$attribute readonly=true}
+                            {control type="AttributeControl" attribute=$attribute readonly=true tooltip=true}
                         </div>
                     {/foreach}
                 {/if}
                 {if $ResourceTypeAttributes && $ResourceTypeAttributes|default:array()|count > 0}
                     {foreach from=$ResourceTypeAttributes item=attribute}
                         <div>
-                            {control type="AttributeControl" attribute=$attribute readonly=true}
+                            {control type="AttributeControl" attribute=$attribute readonly=true tooltip=true}
                         </div>
                     {/foreach}
                 {/if}
@@ -154,19 +154,19 @@
             <div class="description {$class}">
                 <span class="fw-bold mt-2">{translate key=Description}</span>
                 <div class="descriptionContent px-2">
-                {if $description neq ''}
-                    {$description|html_entity_decode|url2link|nl2br}
-                {else}
-                    {translate key=NoDescriptionLabel}
-                {/if}
+                    {if $description neq ''}
+                        {$description|html_entity_decode|url2link|nl2br}
+                    {else}
+                        {translate key=NoDescriptionLabel}
+                    {/if}
                 </div>
-                <span class="fw-bold mt-2">{translate key=Notes}</span>                
+                <span class="fw-bold mt-2">{translate key=Notes}</span>
                 <div class="noteContent px-2">
-                {if $notes neq ''}
-                    {$notes|html_entity_decode|url2link|nl2br}
-                {else}
-                    {translate key=NoNotesLabel}
-                {/if}
+                    {if $notes neq ''}
+                        {$notes|html_entity_decode|url2link|nl2br}
+                    {else}
+                        {translate key=NoNotesLabel}
+                    {/if}
                 </div>
             </div>
         </div>

--- a/tpl/Ajax/user_popup.tpl
+++ b/tpl/Ajax/user_popup.tpl
@@ -1,38 +1,38 @@
 {if $CanViewUser}
 	<div id="userDetailsPopup">
-		<div class="card-header fw-bold">
+		<div class="fw-bold">
 			{fullname first=$User->FirstName()|unescape:'html' last=$User->LastName()|unescape:'html' ignorePrivacy=true}
 		</div>
-		<div id="userDetailsName" class="card-body">
+		<div id="userDetailsName">
 			{if $User->EmailAddress()}
-				<div id="userDetailsEmail" class="fw-bold">
-					<span class="label">{translate key=Email}</span>
+				<div id="userDetailsEmail">
+					<span class="fw-bold">{translate key=Email}</span>
 					<a href="mailto:{$User->EmailAddress()}" class="link-primary">{$User->EmailAddress()}</a>
 				</div>
 			{/if}
 			{if $User->GetAttribute(UserAttribute::Phone)}
-				<div id="userDetailsPhone" class="fw-bold">
-					<span class="label">{translate key=Phone}</span>
+				<div id="userDetailsPhone">
+					<span class="fw-bold">{translate key=Phone}</span>
 					<a href="tel:{$User->GetAttribute(UserAttribute::Phone)}"
 						class="link-primary">{$User->GetAttribute(UserAttribute::Phone)}</a>
 				</div>
 			{/if}
 			{if $User->GetAttribute(UserAttribute::Organization)}
-				<div id="userDetailsOrganization" class="fw-bold">
-					<span class="label">{translate key=Organization}</span>
+				<div id="userDetailsOrganization">
+					<span class="fw-bold">{translate key=Organization}</span>
 					{$User->GetAttribute(UserAttribute::Organization)}
 				</div>
 			{/if}
 			{if $User->GetAttribute(UserAttribute::Position)}
-				<div id="userDetailsPosition" class="fw-bold">
-					<span class="label">{translate key=Position}</span>
+				<div id="userDetailsPosition">
+					<span class="fw-bold">{translate key=Position}</span>
 					{$User->GetAttribute(UserAttribute::Position)}
 				</div>
 			{/if}
-			<div id="userDetailsAttributes" class="fw-bold">
+			<div id="userDetailsAttributes">
 				{foreach from=$Attributes item=attribute}
 					<div class="customAttribute">
-						<span class="label">{$attribute->Label()}</span>
+						<span class="fw-bold">{$attribute->Label()}</span>
 						{$User->GetAttributeValue($attribute->Id())}
 					</div>
 				{/foreach}

--- a/tpl/Controls/Attributes/Checkbox.tpl
+++ b/tpl/Controls/Attributes/Checkbox.tpl
@@ -1,6 +1,6 @@
 <div class="form-group {$class}">
     {if $readonly}
-        <label class="customAttribute readonly" for="{$attributeId}">{$attribute->Label()}</label>
+        <span class="customAttribute readonly">{$attribute->Label()}</span>
         <span
             class="attributeValue {$class}">{if $attribute->Value() == "1"}{translate key='True'}{else}{translate key='False'}{/if}</span>
     {elseif $searchmode}

--- a/tpl/Controls/Attributes/Date.tpl
+++ b/tpl/Controls/Attributes/Date.tpl
@@ -1,9 +1,15 @@
 <div class="form-group {$class}">
 	{assign value="{$attribute->Value()}" var="attributeValue"}
-	<label class="customAttribute d-block {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
-		for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
-			<i class="bi bi-asterisk text-danger align-top text-small"></i>
-		{/if}</label>
+	{if $readonly && isset($tooltip) && $tooltip}
+		<span class="customAttribute readonly fw-bold">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+				<i class="bi bi-asterisk text-danger align-top text-small"></i>
+			{/if}</span>
+	{else}
+		<label class="customAttribute d-block {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
+			for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+				<i class="bi bi-asterisk text-danger align-top text-small"></i>
+			{/if}</label>
+	{/if}
 	{if $readonly}
 		<span class="attributeValue {$class}">{formatdate date=$attributeValue key=general_datetime}</span>
 	{else}

--- a/tpl/Controls/Attributes/MultiLineTextbox.tpl
+++ b/tpl/Controls/Attributes/MultiLineTextbox.tpl
@@ -1,8 +1,14 @@
 <div class="form-group {$class}">
-    <label class="customAttribute {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
-        for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
-            <i class="bi bi-asterisk text-danger align-top text-small"></i>
-        {/if}</label>
+    {if $readonly && isset($tooltip) && $tooltip}
+        <span class="customAttribute readonly fw-bold">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                <i class="bi bi-asterisk text-danger align-top text-small"></i>
+            {/if}</span>
+    {else}
+        <label class="customAttribute {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
+            for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                <i class="bi bi-asterisk text-danger align-top text-small"></i>
+            {/if}</label>
+    {/if}
     {if $readonly}
         <span class="attributeValue {$class}">{$attribute->Value()|nl2br}</span>
     {else}

--- a/tpl/Controls/Attributes/SelectList.tpl
+++ b/tpl/Controls/Attributes/SelectList.tpl
@@ -1,8 +1,14 @@
 <div class="form-group {$class}">
-    <label class="customAttribute {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
-        for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
-            <i class="bi bi-asterisk text-danger align-top text-small"></i>
-        {/if}</label>
+    {if $readonly && isset($tooltip) && $tooltip}
+        <span class="customAttribute readonly fw-bold">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                <i class="bi bi-asterisk text-danger align-top text-small"></i>
+            {/if}</span>
+    {else}
+        <label class="customAttribute {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
+            for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                <i class="bi bi-asterisk text-danger align-top text-small"></i>
+            {/if}</label>
+    {/if}
     {if $readonly}
         <span class="attributeValue {$class}">{$attribute->Value()}</span>
     {else}

--- a/tpl/Controls/Attributes/SingleLineTextbox.tpl
+++ b/tpl/Controls/Attributes/SingleLineTextbox.tpl
@@ -1,9 +1,15 @@
 <div class="form-group {if isset($class)}{$class}{/if}">
-	<label
-		class="customAttribute {if isset($readonly) && $readonly}readonly{elseif isset($searchmode) && $searchmode}search{else}standard{/if} fw-bold"
-		for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
-			<i class="bi bi-asterisk text-danger align-top text-small"></i>
-		{/if}</label>
+	{if isset($readonly) && $readonly && isset($tooltip) && $tooltip}
+		<span class="customAttribute readonly fw-bold">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+				<i class="bi bi-asterisk text-danger align-top text-small"></i>
+			{/if}</span>
+	{else}
+		<label
+			class="customAttribute {if isset($readonly) && $readonly}readonly{elseif isset($searchmode) && $searchmode}search{else}standard{/if} fw-bold"
+			for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+				<i class="bi bi-asterisk text-danger align-top text-small"></i>
+			{/if}</label>
+	{/if}
 	{if isset($readonly) && $readonly}
 		<span class="attributeValue {$class}">{$attribute->Value()}</span>
 	{else}


### PR DESCRIPTION
…ences

Template changes:

tpl/Ajax/respopup.tpl → tpl/Ajax/reservation_popup.tpl tpl/Ajax/resourcedetails.tpl → tpl/Ajax/resource_popup.tpl tpl/Ajax/user_details.tpl → tpl/Ajax/user_popup.tpl

Updated references:
Adjusted the corresponding PHP pages to use the new template names:

Pages/Ajax/ReservationPopupPage.php
Pages/Ajax/ResourceDetailsPage.php
Pages/Ajax/UserDetailsPopupPage.php

These changes ensure more consistent and predictable naming between templates and their associated JS.