### PR TITLE
fix: correct check-in status display in resource details popup

### DIFF
--- a/tpl/Ajax/resourcedetails.tpl
+++ b/tpl/Ajax/resourcedetails.tpl
@@ -135,7 +135,7 @@
                         {translate key='AutoReleaseNotification' args=$autoReleaseMinutes}
                     </div>
                 {/if}
-                {if $isCheckInEnabled neq ''}
+                {if $isCheckInEnabled}
                     <div>
                         {translate key='RequiresCheckInNotification'}
                     </div>


### PR DESCRIPTION
The isCheckInEnabled variable was checked with `neq ''` instead of a boolean check, causing the check-in notification to always display regardless of the actual check-in setting.

Closes: #1240