### PR TITLE
docs(API): document retryParameters and skipconflicts for reservation…

### DIFF
--- a/WebServices/Responses/Reservation/ReservationRetryParameterRequestResponse.php
+++ b/WebServices/Responses/Reservation/ReservationRetryParameterRequestResponse.php
@@ -10,6 +10,6 @@ class ReservationRetryParameterRequestResponse
 
     public static function Example()
     {
-        return new ReservationRetryParameterRequestResponse('name', 'value');
+        return new ReservationRetryParameterRequestResponse('skipconflicts', 'true');
     }
 }

--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -1241,6 +1241,8 @@ Reservations
 POST Endpoints
 ~~~~~~~~~~~~~~
 
+.. _CreateReservation:
+
 CreateReservation
 ^^^^^^^^^^^^^^^^^
 
@@ -1322,12 +1324,36 @@ Creates a new reservation
        "allowParticipation": true,
        "retryParameters": [
            {
-               "name": "name",
-               "value": "value"
+               "name": "skipconflicts",
+               "value": "true"
            }
        ],
        "termsAccepted": true
    }
+
+**retryParameters:**
+
+| The ``retryParameters`` field accepts an array of ``{"name": ..., "value": ...}`` objects
+  that modify how reservation conflicts are handled.
+| Currently supported parameters:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Name
+     - Value
+     - Description
+   * - ``skipconflicts``
+     - ``"true"``
+     - When creating or updating a recurring reservation, any instances that
+       conflict with existing reservations or blackouts are silently skipped
+       instead of causing the entire request to fail. This mirrors the
+       "Skip conflicting reservations" option available in the web interface.
+       Non-conflicting instances are created normally.
+
+| **Tip:** You can include ``retryParameters`` in the initial request — there is
+  no need to submit a first request without it and then retry.
 
 **Response:**
 
@@ -1349,7 +1375,7 @@ Creates a new reservation
        "message": null
    }
 
-**curl example:**
+**curl examples:**
 
 .. code:: bash
 
@@ -1364,6 +1390,31 @@ Creates a new reservation
        "endDateTime": "2026-03-20T10:00:00+0000",
        "resourceId": 1,
        "userId": 1
+     }'
+
+Creating a recurring reservation that skips conflicts:
+
+.. code:: bash
+
+   curl -s -X POST "${BASE_URL}/Web/Services/index.php/Reservations/" \
+     -H "Content-Type: application/json" \
+     -H "X-Booked-SessionToken: ${SESSION_TOKEN}" \
+     -H "X-Booked-UserId: ${USER_ID}" \
+     -d '{
+       "title": "Daily Standup",
+       "startDateTime": "2026-04-01T09:00:00+0000",
+       "endDateTime": "2026-04-01T09:30:00+0000",
+       "resourceId": 1,
+       "userId": 1,
+       "recurrenceRule": {
+         "type": "weekly",
+         "interval": 1,
+         "weekdays": [1, 2, 3, 4, 5],
+         "repeatTerminationDate": "2026-06-01T00:00:00+0000"
+       },
+       "retryParameters": [
+         {"name": "skipconflicts", "value": "true"}
+       ]
      }'
 
 UpdateReservation
@@ -1444,12 +1495,15 @@ UpdateReservation
        "allowParticipation": true,
        "retryParameters": [
            {
-               "name": "name",
-               "value": "value"
+               "name": "skipconflicts",
+               "value": "true"
            }
        ],
        "termsAccepted": true
    }
+
+| See the ``retryParameters`` documentation under CreateReservation_ for
+  supported parameters.
 
 **Response:**
 

--- a/tests/WebServices/Controllers/ReservationSaveControllerTest.php
+++ b/tests/WebServices/Controllers/ReservationSaveControllerTest.php
@@ -234,4 +234,43 @@ class ReservationSaveControllerTest extends TestBase
         $this->assertEquals($errors, $facade->Errors());
         $this->assertEquals(true, $facade->RequiresApproval());
     }
+
+    public function testFacadeReturnsRetryParametersFromRequest()
+    {
+        $session = new FakeWebServiceUserSession(123);
+
+        $request = new ReservationRequest();
+        $request->resourceId = 1;
+        $request->startDateTime = '2012-04-05 01:01:01';
+        $request->endDateTime = '2012-04-05 01:01:01';
+        $request->retryParameters = [
+            new ReservationRetryParameterRequestResponse('skipconflicts', 'true'),
+        ];
+
+        $facade = new ReservationRequestResponseFacade($request, $session);
+
+        $retryParams = $facade->GetRetryParameters();
+
+        $this->assertCount(1, $retryParams);
+        $this->assertInstanceOf(ReservationRetryParameter::class, $retryParams[0]);
+        $this->assertEquals('skipconflicts', $retryParams[0]->Name());
+        $this->assertEquals('true', $retryParams[0]->Value());
+    }
+
+    public function testFacadeReturnsEmptyRetryParametersWhenNoneProvided()
+    {
+        $session = new FakeWebServiceUserSession(123);
+
+        $request = new ReservationRequest();
+        $request->resourceId = 1;
+        $request->startDateTime = '2012-04-05 01:01:01';
+        $request->endDateTime = '2012-04-05 01:01:01';
+
+        $facade = new ReservationRequestResponseFacade($request, $session);
+
+        $retryParams = $facade->GetRetryParameters();
+
+        $this->assertIsArray($retryParams);
+        $this->assertEmpty($retryParams);
+    }
 }


### PR DESCRIPTION
… endpoints

The reservation API already supports skipping conflicting bookings via the retryParameters field, but this was not documented. Users had to inspect the web application's internal requests to discover this capability.

- Document the skipconflicts retry parameter for CreateReservation and UpdateReservation endpoints
- Add curl example showing a recurring reservation with skipconflicts
- Update Example() to show skipconflicts instead of generic placeholder
- Add tests for facade retry parameter parsing

Closes: #1220