### PR TITLE
feat(UI): add noscript warning for users with JavaScript disabled

### DIFF
--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -97,6 +97,7 @@ class de_de extends en_gb
         $strings['LaterThisWeek'] = 'Später diese Woche';
         $strings['NextWeek'] = 'Nächste Woche';
         $strings['SignOut'] = 'Abmelden';
+        $strings['JavascriptRequired'] = 'Diese Anwendung benötigt JavaScript, um ordnungsgemäß zu funktionieren. Bitte aktivieren Sie JavaScript in Ihren Browsereinstellungen.';
         $strings['LayoutDescription'] = 'Beginnend %s, zeige %s Tage';
         $strings['AllResources'] = 'Alle Ressourcen';
         $strings['TakeOffline'] = 'Offline gehen';

--- a/lang/du_nl.php
+++ b/lang/du_nl.php
@@ -98,6 +98,7 @@ class du_nl extends en_gb
         $strings['LaterThisWeek'] = 'Later deze week';
         $strings['NextWeek'] = 'Volgende week';
         $strings['SignOut'] = 'Uitloggen';
+        $strings['JavascriptRequired'] = 'Deze applicatie vereist JavaScript om correct te functioneren. Schakel JavaScript in via uw browserinstellingen.';
         $strings['LayoutDescription'] = 'Begint op %s, met %s zichtbare dagen';
         $strings['AllResources'] = 'Alle bronnen';
         $strings['TakeOffline'] = 'Breng offline';

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -134,6 +134,7 @@ class en_us extends Language
         $strings['LaterThisWeek'] = 'Later This Week';
         $strings['NextWeek'] = 'Next Week';
         $strings['SignOut'] = 'Sign Out';
+        $strings['JavascriptRequired'] = 'This application requires JavaScript to function properly. Please enable JavaScript in your browser settings.';
         $strings['LayoutDescription'] = 'Starts on %s, showing %s days at a time';
         $strings['AllResources'] = 'All Resources';
         $strings['TakeOffline'] = 'Take Offline';

--- a/lang/es.php
+++ b/lang/es.php
@@ -99,6 +99,7 @@ class es extends en_gb
         $strings['LaterThisWeek'] = 'Más tarde esta semana';
         $strings['NextWeek'] = 'Siguiente semana';
         $strings['SignOut'] = 'Cerrar';
+        $strings['JavascriptRequired'] = 'Esta aplicación requiere JavaScript para funcionar correctamente. Por favor, habilite JavaScript en la configuración de su navegador.';
         $strings['LayoutDescription'] = 'Empieza en %s, mostrando %s días cada vez';
         $strings['AllResources'] = 'Todos los recursos';
         $strings['TakeOffline'] = 'Deshabilitar';

--- a/lang/fi_fi.php
+++ b/lang/fi_fi.php
@@ -98,6 +98,7 @@ class fi_fi extends en_gb
         $strings['LaterThisWeek'] = 'Myöhemmin tällä viikolla';
         $strings['NextWeek'] = 'Seuraava viikko';
         $strings['SignOut'] = 'Kirjaudu ulos';
+        $strings['JavascriptRequired'] = 'Tämä sovellus vaatii JavaScriptin toimiakseen oikein. Ota JavaScript käyttöön selaimesi asetuksista.';
         $strings['LayoutDescription'] = 'Alkaa %s, näyttäen %s päivää kerralla';
         $strings['AllResources'] = 'Kaikki resurssit';
         $strings['TakeOffline'] = 'Sulje';

--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -99,6 +99,7 @@ class fr_fr extends en_gb
         $strings['LaterThisWeek'] = 'Reste de la semaine';
         $strings['NextWeek'] = 'La semaine prochaine';
         $strings['SignOut'] = 'Déconnexion';
+        $strings['JavascriptRequired'] = 'Cette application nécessite JavaScript pour fonctionner correctement. Veuillez activer JavaScript dans les paramètres de votre navigateur.';
         $strings['LayoutDescription'] = 'Commence le %s, Affiche %s jours à la fois';
         $strings['AllResources'] = 'Toutes les Ressources';
         $strings['TakeOffline'] = 'Désactiver';

--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -97,6 +97,7 @@ class it_it extends en_gb
         $strings['LaterThisWeek'] = 'Questo fine settimana';
         $strings['NextWeek'] = 'Prossima settimana';
         $strings['SignOut'] = 'Disconnetti';
+        $strings['JavascriptRequired'] = 'Questa applicazione richiede JavaScript per funzionare correttamente. Abilitare JavaScript nelle impostazioni del browser.';
         $strings['LayoutDescription'] = 'Inizia di %s, mostrando %s giorni alla volta';
         $strings['AllResources'] = 'Tutte le risorse';
         $strings['TakeOffline'] = 'Non in linea';

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -135,6 +135,7 @@ class ja_jp extends en_gb
         $strings['LaterThisWeek'] = '今週(明後日以後)';
         $strings['NextWeek'] = '翌週';
         $strings['SignOut'] = 'サインアウト';
+        $strings['JavascriptRequired'] = 'このアプリケーションを正しく動作させるにはJavaScriptが必要です。ブラウザの設定でJavaScriptを有効にしてください。';
         $strings['LayoutDescription'] = '一度に %s から、 %s 日間を表示';
         $strings['AllResources'] = '全てのリソース';
         $strings['TakeOffline'] = 'オフラインにする';

--- a/lang/pt_br.php
+++ b/lang/pt_br.php
@@ -101,6 +101,7 @@ class pt_br extends en_gb
         $strings['LaterThisWeek'] = 'Ainda esta semana';
         $strings['NextWeek'] = 'Próxima Semana';
         $strings['SignOut'] = 'Sair';
+        $strings['JavascriptRequired'] = 'Este aplicativo requer JavaScript para funcionar corretamente. Por favor, ative o JavaScript nas configurações do seu navegador.';
         $strings['LayoutDescription'] = 'Inicia em %s, mostrando %s dias de cada vez';
         $strings['AllResources'] = 'Todos os Recursos';
         $strings['TakeOffline'] = 'Colocar Offline';

--- a/lang/ru_ru.php
+++ b/lang/ru_ru.php
@@ -104,6 +104,7 @@ class ru_ru extends en_gb
         $strings['LaterThisWeek'] = 'Позже на этой неделе';
         $strings['NextWeek'] = 'Следующая неделя';
         $strings['SignOut'] = 'Выйти';
+        $strings['JavascriptRequired'] = 'Для корректной работы этого приложения требуется JavaScript. Пожалуйста, включите JavaScript в настройках вашего браузера.';
         $strings['LayoutDescription'] = 'Запускает на %s, показывая %s дней';
         $strings['AllResources'] = 'Все ресурсы';
         $strings['TakeOffline'] = 'В автономный режим';

--- a/lang/vn_vn.php
+++ b/lang/vn_vn.php
@@ -99,6 +99,7 @@ class vn_vn extends en_gb
         $strings['LaterThisWeek'] = 'Later This Week';
         $strings['NextWeek'] = 'Tuần tới';
         $strings['SignOut'] = 'Đăng xuất';
+        $strings['JavascriptRequired'] = 'Ứng dụng này yêu cầu JavaScript để hoạt động bình thường. Vui lòng bật JavaScript trong cài đặt trình duyệt của bạn.';
         $strings['LayoutDescription'] = 'Starts on %s, showing %s days at a time';
         $strings['AllResources'] = 'Tất cả lịch họp';
         $strings['TakeOffline'] = 'Take Offline';

--- a/tpl/globalheader.tpl
+++ b/tpl/globalheader.tpl
@@ -121,6 +121,12 @@
 
 <body data-bs-theme='{$cssTheme}'>
 
+    <noscript>
+        <div class="alert alert-warning text-center m-2" role="alert">
+            {translate key="JavascriptRequired"}
+        </div>
+    </noscript>
+
     {if !isset($HideNavBar) || $HideNavBar == false}
         <div class="d-flex align-items-center gap-2 m-2">
             <a class="navbar-brand" href="{$HomeUrl}">


### PR DESCRIPTION
LibreBooking requires JavaScript to function, but previously gave no indication to users who had it disabled. Add a <noscript> alert banner in the global header template and a new JavascriptRequired translation key in en_us.

Add machine generated translations for the top 10 languages based on commit activity in Librebooking.

Possibly Related: #1230