### PR TITLE
ci(integration): switch from MySQL to MariaDB and use Docker mirror

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      mysql:
-        image: mysql:8.0
+      mariadb:
+        image: mirror.gcr.io/library/mariadb:11.4
         env:
-          MYSQL_ROOT_PASSWORD: root
-          MYSQL_DATABASE: librebooking_test
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: librebooking_test
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping -h 127.0.0.1"
+          --health-cmd="mariadb-admin ping -h 127.0.0.1"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5


### PR DESCRIPTION
Replace mysql:8.0 from Docker Hub with mariadb:11.4 from mirror.gcr.io
to avoid Docker Hub authentication and rate limit failures in CI. Update
service env vars to use MARIADB_ prefix and health check to use
mariadb-admin. Keep mysql CLI commands as they are compatible with
MariaDB and pre-installed on the GitHub Actions runner.
