### PR TITLE
fix(validators): remove redundant EXISTS from combined route validators

### DIFF
--- a/lib/Server/RouteParamsKeys.php
+++ b/lib/Server/RouteParamsKeys.php
@@ -23,23 +23,22 @@ class RouteParamsKeys
     ];
 
     public const VIEW_SCHEDULE = [
-        FormKeys::PARTICIPANT_ID => [ParamsValidatorKeys::EXISTS, ParamsValidatorKeys::NUMERICAL],
-        FormKeys::USER_ID => [ParamsValidatorKeys::EXISTS, ParamsValidatorKeys::NUMERICAL],
+        FormKeys::PARTICIPANT_ID => ParamsValidatorKeys::NUMERICAL,
+        FormKeys::USER_ID => ParamsValidatorKeys::NUMERICAL,
         QueryStringKeys::SCHEDULE_ID => ParamsValidatorKeys::NUMERICAL,
         QueryStringKeys::START_DATE => ParamsValidatorKeys::DATE,
         'clearFilter' => ParamsValidatorKeys::NUMERICAL,
-        QueryStringKeys::START_DATES => [ParamsValidatorKeys::EXISTS, ParamsValidatorKeys::SIMPLE_DATE],
-        FormKeys::RESOURCE_TYPE_ID => [ParamsValidatorKeys::EXISTS, ParamsValidatorKeys::NUMERICAL],
-        FormKeys::MAX_PARTICIPANTS => [ParamsValidatorKeys::EXISTS, ParamsValidatorKeys::NUMERICAL],
+        QueryStringKeys::START_DATES => ParamsValidatorKeys::SIMPLE_DATE,
+        FormKeys::RESOURCE_TYPE_ID => ParamsValidatorKeys::NUMERICAL,
+        FormKeys::MAX_PARTICIPANTS => ParamsValidatorKeys::NUMERICAL,
         FormKeys::SUBMIT => ParamsValidatorKeys::BOOLEAN,
         QueryStringKeys::DATA_REQUEST => [ParamsValidatorKeys::MATCH => ['reservations']]
     ];
 
     public const VIEW_CALENDAR = [
-        QueryStringKeys::REPORT_ID => [ParamsValidatorKeys::EXISTS, ParamsValidatorKeys::NUMERICAL],
-        QueryStringKeys::SCHEDULE_ID => [ParamsValidatorKeys::EXISTS, ParamsValidatorKeys::NUMERICAL],
+        QueryStringKeys::REPORT_ID => ParamsValidatorKeys::NUMERICAL,
+        QueryStringKeys::SCHEDULE_ID => ParamsValidatorKeys::NUMERICAL,
         QueryStringKeys::START => ParamsValidatorKeys::SIMPLE_DATE,
-        //QueryStringKeys::END => ParamsValidatorKeys::SIMPLE_DATE,
-        QueryStringKeys::GROUP_ID => [ParamsValidatorKeys::EXISTS, ParamsValidatorKeys::NUMERICAL]
+        QueryStringKeys::GROUP_ID => ParamsValidatorKeys::NUMERICAL
     ];
 }


### PR DESCRIPTION
The OR composition in ParamsValidator::validateParam() meant that [EXISTS, NUMERICAL] accepted any non-empty non-numeric value (e.g., ?sid=abc) because EXISTS passed, bypassing the NUMERICAL check.

Since numericalValidator and simpleDateValidatorList already reject missing and empty values, EXISTS was redundant in these combinations. Removing it ensures only properly typed values pass validation.

Also remove a commented-out QueryStringKeys::END entry that has been dead code since the file was created in PR #462.

Closes: #1244