### PR TITLE
fix(calendar): generate correct reservation detail URLs server-side f…

### DIFF
--- a/Pages/Pages.php
+++ b/Pages/Pages.php
@@ -42,6 +42,7 @@ class Pages
     public const SCHEDULE = 'schedule.php';
     public const SEARCH_RESERVATIONS = 'search-reservations.php';
     public const VIEW_CALENDAR = 'view-calendar.php';
+    public const VIEW_RESERVATION = 'view-reservation.php';
     public const VIEW_SCHEDULE = 'view-schedule.php';
 
     private static $_pages = [

--- a/Pages/ViewCalendarPage.php
+++ b/Pages/ViewCalendarPage.php
@@ -28,14 +28,15 @@ class ViewCalendarPage extends CalendarPage
         $factory = ($viewReservations || $allowGuestBookings) ? new SlotLabelFactory() : new NullSlotLabelFactory();
 
         $this->presenter = new CalendarPresenter(
-            $this,
-            new ReservationViewRepository(),
-            $scheduleRepository,
-            new UserRepository(),
-            $resourceService,
-            $subscriptionService,
-            $privacyFilter,
-            $factory
+            page: $this,
+            reservationRepository: new ReservationViewRepository(),
+            scheduleRepository: $scheduleRepository,
+            userRepository: new UserRepository(),
+            resourceService: $resourceService,
+            subscriptionService: $subscriptionService,
+            privacyFilter: $privacyFilter,
+            factory: $factory,
+            reservationPage: Pages::VIEW_RESERVATION,
         );
     }
 

--- a/Presenters/Calendar/CalendarPresenter.php
+++ b/Presenters/Calendar/CalendarPresenter.php
@@ -11,6 +11,32 @@ require_once(ROOT_DIR . 'Presenters/Calendar/CalendarCommon.php');
 
 class CalendarPresenter extends CommonCalendarPresenter
 {
+    private string $reservationPage;
+
+    public function __construct(
+        ICommonCalendarPage $page,
+        IReservationViewRepository $reservationRepository,
+        IScheduleRepository $scheduleRepository,
+        IUserRepository $userRepository,
+        IResourceService $resourceService,
+        ICalendarSubscriptionService $subscriptionService,
+        IPrivacyFilter $privacyFilter,
+        SlotLabelFactory $factory,
+        string $reservationPage = Pages::RESERVATION
+    ) {
+        parent::__construct(
+            page: $page,
+            reservationRepository: $reservationRepository,
+            scheduleRepository: $scheduleRepository,
+            userRepository: $userRepository,
+            resourceService: $resourceService,
+            subscriptionService: $subscriptionService,
+            privacyFilter: $privacyFilter,
+            factory: $factory,
+        );
+        $this->reservationPage = $reservationPage;
+    }
+
     /**
      * @param UserSession $userSession
      * @param int $selectedScheduleId
@@ -71,7 +97,8 @@ class CalendarPresenter extends CommonCalendarPresenter
             $resources,
             $userSession,
             $this->privacyFilter,
-            $this->slotLabelFactory
+            $this->slotLabelFactory,
+            reservationPage: $this->reservationPage
         ));
     }
 

--- a/Web/scripts/calendar.js
+++ b/Web/scripts/calendar.js
@@ -57,10 +57,6 @@ function Calendar(opts) {
           var redirect =
             _options.returnTo + encodeURIComponent('?ct=' + view.name + '&start=' + moment.format('YYYY-MM-DD'));
           var finalUrl = event.url.replace('[redirect]', redirect);
-          if (_options.returnTo.indexOf('view-calendar.php') !== -1) {
-            finalUrl = finalUrl.replace('reservation.php', 'view-reservation.php');
-          }
-
           element.attr('href', finalUrl);
         }
       },

--- a/lib/Application/Schedule/CalendarReservation.php
+++ b/lib/Application/Schedule/CalendarReservation.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once(ROOT_DIR . 'Pages/Pages.php');
+
 class CalendarReservation
 {
     /**
@@ -97,6 +99,8 @@ class CalendarReservation
      */
     public $ScheduleId;
 
+    private string $reservationPage = Pages::RESERVATION;
+
     private function __construct(Date $startDate, Date $endDate, $resourceName, $referenceNumber)
     {
         $this->StartDate = $startDate;
@@ -178,8 +182,16 @@ class CalendarReservation
      * @param SlotLabelFactory|null $factory
      * @return CalendarReservation[]
      */
-    public static function FromScheduleReservationList($reservations, $blackouts, $availablePeriods, $resources, UserSession $userSession, $groupSeriesByResource = false, $factory = null)
-    {
+    public static function FromScheduleReservationList(
+        $reservations,
+        $blackouts,
+        $availablePeriods,
+        $resources,
+        UserSession $userSession,
+        $groupSeriesByResource = false,
+        $factory = null,
+        string $reservationPage = Pages::RESERVATION
+    ) {
         if ($factory == null) {
             $factory = new SlotLabelFactory($userSession);
         }
@@ -211,6 +223,7 @@ class CalendarReservation
             $referenceNumber = $reservation->ReferenceNumber;
 
             $cr = new CalendarReservation($start, $end, $resourceMap[$reservation->ResourceId], $referenceNumber);
+            $cr->reservationPage = $reservationPage;
             $cr->Title = $reservation->Title;
             $cr->OwnerName = new FullName($reservation->FirstName, $reservation->LastName);
             $cr->OwnerFirst = $reservation->FirstName;
@@ -304,7 +317,7 @@ class CalendarReservation
     private function GetUrl()
     {
         if (!empty($this->ReferenceNumber)) {
-            return sprintf('%s?rn=%s&redirect=[redirect]', Pages::RESERVATION, $this->ReferenceNumber);
+            return sprintf('%s?rn=%s&redirect=[redirect]', $this->reservationPage, $this->ReferenceNumber);
         }
 
         if (!empty($this->ResourceId)) {

--- a/tests/Application/Schedule/CalendarReservationTest.php
+++ b/tests/Application/Schedule/CalendarReservationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Application/Schedule/namespace.php');
+require_once(ROOT_DIR . 'Domain/Access/namespace.php');
+require_once(ROOT_DIR . 'Pages/Pages.php');
+
+class CalendarReservationTest extends TestBase
+{
+    public function testExistingReservationUrlUsesDefaultReservationPage(): void
+    {
+        $referenceNumber = 'abc123';
+        $res = new TestReservationItemView(
+            id: 1,
+            startDate: Date::Now(),
+            endDate: Date::Now()->AddHours(1),
+            resourceId: 1,
+            referenceNumber: $referenceNumber,
+        );
+
+        $resource = new FakeBookableResource(1, 'Room A');
+
+        $calendarReservations = CalendarReservation::FromScheduleReservationList(
+            reservations: [$res],
+            blackouts: [],
+            availablePeriods: [],
+            resources: [$resource],
+            userSession: $this->fakeUser,
+        );
+
+        $event = $calendarReservations[0]->AsFullCalendarEvent();
+
+        $this->assertStringStartsWith('reservation.php?rn=' . $referenceNumber, $event['url']);
+        $this->assertStringNotContainsString('view-reservation.php', $event['url']);
+    }
+
+    public function testExistingReservationUrlUsesViewReservationPageWhenSpecified(): void
+    {
+        $referenceNumber = 'xyz789';
+        $res = new TestReservationItemView(
+            id: 1,
+            startDate: Date::Now(),
+            endDate: Date::Now()->AddHours(1),
+            resourceId: 1,
+            referenceNumber: $referenceNumber,
+        );
+
+        $resource = new FakeBookableResource(1, 'Room A');
+
+        $calendarReservations = CalendarReservation::FromScheduleReservationList(
+            reservations: [$res],
+            blackouts: [],
+            availablePeriods: [],
+            resources: [$resource],
+            userSession: $this->fakeUser,
+            reservationPage: Pages::VIEW_RESERVATION,
+        );
+
+        $event = $calendarReservations[0]->AsFullCalendarEvent();
+
+        $this->assertStringStartsWith('view-reservation.php?rn=' . $referenceNumber, $event['url']);
+    }
+}

--- a/tests/Presenters/CalendarPresenterTest.php
+++ b/tests/Presenters/CalendarPresenterTest.php
@@ -224,4 +224,88 @@ class CalendarPresenterTest extends TestBase
 
         $this->presenter->ProcessDataRequest('events');
     }
+
+    public function testGuestCalendarEventsUseViewReservationPage(): void
+    {
+        $referenceNumber = 'guest-ref-123';
+        $resourceId = 1;
+        $res = new TestReservationItemView(
+            id: 1,
+            startDate: Date::Now(),
+            endDate: Date::Now()->AddHours(1),
+            resourceId: $resourceId,
+            referenceNumber: $referenceNumber,
+        );
+
+        $resource = new FakeBookableResource($resourceId, 'Room A');
+
+        $guestPresenter = new CalendarPresenter(
+            $this->page,
+            $this->repository,
+            $this->scheduleRepository,
+            $this->userRepository,
+            $this->resourceService,
+            $this->subscriptionService,
+            $this->privacyFilter,
+            new SlotLabelFactory(),
+            reservationPage: Pages::VIEW_RESERVATION,
+        );
+
+        $this->page
+            ->expects($this->atLeastOnce())
+            ->method('GetResourceId')
+            ->willReturn($resourceId);
+        $this->page
+            ->expects($this->atLeastOnce())
+            ->method('GetScheduleId')
+            ->willReturn(null);
+        $this->page
+            ->expects($this->atLeastOnce())
+            ->method('GetGroupId')
+            ->willReturn(null);
+        $this->page
+            ->expects($this->atLeastOnce())
+            ->method('GetUserId')
+            ->willReturn(null);
+        $this->page
+            ->expects($this->atLeastOnce())
+            ->method('GetParticipantId')
+            ->willReturn(null);
+
+        $this->resourceService
+            ->expects($this->atLeastOnce())
+            ->method('GetAllResources')
+            ->willReturn([$resource]);
+        $this->resourceService
+            ->expects($this->atLeastOnce())
+            ->method('GetResource')
+            ->willReturn($resource);
+        $this->repository
+            ->expects($this->atLeastOnce())
+            ->method('GetReservations')
+            ->willReturn([$res]);
+        $this->repository
+            ->expects($this->atLeastOnce())
+            ->method('GetBlackoutsWithin')
+            ->willReturn([]);
+        $this->scheduleRepository
+            ->expects($this->atLeastOnce())
+            ->method('GetLayout')
+            ->willReturn(new FakeScheduleLayout());
+
+        $boundEvents = null;
+        $this->page
+            ->expects($this->once())
+            ->method('BindEvents')
+            ->willReturnCallback(function ($events) use (&$boundEvents) {
+                $boundEvents = $events;
+            });
+
+        $guestPresenter->ProcessDataRequest('events');
+
+        $this->assertNotNull($boundEvents);
+        $this->assertCount(1, $boundEvents);
+        $event = $boundEvents[0]->AsFullCalendarEvent();
+        $this->assertStringStartsWith('view-reservation.php?rn=' . $referenceNumber, $event['url']);
+    }
 }


### PR DESCRIPTION
…or guest views

CalendarReservation::GetUrl() hardcoded Pages::RESERVATION for all contexts, forcing a fragile client-side string replace in calendar.js to rewrite 'reservation.php' to 'view-reservation.php' for guest calendar views. That .replace() matched the first occurrence anywhere in the URL, so it could match inside a query parameter value rather than just the path.

Inject the reservation-details page into CalendarPresenter at construction time and thread it through to
CalendarReservation::FromScheduleReservationList(), so the server generates the correct URL directly. ViewCalendarPage passes Pages::VIEW_RESERVATION; CalendarPage keeps the default Pages::RESERVATION. The client-side rewrite is removed.

Closes: #1245