### PR TITLE
refactor(validators): replace regex param extraction with parse_url/p…

### DIFF
--- a/lib/Common/Validators/URI/ParamsValidatorMethods.php
+++ b/lib/Common/Validators/URI/ParamsValidatorMethods.php
@@ -3,6 +3,32 @@
 class ParamsValidatorMethods implements IParamsValidatorMethods
 {
     /**
+     * Extracts a string query parameter value from a URI using parse_url/parse_str.
+     *
+     * Only returns simple string values. Array-style parameters (e.g. ?uid[]=1&uid[]=2)
+     * are treated as absent and return null.
+     *
+     * @param string $param      The query parameter name to extract
+     * @param string $requestURI The full request URI
+     * @return string|null       The parameter value, or null if absent or non-string
+     */
+    private static function getQueryParam(string $param, string $requestURI): ?string
+    {
+        $query = parse_url($requestURI, PHP_URL_QUERY);
+        if ($query === null || $query === false) {
+            return null;
+        }
+
+        parse_str($query, $params);
+
+        if (!array_key_exists($param, $params) || !is_string($params[$param])) {
+            return null;
+        }
+
+        return $params[$param];
+    }
+
+    /**
      * Validates that a query parameter is present and its value is numeric.
      */
     public static function numericalValidator(string $param, string $requestURI): bool
@@ -11,13 +37,12 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $pattern = '/[?&]' . preg_quote($param, '/') . '=([0-9]+)/';
-
-        if (preg_match($pattern, $requestURI, $matches)) {
-            return is_numeric($matches[1]);
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return false;
         }
 
-        return false;
+        return ctype_digit($value);
     }
 
     /**
@@ -29,13 +54,9 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $pattern = "/(?:\?|&)" . preg_quote($param, '/') . '=([^&]*)/';
+        $value = self::getQueryParam($param, $requestURI);
 
-        if (preg_match($pattern, $requestURI, $matches)) {
-            return $matches[1] !== '';
-        }
-
-        return false;
+        return $value !== null && $value !== '';
     }
 
 
@@ -48,14 +69,14 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $pattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-
-        if (preg_match($pattern, $requestURI, $matches)) {
-            $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
-            return preg_match('/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/', $value) === 1;
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return false;
         }
 
-        return false;
+        $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+
+        return preg_match('/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/', $value) === 1;
     }
 
     /**
@@ -68,23 +89,21 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $pattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-
-        if (preg_match($pattern, $requestURI, $matches)) {
-            $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
-
-            $dates = explode(',', $value);
-
-            foreach ($dates as $date) {
-                if (!preg_match('/^\d{4}-(0?[1-9]|1[0-2])-(0?[1-9]|[12]?\d|3[01])$/', $date)) {
-                    return false;
-                }
-            }
-
-            return true;
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return false;
         }
 
-        return false;
+        $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        $dates = explode(',', $value);
+
+        foreach ($dates as $date) {
+            if (!preg_match('/^\d{4}-(0?[1-9]|1[0-2])-(0?[1-9]|[12]?\d|3[01])$/', $date)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
 
@@ -98,21 +117,20 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $pattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-
-        if (preg_match($pattern, $requestURI, $matches)) {
-            $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
-            // Validates: YYYY-MM-DD HH:MM (no seconds)
-            return preg_match('/
-                ^\d{4}                   # year (YYYY)
-                -(0[1-9]|1[0-2])         # month (01-12)
-                -(0[1-9]|[12]\d|3[01])   # day (01-31)
-                \ ([01]\d|2[0-3])        # hour (00-23)
-                :([0-5]\d)               # minute (00-59)
-            $/x', $value) === 1;
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return false;
         }
 
-        return false;
+        $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        // Validates: YYYY-MM-DD HH:MM (no seconds)
+        return preg_match('/
+            ^\d{4}                   # year (YYYY)
+            -(0[1-9]|1[0-2])         # month (01-12)
+            -(0[1-9]|[12]\d|3[01])   # day (01-31)
+            \ ([01]\d|2[0-3])        # hour (00-23)
+            :([0-5]\d)               # minute (00-59)
+        $/x', $value) === 1;
     }
 
     /**
@@ -125,22 +143,21 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $pattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-
-        if (preg_match($pattern, $requestURI, $matches)) {
-            $value = htmlspecialchars(urldecode($matches[1]), ENT_QUOTES, 'UTF-8');
-            // Validates: YYYY-MM-DD HH:MM:SS (with seconds, unlike simpleDateTimeValidator)
-            return preg_match('/
-                ^\d{4}                   # year (YYYY)
-                -(0[1-9]|1[0-2])         # month (01-12)
-                -(0[1-9]|[12]\d|3[01])   # day (01-31)
-                \ ([01]\d|2[0-3])        # hour (00-23)
-                :([0-5]\d)               # minute (00-59)
-                :([0-5]\d)               # second (00-59)
-            $/x', $value) === 1;
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return false;
         }
 
-        return false;
+        $value = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+        // Validates: YYYY-MM-DD HH:MM:SS (with seconds, unlike simpleDateTimeValidator)
+        return preg_match('/
+            ^\d{4}                   # year (YYYY)
+            -(0[1-9]|1[0-2])         # month (01-12)
+            -(0[1-9]|[12]\d|3[01])   # day (01-31)
+            \ ([01]\d|2[0-3])        # hour (00-23)
+            :([0-5]\d)               # minute (00-59)
+            :([0-5]\d)               # second (00-59)
+        $/x', $value) === 1;
     }
 
     /**
@@ -153,28 +170,39 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $pattern = "/(?:\?|&)redirect=([^&]+)/";
-
-        if (preg_match($pattern, $requestURI, $matches)) {
-            $redirectURL = urldecode($matches[1]);
-
-            $segments = explode('?', $requestURI);
-            if (!isset($segments[1]) || $segments[1] === '') {
-                return false;
-            }
-
-            $validStart = preg_match('/[?&]start=(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])/', $redirectURL);
-
-            preg_match('/[?&]ct=([a-zA-Z0-9_]+)/', $redirectURL, $ct);
-            $validCt = in_array($ct[1], [
-                CalendarTypes::Day,
-                CalendarTypes::Week,
-                CalendarTypes::Month
-            ]);
-            return ($validCt && $validStart);
+        $redirectURL = self::getQueryParam('redirect', $requestURI);
+        if ($redirectURL === null) {
+            return false;
         }
 
-        return false;
+        // Ensure the original URI has a query string
+        $query = parse_url($requestURI, PHP_URL_QUERY);
+        if ($query === null || $query === '' || $query === false) {
+            return false;
+        }
+
+        // Parse sub-parameters from the redirect URL
+        $redirectQuery = parse_url($redirectURL, PHP_URL_QUERY);
+        if ($redirectQuery === null || $redirectQuery === false) {
+            return false;
+        }
+
+        parse_str($redirectQuery, $redirectParams);
+
+        // Validate 'start' date parameter
+        $start = $redirectParams['start'] ?? null;
+        $validStart = is_string($start)
+            && preg_match('/^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/', $start) === 1;
+
+        // Validate 'ct' calendar type parameter
+        $ct = $redirectParams['ct'] ?? null;
+        $validCt = is_string($ct) && in_array($ct, [
+            CalendarTypes::Day,
+            CalendarTypes::Week,
+            CalendarTypes::Month,
+        ], strict: true);
+
+        return $validStart && $validCt;
     }
 
     /**
@@ -186,9 +214,12 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $pattern = '/[?&]' . preg_quote($param, '/') . '=(true|false)(?:&|$)/i';
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return false;
+        }
 
-        return preg_match($pattern, $requestURI) === 1;
+        return in_array(strtolower($value), ['true', 'false'], strict: true);
     }
 
     /**
@@ -205,15 +236,12 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
             return false; // Reject URLs containing potential XSS payloads
         }
 
-        $paramPresentPattern = '/[?&]' . preg_quote($param, '/') . '=([^&]*)/';
-
-        if (!preg_match($paramPresentPattern, $requestURI)) {
-            return true;
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return true; // Parameter absent — no constraint to enforce
         }
 
-        $pattern = '/[?&]' . preg_quote($param, '/') . '=' . preg_quote($expectedValue, '/') . '(?:&|$)/';
-
-        return preg_match($pattern, $requestURI) === 1;
+        return $value === $expectedValue;
     }
 
 

--- a/tests/Infrastructure/Common/URIParamValidatorTest.php
+++ b/tests/Infrastructure/Common/URIParamValidatorTest.php
@@ -67,6 +67,35 @@ class URIParamValidatorTest extends TestBase
         $this->assertFalse($result);
     }
 
+    /**
+     * @dataProvider numericalValidatorProvider
+     */
+    public function testNumericalValidator(string $uri, bool $expected)
+    {
+        $result = ParamsValidatorMethods::numericalValidator('uid', $uri);
+        $this->assertSame($expected, $result, "Failed for URI: $uri");
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function numericalValidatorProvider(): array
+    {
+        return [
+            'valid digits' => ['/Web/view-schedule.php?uid=123', true],
+            'zero is valid' => ['/Web/view-schedule.php?uid=0', true],
+            'trailing alpha rejected' => ['/Web/view-schedule.php?uid=123abc', false],
+            'leading alpha rejected' => ['/Web/view-schedule.php?uid=abc123', false],
+            'float rejected' => ['/Web/view-schedule.php?uid=1.5', false],
+            'scientific notation rejected' => ['/Web/view-schedule.php?uid=1e10', false],
+            'negative rejected' => ['/Web/view-schedule.php?uid=-1', false],
+            'empty value rejected' => ['/Web/view-schedule.php?uid=', false],
+            'missing param rejected' => ['/Web/view-schedule.php?other=123', false],
+            'array param rejected' => ['/Web/view-schedule.php?uid[]=123', false],
+            'repeated array param rejected' => ['/Web/view-schedule.php?uid[]=1&uid[]=2', false],
+        ];
+    }
+
     public function testExistsInURLValidatorPassesWhenParamHasValue()
     {
         $result = ParamsValidatorMethods::existsInURLValidator('sid', '/Web/reservation.php?sid=123&rid=456');
@@ -109,6 +138,7 @@ class URIParamValidatorTest extends TestBase
             'xss script tag rejected' => ['dr', 'reservations', '/Web/view-schedule.php?dr=reservations&x=%3Cscript%3E', false],
             'xss script tag rejected even when param absent' => ['dr', 'reservations', '/Web/view-schedule.php?x=%3Cscript%3E', false],
             'xss double quotes rejected' => ['dr', 'reservations', '/Web/view-schedule.php?dr=reservations&x=%22alert%22', false],
+            'array param treated as absent' => ['dr', 'reservations', '/Web/view-schedule.php?dr[]=reservations', true],
         ];
     }
 
@@ -142,6 +172,7 @@ class URIParamValidatorTest extends TestBase
             'missing param' => ['/Web/reservation.php?other=value', false],
             'empty param' => ['/Web/reservation.php?sd=', false],
             'with seconds rejected' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 08:00:00'), false],
+            'array param rejected' => ['/Web/reservation.php?sd[]=2026-03-23+08%3A00', false],
         ];
     }
 
@@ -176,6 +207,34 @@ class URIParamValidatorTest extends TestBase
             'missing param' => ['/Web/reservation.php?other=value', false],
             'empty param' => ['/Web/reservation.php?sd=', false],
             'without seconds rejected' => ['/Web/reservation.php?sd=' . urlencode('2026-03-23 08:00'), false],
+            'array param rejected' => ['/Web/reservation.php?sd[]=2026-03-23+08%3A00%3A00', false],
+        ];
+    }
+
+    /**
+     * @dataProvider arrayParamRejectedProvider
+     */
+    public function testArrayParamRejectedAcrossValidators(string $validator, string $param, string $uri)
+    {
+        $result = match ($validator) {
+            'existsInURL' => ParamsValidatorMethods::existsInURLValidator($param, $uri),
+            'boolean' => ParamsValidatorMethods::booleanValidator($param, $uri),
+            'date' => ParamsValidatorMethods::dateValidator($param, $uri),
+            'simpleDateList' => ParamsValidatorMethods::simpleDateValidatorList($param, $uri),
+        };
+        $this->assertFalse($result, "Array param should be rejected by $validator for URI: $uri");
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function arrayParamRejectedProvider(): array
+    {
+        return [
+            'existsInURL rejects array' => ['existsInURL', 'sid', '/Web/reservation.php?sid[]=123'],
+            'boolean rejects array' => ['boolean', 'show', '/Web/view-schedule.php?show[]=true'],
+            'date rejects array' => ['date', 'sd', '/Web/reservation.php?sd[]=2026-03-23'],
+            'simpleDateList rejects array' => ['simpleDateList', 'sd', '/Web/reservation.php?sd[]=2026-03-23'],
         ];
     }
 }


### PR DESCRIPTION
…arse_str

Use PHP's built-in parse_url() and parse_str() for query parameter extraction instead of hand-rolled regex patterns in each validator method. This centralizes extraction in a single getQueryParam() helper, reducing duplication and improving readability.

Also fixes a bug where numericalValidator accepted values like '123abc' because the regex ([0-9]+) only captured leading digits, and is_numeric("123") always returned true. Now uses ctype_digit() which correctly rejects non-digit-only strings.