### PR TITLE
fix(i18n): add English fallback for 3 languages missing parent transl…

### DIFF
--- a/lang/ar.php
+++ b/lang/ar.php
@@ -15,7 +15,7 @@ class ar extends en_us
      */
     protected function _LoadDates()
     {
-        $dates = [];
+        $dates = parent::_LoadDates();
 
         $dates['general_date'] = 'm/d/Y';
         $dates['general_datetime'] = 'm/d/Y g:i:s A';
@@ -48,7 +48,7 @@ class ar extends en_us
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'الاسم الأول ';
         $strings['LastName'] = 'الاسم الأخير';
@@ -1047,7 +1047,7 @@ class ar extends en_us
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
          * DAY NAMES
@@ -1073,7 +1073,7 @@ class ar extends en_us
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
          * MONTH NAMES

--- a/lang/hu_hu.php
+++ b/lang/hu_hu.php
@@ -9,7 +9,7 @@ class hu_hu extends en_us
      */
     protected function _LoadDates()
     {
-        $dates = [];
+        $dates = parent::_LoadDates();
 
         $dates['general_date'] = 'm/d/Y';
         $dates['general_datetime'] = 'm/d/Y g:i:s A';
@@ -42,7 +42,7 @@ class hu_hu extends en_us
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = 'Keresztnév';
         $strings['LastName'] = 'Vezetkéknév';
@@ -1020,7 +1020,7 @@ class hu_hu extends en_us
      */
     protected function _LoadDays()
     {
-        $days = [];
+        $days = parent::_LoadDays();
 
         /***
          * DAY NAMES
@@ -1046,7 +1046,7 @@ class hu_hu extends en_us
      */
     protected function _LoadMonths()
     {
-        $months = [];
+        $months = parent::_LoadMonths();
 
         /***
          * MONTH NAMES

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -15,7 +15,7 @@ class ja_jp extends en_gb
      */
     protected function _LoadDates()
     {
-        $dates = [];
+        $dates = parent::_LoadDates();
 
         $dates['general_date'] = 'Y-m-d';
         $dates['general_datetime'] = 'Y-m-d H:i:s';
@@ -48,7 +48,7 @@ class ja_jp extends en_gb
      */
     protected function _LoadStrings()
     {
-        $strings = [];
+        $strings = parent::_LoadStrings();
 
         $strings['FirstName'] = '名';
         $strings['LastName'] = '姓';


### PR DESCRIPTION
…ation calls

Follow-up to 4ee1ab87d which fixed the same issue for 8 other languages. Arabic (ar.php), Hungarian (hu_hu.php), and Japanese (ja_jp.php) were missed in that commit and still initialized their translation arrays from scratch ($strings = []) instead of calling parent::_LoadStrings() first. This meant any key not explicitly translated in that language was missing entirely, causing Resources::GetString() to return "?" instead of falling back to the English string.

The fix changes each affected _Load* method to call its parent first (e.g. $strings = parent::_LoadStrings()) so untranslated keys inherit the English value. _LoadLetters was left unchanged since alphabets are intentionally language-specific replacements.

Affected languages and methods:
- ar (Arabic): _LoadDates, _LoadStrings, _LoadDays, _LoadMonths
- hu_hu (Hungarian): _LoadDates, _LoadStrings, _LoadDays, _LoadMonths
- ja_jp (Japanese): _LoadDates, _LoadStrings