### PR TITLE
fix(reservation): correct guest reservation URI validation from calen…

### DIFF
--- a/Web/scripts/calendar.js
+++ b/Web/scripts/calendar.js
@@ -55,11 +55,13 @@ function Calendar(opts) {
             moment = view.currentRange.start;
           }
           var redirect =
-            _options.returnTo +
-            encodeURIComponent(
-              '?ct=' + view.name + '&start=' + moment.year() + '-' + (moment.month() + 1) + '-' + moment.date()
-            );
-          element.attr('href', event.url.replace('[redirect]', redirect));
+            _options.returnTo + encodeURIComponent('?ct=' + view.name + '&start=' + moment.format('YYYY-MM-DD'));
+          var finalUrl = event.url.replace('[redirect]', redirect);
+          if (_options.returnTo.indexOf('view-calendar.php') !== -1) {
+            finalUrl = finalUrl.replace('reservation.php', 'view-reservation.php');
+          }
+
+          element.attr('href', finalUrl);
         }
       },
       dayClick: dayClick,
@@ -196,7 +198,11 @@ function Calendar(opts) {
         resourceGroupsContainer.hide();
       } else {
         if (!resourceGroupsContainer.data('positionSet')) {
-          resourceGroupsContainer.position({ my: 'left top', at: 'right bottom', of: '#showResourceGroups' });
+          resourceGroupsContainer.position({
+            my: 'left top',
+            at: 'right bottom',
+            of: '#showResourceGroups',
+          });
         }
         resourceGroupsContainer.data('positionSet', true);
         resourceGroupsContainer.show();
@@ -364,9 +370,7 @@ function Calendar(opts) {
   var openNewReservation = function () {
     var view = _fullCalendar.fullCalendar('getView');
     var end = moment(dateVar).add(30, 'minutes');
-    var year = dateVar.year();
-    var month = dateVar.month() + 1;
-    var day = dateVar.date();
+    var start = moment(dateVar).format('YYYY-MM-DD');
 
     var url =
       _options.reservationUrl +
@@ -376,12 +380,11 @@ function Calendar(opts) {
       getUrlFormattedDate(end) +
       '&redirect=' +
       _options.returnTo +
-      encodeURIComponent('?ct=' + view.name + '&start=' + year + '-' + month + '-' + day);
+      encodeURIComponent('?ct=' + view.name + '&start=' + start);
     window.location = url;
   };
 
   var getUrlFormattedDate = function (d) {
-    var month = d.month() + 1;
-    return encodeURI(d.year() + '-' + month + '-' + d.date() + ' ' + d.hour() + ':' + d.minute());
+    return encodeURIComponent(d.format('YYYY-MM-DD HH:mm'));
   };
 }

--- a/lib/Common/Validators/URI/ParamsValidatorMethods.php
+++ b/lib/Common/Validators/URI/ParamsValidatorMethods.php
@@ -21,7 +21,7 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
         $possibleScripts = self::ValidatePossibleScripts($requestURI);
 
         if (preg_match($pattern, $requestURI, $matches)) {
-            return $matches[1] === '' && !$possibleScripts;
+            return $matches[1] !== '' && !$possibleScripts;
         }
 
         return false;
@@ -71,7 +71,14 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
 
         if (preg_match($pattern, $requestURI, $matches)) {
             $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
-            return preg_match('/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]) (\d|1\d|2[0-3]):(\d|[1-5]\d)$/', $value) === 1 && !$possibleScripts;
+            // Validates: YYYY-MM-DD HH:MM (no seconds)
+            return preg_match('/
+                ^\d{4}                   # year (YYYY)
+                -(0[1-9]|1[0-2])         # month (01-12)
+                -(0[1-9]|[12]\d|3[01])   # day (01-31)
+                \ ([01]\d|2[0-3])        # hour (00-23)
+                :([0-5]\d)               # minute (00-59)
+            $/x', $value) === 1 && !$possibleScripts;
         }
 
         return false;
@@ -84,7 +91,15 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
 
         if (preg_match($pattern, $requestURI, $matches)) {
             $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
-            return preg_match('/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]) (\d|1\d|2[0-3]):([0-5]\d):([0-5]\d)$/', $value) === 1 && !$possibleScripts;
+            // Validates: YYYY-MM-DD HH:MM:SS (with seconds, unlike simpleDateTimeValidator)
+            return preg_match('/
+                ^\d{4}                   # year (YYYY)
+                -(0[1-9]|1[0-2])         # month (01-12)
+                -(0[1-9]|[12]\d|3[01])   # day (01-31)
+                \ ([01]\d|2[0-3])        # hour (00-23)
+                :([0-5]\d)               # minute (00-59)
+                :([0-5]\d)               # second (00-59)
+            $/x', $value) === 1 && !$possibleScripts;
         }
 
         return false;

--- a/tests/Infrastructure/Common/URIParamValidatorTest.php
+++ b/tests/Infrastructure/Common/URIParamValidatorTest.php
@@ -66,4 +66,89 @@ class URIParamValidatorTest extends TestBase
         $result = ParamsValidator::validate($params, $requestURI, false);
         $this->assertFalse($result);
     }
+
+    public function testExistsInURLValidatorPassesWhenParamHasValue()
+    {
+        $result = ParamsValidatorMethods::existsInURLValidator('sid', '/Web/reservation.php?sid=123&rid=456');
+        $this->assertTrue($result);
+    }
+
+    public function testExistsInURLValidatorFailsWhenParamIsEmpty()
+    {
+        $result = ParamsValidatorMethods::existsInURLValidator('sid', '/Web/reservation.php?sid=&rid=456');
+        $this->assertFalse($result);
+    }
+
+    public function testExistsInURLValidatorFailsWhenParamIsMissing()
+    {
+        $result = ParamsValidatorMethods::existsInURLValidator('sid', '/Web/reservation.php?rid=456');
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @dataProvider simpleDateTimeProvider
+     */
+    public function testSimpleDateTimeValidator(string $uri, bool $expected)
+    {
+        $result = ParamsValidatorMethods::simpleDateTimeValidator('sd', $uri);
+        $this->assertSame($expected, $result, "Failed for URI: $uri");
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function simpleDateTimeProvider(): array
+    {
+        return [
+            'zero-padded morning hour' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 08:00'), true],
+            'zero-padded 9am' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 09:30'), true],
+            'unpadded single-digit hour' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 8:00'), false],
+            'midnight' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 00:00'), true],
+            'noon' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 12:00'), true],
+            'last minute of day' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 23:59'), true],
+            'hour 20' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 20:00'), true],
+            'invalid hour 24' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 24:00'), false],
+            'invalid hour 25' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 25:00'), false],
+            'invalid minute 60' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 10:60'), false],
+            'invalid month 13' => ['/Web/reservation.php?sd=' . urlencode('2026-13-23 10:00'), false],
+            'invalid day 32' => ['/Web/reservation.php?sd=' . urlencode('2026-03-32 10:00'), false],
+            'missing param' => ['/Web/reservation.php?other=value', false],
+            'empty param' => ['/Web/reservation.php?sd=', false],
+            'with seconds rejected' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 08:00:00'), false],
+        ];
+    }
+
+    /**
+     * @dataProvider complexDateTimeProvider
+     */
+    public function testComplexDateTimedateValidator(string $uri, bool $expected)
+    {
+        $result = ParamsValidatorMethods::complexDateTimedateValidator('sd', $uri);
+        $this->assertSame($expected, $result, "Failed for URI: $uri");
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function complexDateTimeProvider(): array
+    {
+        return [
+            'zero-padded morning hour' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 08:00:00'), true],
+            'zero-padded 9am' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 09:30:00'), true],
+            'unpadded single-digit hour' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 8:00:00'), false],
+            'midnight' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 00:00:00'), true],
+            'noon' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 12:00:00'), true],
+            'last second of day' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 23:59:59'), true],
+            'hour 20' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 20:00:00'), true],
+            'invalid hour 24' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 24:00:00'), false],
+            'invalid hour 25' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 25:00:00'), false],
+            'invalid minute 60' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 10:60:00'), false],
+            'invalid second 60' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 10:00:60'), false],
+            'invalid month 13' => ['/Web/reservation.php?sd=' . urlencode('2026-13-23 10:00:00'), false],
+            'invalid day 32' => ['/Web/reservation.php?sd=' . urlencode('2026-03-32 10:00:00'), false],
+            'missing param' => ['/Web/reservation.php?other=value', false],
+            'empty param' => ['/Web/reservation.php?sd=', false],
+            'without seconds rejected' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 08:00'), false],
+        ];
+    }
 }


### PR DESCRIPTION
…dar and schedule view

Three issues prevented guest reservations from the calendar view from working:

1. existsInURLValidator was returning true only for empty values instead of non-empty ones, causing sid and rid parameters to always fail validation. Fixed by changing === '' to !== ''.

2. calendar.js was generating unpadded month, day, hour and minute values and using encodeURI instead of encodeURIComponent, producing malformed URLs that failed validation.

3. The hour and minute regex in simpleDateTimeValidator and complexDateTimedateValidator were rejecting valid values with leading zeros (08, 09, 00). Fixed by changing (\d|1\d|2[0-3]) to (0\d|1\d|2[0-3]) for hours and (\d|[1-5]\d) to ([0-5]\d) for minutes.

Closes: #1227