### PR TITLE
fix(i18n): add missing embedded_datetime date format to en_gb locale

### DIFF
--- a/lang/en_gb.php
+++ b/lang/en_gb.php
@@ -31,6 +31,8 @@ class en_gb extends en_us
         $dates['momentjs_datetime'] = 'D/M/YY H:mm';
         $dates['calendar_time'] = 'H:mm';
         $dates['calendar_dates'] = 'd M';
+        $dates['embedded_time'] = 'H:i';
+        $dates['embedded_datetime'] = 'd/m/Y H:i';
         $dates['report_date'] = '%d/%m';
 
         $this->Dates = $dates;


### PR DESCRIPTION
The embedded_datetime key was missing from en_gb.php, causing PDF exports, embedded calendar views, and print attribute views to display dates in US format (m/d with AM/PM) instead of the expected d/m with 24-hour time. Since fr_fr and 22 other locales inherit dates from en_gb, this affected all of them.

Issue solved by: labmecanicatec <labmecanicatec@udistrital.edu.co>