### PR TITLE
refactor(validators): use early-return guard clause for XSS check in …

### DIFF
--- a/lib/Common/Validators/URI/ParamsValidatorMethods.php
+++ b/lib/Common/Validators/URI/ParamsValidatorMethods.php
@@ -2,49 +2,73 @@
 
 class ParamsValidatorMethods implements IParamsValidatorMethods
 {
+    /**
+     * Validates that a query parameter is present and its value is numeric.
+     */
     public static function numericalValidator(string $param, string $requestURI): bool
     {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
         $pattern = '/[?&]' . preg_quote($param, '/') . '=([0-9]+)/';
-        $possibleScripts = self::ValidatePossibleScripts(($requestURI));
 
         if (preg_match($pattern, $requestURI, $matches)) {
-            return is_numeric($matches[1]) && !$possibleScripts;
+            return is_numeric($matches[1]);
         }
 
         return false;
     }
 
+    /**
+     * Validates that a query parameter is present and has a non-empty value.
+     */
     public static function existsInURLValidator(string $param, string $requestURI): bool
     {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
         $pattern = "/(?:\?|&)" . preg_quote($param, '/') . '=([^&]*)/';
 
-        $possibleScripts = self::ValidatePossibleScripts($requestURI);
-
         if (preg_match($pattern, $requestURI, $matches)) {
-            return $matches[1] !== '' && !$possibleScripts;
+            return $matches[1] !== '';
         }
 
         return false;
     }
 
 
+    /**
+     * Validates that a query parameter is present and its value is a date in YYYY-MM-DD format.
+     */
     public static function dateValidator(string $param, string $requestURI): bool
     {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
         $pattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-        $possibleScripts = self::ValidatePossibleScripts(($requestURI));
 
         if (preg_match($pattern, $requestURI, $matches)) {
             $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
-            return preg_match('/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/', $value) === 1 && !$possibleScripts;
+            return preg_match('/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/', $value) === 1;
         }
 
         return false;
     }
 
+    /**
+     * Validates that a query parameter is present and its value is a comma-separated
+     * list of dates in YYYY-M-D format (leading zeros optional for month and day).
+     */
     public static function simpleDateValidatorList(string $param, string $requestURI): bool
     {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
         $pattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-        $possibleScripts = self::ValidatePossibleScripts(($requestURI));
 
         if (preg_match($pattern, $requestURI, $matches)) {
             $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
@@ -57,17 +81,24 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
                 }
             }
 
-            return !$possibleScripts;
+            return true;
         }
 
         return false;
     }
 
 
+    /**
+     * Validates that a query parameter is present and its value is a datetime
+     * in YYYY-MM-DD HH:MM format (no seconds).
+     */
     public static function simpleDateTimeValidator(string $param, string $requestURI): bool
     {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
         $pattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-        $possibleScripts = self::ValidatePossibleScripts(($requestURI));
 
         if (preg_match($pattern, $requestURI, $matches)) {
             $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
@@ -78,16 +109,23 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
                 -(0[1-9]|[12]\d|3[01])   # day (01-31)
                 \ ([01]\d|2[0-3])        # hour (00-23)
                 :([0-5]\d)               # minute (00-59)
-            $/x', $value) === 1 && !$possibleScripts;
+            $/x', $value) === 1;
         }
 
         return false;
     }
 
+    /**
+     * Validates that a query parameter is present and its value is a datetime
+     * in YYYY-MM-DD HH:MM:SS format (with seconds).
+     */
     public static function complexDateTimedateValidator(string $param, string $requestURI): bool
     {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
         $pattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-        $possibleScripts = self::ValidatePossibleScripts(($requestURI));
 
         if (preg_match($pattern, $requestURI, $matches)) {
             $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
@@ -99,16 +137,23 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
                 \ ([01]\d|2[0-3])        # hour (00-23)
                 :([0-5]\d)               # minute (00-59)
                 :([0-5]\d)               # second (00-59)
-            $/x', $value) === 1 && !$possibleScripts;
+            $/x', $value) === 1;
         }
 
         return false;
     }
 
+    /**
+     * Validates a guest reservation redirect URL contains a valid 'start' date
+     * and a valid 'ct' (calendar type: day, week, or month).
+     */
     public static function redirectGuestReservationValidator(string $requestURI): bool
     {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
         $pattern = "/(?:\?|&)redirect=([^&]+)/";
-        $possibleScripts = self::ValidatePossibleScripts(($requestURI));
 
         if (preg_match($pattern, $requestURI, $matches)) {
             $redirectURL = urldecode($matches[1]);
@@ -126,22 +171,40 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
                 CalendarTypes::Week,
                 CalendarTypes::Month
             ]);
-            return ($validCt && $validStart && !$possibleScripts);
+            return ($validCt && $validStart);
         }
 
         return false;
     }
 
+    /**
+     * Validates that a query parameter is present and its value is "true" or "false" (case-insensitive).
+     */
     public static function booleanValidator(string $param, string $requestURI): bool
     {
-        $pattern = '/[?&]' . preg_quote($param, '/') . '=(true|false)(?:&|$)/i';
-        $possibleScripts = self::ValidatePossibleScripts($requestURI);
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
 
-        return preg_match($pattern, $requestURI) === 1 && !$possibleScripts;
+        $pattern = '/[?&]' . preg_quote($param, '/') . '=(true|false)(?:&|$)/i';
+
+        return preg_match($pattern, $requestURI) === 1;
     }
 
+    /**
+     * Validates that a query parameter, if present, matches the expected value.
+     *
+     * Returns false if the URL contains potential XSS payloads.
+     * Returns true if the parameter is absent (no constraint to enforce).
+     * Returns true if the parameter is present and its value matches $expectedValue.
+     * Returns false if the parameter is present with a non-matching value.
+     */
     public static function matchValidator(string $param, string $expectedValue, string $requestURI): bool
     {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
         $paramPresentPattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
 
         if (!preg_match($paramPresentPattern, $requestURI)) {
@@ -149,13 +212,16 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
         }
 
         $pattern = '/[?&]' . preg_quote($param, '/') . '=' . preg_quote($expectedValue, '/') . '(?:&|$)/';
-        $possibleScripts = self::ValidatePossibleScripts($requestURI);
 
-        return preg_match($pattern, $requestURI) === 1 && !$possibleScripts;
+        return preg_match($pattern, $requestURI) === 1;
     }
 
 
 
+    /**
+     * Checks if the URL contains patterns indicating potential XSS script injection,
+     * such as <script> tags, quoted strings, or their URL-encoded equivalents.
+     */
     private static function validatePossibleScripts(string $requestURI): bool
     {
         return preg_match('/%22.*%22/', $requestURI) ||

--- a/tests/Infrastructure/Common/URIParamValidatorTest.php
+++ b/tests/Infrastructure/Common/URIParamValidatorTest.php
@@ -86,6 +86,33 @@ class URIParamValidatorTest extends TestBase
     }
 
     /**
+     * @dataProvider matchValidatorProvider
+     */
+    public function testMatchValidator(string $param, string $expectedValue, string $uri, bool $expected)
+    {
+        $result = ParamsValidatorMethods::matchValidator($param, $expectedValue, $uri);
+        $this->assertSame($expected, $result, "Failed for URI: $uri");
+    }
+
+    /**
+     * @return array<string, array{string, string, string, bool}>
+     */
+    public static function matchValidatorProvider(): array
+    {
+        return [
+            'param matches expected value' => ['dr', 'reservations', '/Web/view-schedule.php?dr=reservations', true],
+            'param does not match expected value' => ['dr', 'reservations', '/Web/view-schedule.php?dr=wrongvalue', false],
+            'param absent returns true' => ['dr', 'reservations', '/Web/view-schedule.php?other=value', true],
+            'param empty does not match' => ['dr', 'reservations', '/Web/view-schedule.php?dr=', false],
+            'param with multiple query params' => ['dr', 'reservations', '/Web/view-schedule.php?uid=123&dr=reservations&sd=2026-01-01', true],
+            'param wrong value with multiple query params' => ['dr', 'reservations', '/Web/view-schedule.php?uid=123&dr=wrong&sd=2026-01-01', false],
+            'xss script tag rejected' => ['dr', 'reservations', '/Web/view-schedule.php?dr=reservations&x=%3Cscript%3E', false],
+            'xss script tag rejected even when param absent' => ['dr', 'reservations', '/Web/view-schedule.php?x=%3Cscript%3E', false],
+            'xss double quotes rejected' => ['dr', 'reservations', '/Web/view-schedule.php?dr=reservations&x=%22alert%22', false],
+        ];
+    }
+
+    /**
      * @dataProvider simpleDateTimeProvider
      */
     public function testSimpleDateTimeValidator(string $uri, bool $expected)


### PR DESCRIPTION
…URL validators

Move the ValidatePossibleScripts() call to the top of each validator method as a guard clause, returning false immediately if potential XSS payloads are detected. This replaces the previous pattern of storing the result in a variable and combining it with && at the end of each method.

The change improves readability by making the security check an explicit first step, avoids unnecessary regex processing on rejected URLs, and removes the repeated `&& !$possibleScripts` pattern from return statements.