### PR TITLE
fix(blackouts): require repeat-until for interval recurrence

### DIFF
--- a/Web/scripts/ajax-helpers.js
+++ b/Web/scripts/ajax-helpers.js
@@ -171,7 +171,12 @@ function BeforeFormSubmit(formData, jqForm, opts) {
     .each(function (index, ele) {
       if ($(ele).is(':visible') && $(ele).val() == '' && $(ele).attr('disabled') != 'disabled') {
         isValid = false;
-        $(ele).closest('.has-feedback').addClass('is-invalid');
+        var invalidTarget = $(ele).closest('.has-feedback');
+        if (invalidTarget.length == 0) {
+          // Some controls, such as flatpickr alt inputs, do not have a has-feedback wrapper.
+          invalidTarget = $(ele);
+        }
+        invalidTarget.addClass('is-invalid');
       }
     });
 

--- a/Web/scripts/recurrence.js
+++ b/Web/scripts/recurrence.js
@@ -80,9 +80,34 @@ function Recurrence(recurOptions, recurElements, prefix) {
     element.addClass('d-none'); //.removeClass('d-inline')
   };
 
+  var RequiresTerminationDate = function (repeatType) {
+    return ['daily', 'weekly', 'monthly', 'yearly'].includes(repeatType);
+  };
+
+  var UpdateTerminationDateValidation = function () {
+    var isRequired = RequiresTerminationDate(elements.repeatOptions.val());
+    var altInput = elements.repeatTermination[0]?._flatpickr?.altInput
+      ? $(elements.repeatTermination[0]._flatpickr.altInput)
+      : $();
+    var requiredAsterisk = $('#' + prefix + 'repeatUntilDiv').find('.required-asterisk');
+
+    // Ensure the hidden original flatpickr input is never marked as required.
+    // Apply native required validation only to the visible alt input.
+    elements.repeatTermination.prop('required', false);
+    elements.repeatTermination.removeClass('required');
+    altInput.prop('required', isRequired);
+    altInput.toggleClass('required', isRequired);
+    requiredAsterisk.toggleClass('d-none', !isRequired);
+
+    if (!isRequired) {
+      elements.repeatTermination.removeClass('is-invalid');
+      altInput.removeClass('is-invalid');
+    }
+  };
+
   var ChangeRepeatOptions = function () {
     var repeatDropDown = elements.repeatOptions;
-    if (repeatDropDown.val() != 'none' && repeatDropDown.val() != 'custom') {
+    if (RequiresTerminationDate(repeatDropDown.val())) {
       show($('#' + prefix + 'repeatUntilDiv'));
     } else {
       hide($('.recur-toggle', elements.repeatDiv));
@@ -114,6 +139,7 @@ function Recurrence(recurOptions, recurElements, prefix) {
       show($('.specific-dates', elements.repeatDiv));
     }
 
+    UpdateTerminationDateValidation();
     NotifyChange();
   };
 

--- a/lang/ar.php
+++ b/lang/ar.php
@@ -832,6 +832,7 @@ class ar extends en_us
         $strings['ConflictingReservationDates'] = 'توجد حجوزات متضاربة في التواريخ التالية:';
         $strings['InstancesOverlapRule'] = 'تتداخل بعض حالات سلسلة الحجز:';
         $strings['StartDateBeforeEndDateRule'] = 'يجب أن يكون تاريخ ووقت البدء قبل تاريخ ووقت الانتهاء.';
+        $strings['RecurringWithoutTerminationRule'] = 'تاريخ الانتهاء مطلوب لعمليات الحجب المتكررة.';
         $strings['StartIsInPast'] = 'لا يمكن أن يكون تاريخ ووقت البدء في الماضي.';
         $strings['EmailDisabled'] = 'قام المسؤول بتعطيل إشعارات البريد الإلكتروني.';
         $strings['ValidLayoutRequired'] = 'يجب توفير الخانات الزمنية لجميع الـ 24 ساعة من اليوم التي تبدأ وتنتهي في 00:00.';

--- a/lang/bg_bg.php
+++ b/lang/bg_bg.php
@@ -396,6 +396,7 @@ class bg_bg extends en_gb
         $strings['NoResourcePermission'] = 'Вие нямате права за достъп до един или повече от поисканите ресурси';
         $strings['ConflictingReservationDates'] = 'Има противоречиви резервации на следните дати:';
         $strings['StartDateBeforeEndDateRule'] = 'Началната дата и час трябва да бъде преди крайната дата и час';
+        $strings['RecurringWithoutTerminationRule'] = 'Крайна дата е задължителна за повтарящи се блокирания.';
         $strings['StartIsInPast'] = 'Началната дата и час не могат да бъдат в миналото';
         $strings['EmailDisabled'] = 'Администраторът е забранил известия по имейл';
         $strings['ValidLayoutRequired'] = 'Времеви интервали трябва да бъдат осигурени за всички 24 часа на денонощието, започвайки и завършвайки в 12:00 ч.';

--- a/lang/ca.php
+++ b/lang/ca.php
@@ -319,6 +319,7 @@ class ca extends en_gb
         $strings['NoResourcePermission'] = 'No tens permisos per accedir a un o m&eacute;s dels recursos requerits';
         $strings['ConflictingReservationDates'] = 'Hi ha conflictes a les reserves de les seguents dates:';
         $strings['StartDateBeforeEndDateRule'] = 'La data d\'Inici ha de ser anterior que la data final';
+        $strings['RecurringWithoutTerminationRule'] = 'Cal una data de finalització per als bloquejos recurrents.';
         $strings['StartIsInPast'] = 'La data inicial no pot ser passada';
         $strings['EmailDisabled'] = 'L\'administrador ha desactivat les notificacions per email';
         $strings['ValidLayoutRequired'] = 'S\'han de proporcionar slots per les 24 hores del dia comen&ccedil;ant i acabant a les 12:00 AM.';

--- a/lang/cz.php
+++ b/lang/cz.php
@@ -663,6 +663,7 @@ class cz extends en_us
         $strings['NoResourcePermission'] = 'Nemáte oprávnění pro vstup k jednomu nebo více požadovaným prostředkům';
         $strings['ConflictingReservationDates'] = 'Zde je výpis rezervací, které jsou v konfliktu s Vámi vytvořenou:';
         $strings['StartDateBeforeEndDateRule'] = 'Začátek rezervace musí začínat dříve než její konec.';
+        $strings['RecurringWithoutTerminationRule'] = 'Pro opakované blokace je vyžadováno datum ukončení.';
         $strings['StartIsInPast'] = 'Začátek rezervace nemůže být vytvořen v minulosti';
         $strings['EmailDisabled'] = 'Administrátor zakázal posílání e-mailových upozornění.';
         $strings['ValidLayoutRequired'] = 'Časový úsek musí být vytvořen na celý den - 24hodin';

--- a/lang/da_da.php
+++ b/lang/da_da.php
@@ -827,6 +827,7 @@ class da_da extends en_gb
         $strings['ConflictingReservationDates'] = 'Der er konflikter mellem reservationer på følgende datoer.';
         $strings['InstancesOverlapRule'] = 'I nogle af reservationerne i serien er der overlap.';
         $strings['StartDateBeforeEndDateRule'] = 'Begyndelsestidspunktet skal være før sluttidspunktet.';
+        $strings['RecurringWithoutTerminationRule'] = 'En slutdato er påkrævet for gentagne blokeringer.';
         $strings['StartIsInPast'] = 'Begyndelsestidspunktet kan ikke være i fortiden';
         $strings['EmailDisabled'] = 'Din administrator har fjernet muligheden for at få besked via e-mail.';
         $strings['ValidLayoutRequired'] = 'Tidsintervallerne skal dække alle 24 timer i døgnet og begynde og slutte kl. 00:00.';

--- a/lang/de_de.php
+++ b/lang/de_de.php
@@ -813,6 +813,7 @@ class de_de extends en_gb
         $strings['NoResourcePermission'] = 'Sie haben keine Berechtigung für eine oder mehrere der angefragten Ressourcen';
         $strings['ConflictingReservationDates'] = 'Es gibt in Konflikt stehende Reservierungen an folgenden Tagen:';
         $strings['StartDateBeforeEndDateRule'] = 'Der Startzeitpunkt muss vor dem Endzeitpunkt liegen';
+        $strings['RecurringWithoutTerminationRule'] = 'Ein Enddatum ist für wiederkehrende Blockierungen erforderlich.';
         $strings['StartIsInPast'] = 'Der Startzeitpunkt darf nicht in der Vergangenheit liegen';
         $strings['EmailDisabled'] = 'Em-Mail-Benachrichtigungen wurden vom Administrator deaktiviert';
         $strings['ValidLayoutRequired'] = 'Zeitfenster müssen für alle 24 Stunden eines Tages vorgegeben werden, von und bis 0 Uhr.';

--- a/lang/du_be.php
+++ b/lang/du_be.php
@@ -319,6 +319,7 @@ class du_be extends en_gb
         $strings['NoResourcePermission'] = 'U hebt onvoldoende rechten om toegang tot een of meerdere van de resources te verkrijgen';
         $strings['ConflictingReservationDates'] = 'Er zijn conflicterende reserveringen op volgende data:';
         $strings['StartDateBeforeEndDateRule'] = 'De startdatum moet voor de einddatum liggen';
+        $strings['RecurringWithoutTerminationRule'] = 'Een einddatum is vereist voor terugkerende blokkeringen.';
         $strings['StartIsInPast'] = 'Een startdatum in het verleden is ongeldig';
         $strings['EmailDisabled'] = 'De beheerder zette de optie email meldingen af';
         $strings['ValidLayoutRequired'] = 'Slots moeten voor de volledige 24 uren van de dag voorzien worden, beginnend en eindigend om 12:00 AM.';

--- a/lang/du_nl.php
+++ b/lang/du_nl.php
@@ -816,6 +816,7 @@ class du_nl extends en_gb
         $strings['ConflictingReservationDates'] = 'Er zijn conflicterende reserveringen op volgende data:';
         $strings['InstancesOverlapRule'] = 'Sommige exemplaren van de reserveringsreeks overlappen elkaar:';
         $strings['StartDateBeforeEndDateRule'] = 'De startdatum moet voor de einddatum liggen';
+        $strings['RecurringWithoutTerminationRule'] = 'Een einddatum is vereist voor terugkerende blokkeringen.';
         $strings['StartIsInPast'] = 'Een startdatum in het verleden is ongeldig';
         $strings['EmailDisabled'] = 'De beheerder zette de optie email meldingen af';
         $strings['ValidLayoutRequired'] = 'Slots moeten voor de volledige 24 uren van de dag voorzien worden, beginnend en eindigend om 12:00 AM.';

--- a/lang/ee_ee.php
+++ b/lang/ee_ee.php
@@ -617,6 +617,7 @@ class ee_ee extends en_gb
         $strings['NoResourcePermission'] = 'You do not have permission to access one or more of the requested resources';
         $strings['ConflictingReservationDates'] = 'Järgnevatel kuupäevadel on vastuolulised broneeringud:';
         $strings['StartDateBeforeEndDateRule'] = 'Broneeringu algusaeg peab olema enne lõppemisaega';
+        $strings['RecurringWithoutTerminationRule'] = 'Korduvate blokkide jaoks on lõppkuupäev nõutav.';
         $strings['StartIsInPast'] = 'Alguse kuupäev ja aeg ei tohi olla juba möödunud';
         $strings['EmailDisabled'] = 'Administraator on keelanud emailile teavitamise';
         $strings['ValidLayoutRequired'] = 'Slots must be provided for all 24 hours of the day beginning and ending at 12:00 AM.';

--- a/lang/el_gr.php
+++ b/lang/el_gr.php
@@ -844,6 +844,7 @@ class el_gr extends en_gb
         $strings['ConflictingReservationDates'] = 'Υπάρχουν κρατήσεις σε σύγκρουση για τις ακόλουθες ημερομηνίες:';
         $strings['InstancesOverlapRule'] = 'Ορισμένα στιγμιότυπα της σειράς κρατήσεων αλληλοεπικαλύπτονται:';
         $strings['StartDateBeforeEndDateRule'] = 'Η ημερομηνία και ώρα έναρξης πρέπει να είναι πριν την ημερομηνία και ώρα λήξης.';
+        $strings['RecurringWithoutTerminationRule'] = 'Απαιτείται ημερομηνία λήξης για επαναλαμβανόμενες δεσμεύσεις.';
         $strings['StartIsInPast'] = 'Η ημερομηνία και ώρα έναρξης δεν μπορούν να είναι στο παρελθόν.';
         $strings['EmailDisabled'] = 'Ο διαχειριστής έχει απενεργοποιήσει τις ειδοποιήσεις με email.';
         $strings['ValidLayoutRequired'] = 'Τα κενά πρέπει να παρέχονται για όλες τις 24 ώρες της ημέρας με αρχή και λήξη στις 12:00 ΠΜ.';

--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -859,6 +859,7 @@ class en_us extends Language
         $strings['ConflictingReservationDates'] = 'There are conflicting reservations on the following dates:';
         $strings['InstancesOverlapRule'] = 'Some instances of the reservation series overlap:';
         $strings['StartDateBeforeEndDateRule'] = 'The start date and time must be before the end date and time.';
+        $strings['RecurringWithoutTerminationRule'] = 'A termination date is required for recurring blackouts.';
         $strings['StartIsInPast'] = 'The start date and time cannot be in the past.';
         $strings['EmailDisabled'] = 'The administrator has disabled email notifications.';
         $strings['ValidLayoutRequired'] = 'Slots must be provided for all 24 hours of the day beginning and ending at 00:00.';

--- a/lang/es.php
+++ b/lang/es.php
@@ -823,6 +823,7 @@ class es extends en_gb
         $strings['ConflictingReservationDates'] = 'Hay conflictos en las reservas de las siguientes fechas:';
         $strings['InstancesOverlapRule'] = 'Algunas instancias de la serie de reservas se solapan:';
         $strings['StartDateBeforeEndDateRule'] = 'La fecha de inicio debe ser anterior a la fecha final';
+        $strings['RecurringWithoutTerminationRule'] = 'Se requiere una fecha de finalización para los bloqueos recurrentes.';
         $strings['StartIsInPast'] = 'La fecha inicial no puede ser pasada';
         $strings['EmailDisabled'] = 'El administrador ha desactivado las notificaciones por correo';
         $strings['ValidLayoutRequired'] = 'Se deben proporcionar intervalos de tiempo para las 24 horas del día comenzando y terminando a las 12:00 AM.';

--- a/lang/eu_es.php
+++ b/lang/eu_es.php
@@ -586,6 +586,7 @@ class eu_es extends en_gb
         $strings['NoResourcePermission'] = 'Ez duzu baimenik eskatutako baliabideren baterako';
         $strings['ConflictingReservationDates'] = 'Data hauetako erreserben arteko gatazkak daude:';
         $strings['StartDateBeforeEndDateRule'] = 'Hasiera datak amaiera data baino lehenago izan behar duLa fecha de inicio debe ser anterior a la fecha final';
+        $strings['RecurringWithoutTerminationRule'] = 'Amaiera data beharrezkoa da blokeaketa errepikakorrentzat.';
         $strings['StartIsInPast'] = 'Hasiera data ezin da pasatutakoa izan';
         $strings['EmailDisabled'] = 'Kudeatzaileak posta bidezko jakinarazpenak desgaitu ditu';
         $strings['ValidLayoutRequired'] = 'Eguneko 24 orduetarako denbora tarteak eman behar dira 12:00 AM-n hasita eta bukatuta.';

--- a/lang/fi_fi.php
+++ b/lang/fi_fi.php
@@ -795,6 +795,7 @@ class fi_fi extends en_gb
         $strings['ConflictingReservationDates'] = 'Seuraavina päivinä on ristiriidan aiheuttavia toisia varauksia: ';
         $strings['InstancesOverlapRule'] = 'Jotkut varaussarjan esiintymät menevät päällekkäin:';
         $strings['StartDateBeforeEndDateRule'] = 'Aloituspäivän tulee olla ennen varauksen loppumispäivää';
+        $strings['RecurringWithoutTerminationRule'] = 'Toistuvalle estolle vaaditaan päättymispäivä.';
         $strings['StartIsInPast'] = 'Aloituspäivä ei voi olla menneisyydessä';
         $strings['EmailDisabled'] = 'Moderaattori on estänyt automaattiset sähköposti-ilmoitukset';
         $strings['ValidLayoutRequired'] = 'Varaa kaikki 24 tuntia alkaen ja päättyen klo 00:00.';

--- a/lang/fr_fr.php
+++ b/lang/fr_fr.php
@@ -822,6 +822,7 @@ class fr_fr extends en_gb
         $strings['ConflictingReservationDates'] = 'Il y a des réservations en conflit à la date suivante:';
         $strings['InstancesOverlapRule'] = 'Plusieurs instances de la réservation se chevauchent:';
         $strings['StartDateBeforeEndDateRule'] = 'La date de départ doit être avant la date de fin';
+        $strings['RecurringWithoutTerminationRule'] = 'Une date de fin est requise pour les blocages récurrents.';
         $strings['StartIsInPast'] = 'La date de départ ne peut être passée';
         $strings['EmailDisabled'] = 'L\'administrateur a désactivé les notifications par email.';
         $strings['ValidLayoutRequired'] = 'Les créneaux doivent couvrir 24 heures (de minuit à minuit).';

--- a/lang/he.php
+++ b/lang/he.php
@@ -624,6 +624,7 @@ class he extends en_gb
         $strings['NoResourcePermission'] = 'אין לך הרשאות לגשת לאחד או יותר מהמשאבים המבוקשים';
         $strings['ConflictingReservationDates'] = 'כבר קיימת הזמנה לחדר זה באותו מועד:';
         $strings['StartDateBeforeEndDateRule'] = 'תאריך/שעת התחלה חייב להיות לפני תאריך/שעת סיום';
+        $strings['RecurringWithoutTerminationRule'] = 'נדרש תאריך סיום עבור חסימות חוזרות.';
         $strings['StartIsInPast'] = 'תאריך/שעת התחלה לא יכול להיות בעבר';
         $strings['EmailDisabled'] = 'מנהל המערכת ביטל הודעות באמצעות דואר אלקטרוני';
         $strings['ValidLayoutRequired'] = 'יש לשבץ כל 24 שעות היממא, החל ומסיים בחצות הלילה.';

--- a/lang/hr_hr.php
+++ b/lang/hr_hr.php
@@ -502,6 +502,7 @@ class hr_hr extends en_gb
         $strings['NoResourcePermission'] = 'Nemate prava za pristup resursima.';
         $strings['ConflictingReservationDates'] = 'Postoje rezervacije u konfliktu za slijedeci datum:';
         $strings['StartDateBeforeEndDateRule'] = 'Datum i vrijeme pocetka mora biti prije datuma i vremena kraja.';
+        $strings['RecurringWithoutTerminationRule'] = 'Datum završetka je obavezan za ponavljajuće blokade.';
         $strings['StartIsInPast'] = 'Datum i vrijeme pocetka ne moďż˝e biti u proďż˝losti.';
         $strings['EmailDisabled'] = 'Administrator je iskljucio email obavijesti.';
         $strings['ValidLayoutRequired'] = 'Slots must be provided for all 24 hours of the day beginning and ending at 12:00 AM.';

--- a/lang/hu_hu.php
+++ b/lang/hu_hu.php
@@ -807,6 +807,7 @@ class hu_hu extends en_us
         $strings['NoResourcePermission'] = 'Nincs megfeleő joga hozzáférni egy vagy több elemhez.';
         $strings['ConflictingReservationDates'] = 'Ütköző fogalások vannak az alábbi dátumokon:';
         $strings['StartDateBeforeEndDateRule'] = 'A kezdés dátuma és időpontja a befejezés dátumának és időpontjának előtt kell, hogy legyen.';
+        $strings['RecurringWithoutTerminationRule'] = 'Az ismétlődő zárolásokhoz befejezési dátum szükséges.';
         $strings['StartIsInPast'] = 'A kezdés dátuma és időpontja nem lehet a múltban.';
         $strings['EmailDisabled'] = 'Az admin letiltotta az e-mail értesítőket.';
         $strings['ValidLayoutRequired'] = 'A rekeszeket egész napra be kell osztani.';

--- a/lang/id_id.php
+++ b/lang/id_id.php
@@ -465,6 +465,7 @@ class id_id extends en_gb
         $strings['NoResourcePermission'] = 'Anda tidak memiliki akses untuk resource yang diminta';
         $strings['ConflictingReservationDates'] = 'Terjadi bentrokan reservasi pada tanggal berikut:';
         $strings['StartDateBeforeEndDateRule'] = 'Tanggal dan waktu mulai harus sebelum tanggal dan waktu berakhir';
+        $strings['RecurringWithoutTerminationRule'] = 'Tanggal akhir diperlukan untuk pemblokiran berulang.';
         $strings['StartIsInPast'] = 'Tanggal dan waktu mulai tidak bisa dilakukan pada masa lampau';
         $strings['EmailDisabled'] = 'Administrator menonatifkan email pemberitahuan';
         $strings['ValidLayoutRequired'] = 'Slot harus tersedia pada semua 24 jam sehari dimulai dan diakhiri pada 12:00 AM.';

--- a/lang/it_it.php
+++ b/lang/it_it.php
@@ -812,6 +812,7 @@ class it_it extends en_gb
         $strings['ConflictingReservationDates'] = 'Ci sono prenotazioni in conflitto nelle seguenti date:';
         $strings['InstancesOverlapRule'] = 'Qualche istanza della serie di prenotazioni si sovrappone:';
         $strings['StartDateBeforeEndDateRule'] = 'La data di inizio deve essere antecedente alla data di fine';
+        $strings['RecurringWithoutTerminationRule'] = 'È richiesta una data di termine per i blocchi ricorrenti.';
         $strings['StartIsInPast'] = 'La data di inizio non può essere nel passato';
         $strings['EmailDisabled'] = 'L\'amministratore ha disabilitato le notifiche via email';
         $strings['ValidLayoutRequired'] = 'L\'insieme delle fasce orarie deve coprire tutte le 24 ore del giorno iniziando e finendo alle 00:00.';

--- a/lang/ja_jp.php
+++ b/lang/ja_jp.php
@@ -829,6 +829,7 @@ class ja_jp extends en_gb
         $strings['NoResourcePermission'] = 'リソースを使用する権限がありません';
         $strings['ConflictingReservationDates'] = '次の日時で予約が重なっています:';
         $strings['StartDateBeforeEndDateRule'] = '開始日時を終了よりも前にしてください。';
+        $strings['RecurringWithoutTerminationRule'] = '繰り返しブラックアウトには終了日が必要です。';
         $strings['StartIsInPast'] = '開始時刻を過ぎていいます。';
         $strings['EmailDisabled'] = '管理者がメールでの通知を無効にしています。';
         $strings['ValidLayoutRequired'] = '時間枠は一日の最初から最後(12:00 AM)までの24時間全てを網羅するようにしてください。';

--- a/lang/lt.php
+++ b/lang/lt.php
@@ -811,6 +811,7 @@ class lt extends en_gb
         $strings['ConflictingReservationDates'] = 'Yra susikertančių rezervacijų šiomis datomis:';
         $strings['InstancesOverlapRule'] = 'Some instances of the reservation series overlap:';
         $strings['StartDateBeforeEndDateRule'] = 'Pradžios laikas turi būti anksčiau už pabaigos laiką';
+        $strings['RecurringWithoutTerminationRule'] = 'Pasikartojančioms blokavimo datos reikalinga pabaigos data.';
         $strings['StartIsInPast'] = 'Pradžios laikas negali būti praeityje';
         $strings['EmailDisabled'] = 'Administratorius išjungęs perspėjimus paštu';
         $strings['ValidLayoutRequired'] = 'Pateiktos nišos turi padengti visą parą nuo 00h iki 24h';

--- a/lang/no_no.php
+++ b/lang/no_no.php
@@ -512,6 +512,7 @@ class no_no extends en_gb
         $strings['NoResourcePermission'] = 'Du har ikke tilgangsrettigheter til en eller flere av de anmodede enheter.';
         $strings['ConflictingReservationDates'] = 'Det er konflikt i reservasjonene på følgende datoer:';
         $strings['StartDateBeforeEndDateRule'] = 'Starttid må være før sluttid.';
+        $strings['RecurringWithoutTerminationRule'] = 'En sluttdato er påkrevd for gjentakende blokkeringer.';
         $strings['StartIsInPast'] = 'Du må velge en starttid som ikke er passert.';
         $strings['EmailDisabled'] = 'Adiministrator har slått av epostkunngjøringer.';
         $strings['ValidLayoutRequired'] = 'Tidsperioder må angis for alle 24 timer, men begynnelse og slutt kl 12:00 AM.';

--- a/lang/pl.php
+++ b/lang/pl.php
@@ -851,6 +851,7 @@ class pl extends en_gb
         $strings['ConflictingReservationDates'] = 'Istnieją konflikty rezerwacji w podanych dniach:';
         $strings['InstancesOverlapRule'] = 'Rezerwacje nakładają się na siebie:';
         $strings['StartDateBeforeEndDateRule'] = 'Data rozpoczęcia musi być wcześniejsza niż data zakończenia';
+        $strings['RecurringWithoutTerminationRule'] = 'Data zakończenia jest wymagana dla powtarzających się blokad.';
         $strings['StartIsInPast'] = 'Data rozpoczęcia nie może być datą z przeszłości';
         $strings['EmailDisabled'] = 'Administrator wyłączył powiadomienia mailowe';
         $strings['ValidLayoutRequired'] = 'Wpisy muszą być uzupełnione dla wszystkich 24 godzin od rozpoczęcia dnia aż do północy.';

--- a/lang/pt_br.php
+++ b/lang/pt_br.php
@@ -836,6 +836,7 @@ class pt_br extends en_gb
         $strings['ConflictingReservationDates'] = 'Há reservas conflitantes nas seguintes datas:';
         $strings['InstancesOverlapRule'] = 'Algumas instâncias da série de reservas se sobrepõem:';
         $strings['StartDateBeforeEndDateRule'] = 'A data e a hora de início devem ser anteriores à data e à hora de término.';
+        $strings['RecurringWithoutTerminationRule'] = 'Uma data de término é obrigatória para bloqueios recorrentes.';
         $strings['StartIsInPast'] = 'A data e a hora de início não podem ser no passado.';
         $strings['EmailDisabled'] = 'O administrador desativou as notificações por e-mail.';
         $strings['ValidLayoutRequired'] = 'Intervalos devem ser fornecidas para todas as 24 horas do dia começando e terminando às 00:00.';

--- a/lang/pt_pt.php
+++ b/lang/pt_pt.php
@@ -818,6 +818,7 @@ class pt_pt extends en_gb
         $strings['Standard'] = 'Padrão';
         $strings['StandardScheduleDisplay'] = 'Utilize a exibição de agenda padrão';
         $strings['StartDateBeforeEndDateRule'] = 'A data de início deve ser anterior à data de término';
+        $strings['RecurringWithoutTerminationRule'] = 'É necessária uma data de término para bloqueios recorrentes.';
         $strings['StartIsInPast'] = 'A data de início não pode ser no passado';
         $strings['StartTime'] = 'Hora de início';
         $strings['StartsOn'] = 'Inicia em';

--- a/lang/ro_ro.php
+++ b/lang/ro_ro.php
@@ -409,6 +409,7 @@ class ro_ro extends en_gb
         $strings['NoResourcePermission'] = 'Nu aveți permisiunea de a avea acces la una sau mai multe; din resursele necesare';
         $strings['ConflictingReservationDates'] = 'Există rezervari contradictorii cu privire la următoarele date:';
         $strings['StartDateBeforeEndDateRule'] = 'Data de începere trebuie să fie anterioară datei de încheiere';
+        $strings['RecurringWithoutTerminationRule'] = 'O dată de încheiere este necesară pentru blocările recurente.';
         $strings['StartIsInPast'] = 'Data de inceput nu poate fi stabilita in trecut';
         $strings['EmailDisabled'] = 'Administratorul a restrictionat notificarea prin e-mail';
         $strings['ValidLayoutRequired'] = 'Gli Slots devono essere indicati per tutte le 24 ore del giorno partendo e finendo alle 12:00 AM.';

--- a/lang/ru_ru.php
+++ b/lang/ru_ru.php
@@ -650,6 +650,7 @@ class ru_ru extends en_gb
         $strings['NoResourcePermission'] = 'У вас нет разрешения на доступ к одному или нескольким из требуемых помещений.';
         $strings['ConflictingReservationDates'] = 'Существуют противоречивые Бронирования в следующих сроках:';
         $strings['StartDateBeforeEndDateRule'] = 'Дата и время начала должно быть до даты и времени окончания.';
+        $strings['RecurringWithoutTerminationRule'] = 'Для повторяющихся блокировок требуется дата окончания.';
         $strings['StartIsInPast'] = 'Дата и время начала не может быть в прошлом.';
         $strings['EmailDisabled'] = 'Администратор отключил уведомления по электронной почте.';
         $strings['ValidLayoutRequired'] = 'Слоты должны быть обеспечены для всех 24 часов дня начиная и заканчивая в 12:00 AM.';

--- a/lang/si_si.php
+++ b/lang/si_si.php
@@ -523,6 +523,7 @@ class si_si extends en_gb
         $strings['NoResourcePermission'] = 'Nimate dovoljenja za dostop do enega ali več zahtevanih virov.';
         $strings['ConflictingReservationDates'] = 'Obstajajo konfliktne rezervacije za naslednje datume:';
         $strings['StartDateBeforeEndDateRule'] = 'Začetni datum in čas rezervacije mora biti pred končnim datumom in časom.';
+        $strings['RecurringWithoutTerminationRule'] = 'Za ponavljajoče blokade je potreben končni datum.';
         $strings['StartIsInPast'] = 'Začetni in končni datum rezervacije ne more biti v preteklosti.';
         $strings['EmailDisabled'] = 'Administrator je onemogočil obveščanje po elektronski pošti.';
         $strings['ValidLayoutRequired'] = 'Termini morajo biti postavljeni za vseh 24 ur v dnevu z začetkom in koncem ob 12:00.';

--- a/lang/sk.php
+++ b/lang/sk.php
@@ -511,6 +511,7 @@ class sk extends en_gb
         $strings['NoResourcePermission'] = 'Nemáte oprávnenie k jednemu alebo viac požadovaným prostriedkom';
         $strings['ConflictingReservationDates'] = 'Tu je výpis rezervácií, ktoré sú v konflikte s Vami vytvorenou:';
         $strings['StartDateBeforeEndDateRule'] = 'Začiatok rezervácie musí začínať skôr ako jej koniec.';
+        $strings['RecurringWithoutTerminationRule'] = 'Pre opakované blokovania je vyžadovaný dátum ukončenia.';
         $strings['StartIsInPast'] = 'Začiatok rezervácie nemôže být vytvorený v minulosti';
         $strings['EmailDisabled'] = 'Administrátor zakázal odosielanie e-mailových upozornení.';
         $strings['ValidLayoutRequired'] = 'Časový úsek musí byť vytvorený na celý deň - 24 hodín';

--- a/lang/sr_sr.php
+++ b/lang/sr_sr.php
@@ -529,6 +529,7 @@ class sr_sr extends en_gb
         $strings['NoResourcePermission'] = 'Nemate prava za pristup resursima.';
         $strings['ConflictingReservationDates'] = 'Postoje rezervacije u konfliktu za sledeći datum:';
         $strings['StartDateBeforeEndDateRule'] = 'Datum i vreme početka mora biti pre datuma i vremena kraja.';
+        $strings['RecurringWithoutTerminationRule'] = 'Datum završetka je obavezan za ponavljajuće blokade.';
         $strings['StartIsInPast'] = 'Datum i vreme početka ne može biti u prošlosti.';
         $strings['EmailDisabled'] = 'Administrator je isključio e-mail obaveštenja.';
         $strings['ValidLayoutRequired'] = 'Slots must be provided for all 24 hours of the day beginning and ending at 12:00 AM.';

--- a/lang/sv_sv.php
+++ b/lang/sv_sv.php
@@ -456,6 +456,7 @@ class sv_sv extends en_gb
         $strings['NoResourcePermission'] = 'Du har ingen behörighet att komma åt begärd(a) lokal(er)'; // // tjänst --> lokal
         $strings['ConflictingReservationDates'] = 'Det finns motstridiga reservationer på följande datum:';
         $strings['StartDateBeforeEndDateRule'] = 'Startdatum och tid måste vara före slutdatum och tid';
+        $strings['RecurringWithoutTerminationRule'] = 'Ett slutdatum krävs för återkommande blockeringar.';
         $strings['StartIsInPast'] = 'Startdatum och tid kan inte vara i det förflutna';
         $strings['EmailDisabled'] = 'Administratören har inaktiverat e-postmeddelanden';
         $strings['ValidLayoutRequired'] = 'Tidsintervall skall lämnas för alla 24 timmar på dagen med början och slut vid 12:00 .';

--- a/lang/th_th.php
+++ b/lang/th_th.php
@@ -692,6 +692,7 @@ class th_th extends en_gb
         $strings['NoResourcePermission'] = 'คุณไม่มีสิทธิ์เข้าถึงแหล่งข้อมูลที่ร้องขออย่างน้อยหนึ่งรายการ';
         $strings['ConflictingReservationDates'] = 'มีการจองที่ขัดแย้งกันในวันที่ต่อไปนี้:';
         $strings['StartDateBeforeEndDateRule'] = 'วันที่และเวลาเริ่มต้นต้องอยู่ก่อนวันที่และเวลาสิ้นสุด';
+        $strings['RecurringWithoutTerminationRule'] = 'จำเป็นต้องระบุวันที่สิ้นสุดสำหรับการปิดกั้นที่เกิดซ้ำ';
         $strings['StartIsInPast'] = 'วันที่และเวลาเริ่มต้นไม่สามารถใช้วันที่ผ่านมาแล้วได้';
         $strings['EmailDisabled'] = 'ผู้ดูแลระบบปิดการแจ้งเตือนทางอีเมล';
         $strings['ValidLayoutRequired'] = 'สล็อตต้องมีการให้บริการตลอด 24 ชั่วโมงของวันเริ่มต้นและสิ้นสุดในเวลา 12:00 AM ';

--- a/lang/tr_tr.php
+++ b/lang/tr_tr.php
@@ -633,6 +633,7 @@ class tr_tr extends en_gb
         $strings['NoResourcePermission'] = 'You do not have permission to access one or more of the requested resources.';
         $strings['ConflictingReservationDates'] = 'Şu zaman için çakışma mevcut:';
         $strings['StartDateBeforeEndDateRule'] = 'The start date and time must be before the end date and time.';
+        $strings['RecurringWithoutTerminationRule'] = 'Tekrarlayan karartmalar için bir bitiş tarihi gereklidir.';
         $strings['StartIsInPast'] = 'The start date and time cannot be in the past.';
         $strings['EmailDisabled'] = 'The administrator has disabled email notifications.';
         $strings['ValidLayoutRequired'] = 'Slots must be provided for all 24 hours of the day beginning and ending at 12:00 AM.';

--- a/lang/vn_vn.php
+++ b/lang/vn_vn.php
@@ -605,6 +605,7 @@ class vn_vn extends en_gb
         $strings['NoResourcePermission'] = 'You do not have permission to access one or more of the requested resources.';
         $strings['ConflictingReservationDates'] = 'There are conflicting reservations on the following dates:';
         $strings['StartDateBeforeEndDateRule'] = 'The start date and time must be before the end date and time.';
+        $strings['RecurringWithoutTerminationRule'] = 'Ngày kết thúc là bắt buộc đối với các lần chặn định kỳ.';
         $strings['StartIsInPast'] = 'The start date and time cannot be in the past.';
         $strings['EmailDisabled'] = 'The administrator has disabled email notifications.';
         $strings['ValidLayoutRequired'] = 'Slots must be provided for all 24 hours of the day beginning and ending at 12:00 AM.';

--- a/lang/zh_cn.php
+++ b/lang/zh_cn.php
@@ -436,6 +436,7 @@ class zh_cn extends en_us
         $strings['NoResourcePermission'] = '您没有权限访问一个或一个以上的请求.';
         $strings['ConflictingReservationDates'] = '在接下来的日子里存在有冲突的预约:';
         $strings['StartDateBeforeEndDateRule'] = '开始时间和日期必须早于结束时间和日期';
+        $strings['RecurringWithoutTerminationRule'] = '重复黑名单需要设定终止日期。';
         $strings['StartIsInPast'] = '开始时间和日期必须比当前时间晚';
         $strings['EmailDisabled'] = '管理员已经禁止了邮件提醒';
         $strings['ValidLayoutRequired'] = '时间间隔必须提供全天24小时而且必须从上午12时开始并结束于上午12时.';

--- a/lang/zh_tw.php
+++ b/lang/zh_tw.php
@@ -507,6 +507,7 @@ class zh_tw extends en_us
         $strings['NoResourcePermission'] = '您沒有權限訪問一個或一個以上的請求.';
         $strings['ConflictingReservationDates'] = '在接下來的日子裡存在有衝突的預約:';
         $strings['StartDateBeforeEndDateRule'] = '開始時間和日期必須早於結束時間和日期';
+        $strings['RecurringWithoutTerminationRule'] = '重複封鎖需要設定終止日期。';
         $strings['StartIsInPast'] = '開始時間和日期必須比當前時間晚';
         $strings['EmailDisabled'] = '管理員已經禁止了郵件提醒';
         $strings['ValidLayoutRequired'] = '時間間隔必須提供全天24小時而且必須從上午12時開始並結束於上午12時.';

--- a/lib/Application/Reservation/ManageBlackoutsService.php
+++ b/lib/Application/Reservation/ManageBlackoutsService.php
@@ -101,6 +101,10 @@ class ManageBlackoutsService implements IManageBlackoutsService
             return new BlackoutDateTimeValidationResult();
         }
 
+        if ($this->HasMissingRequiredTerminationDate($repeatOptions)) {
+            return new BlackoutDateTimeValidationResult('RecurringWithoutTerminationRule');
+        }
+
         $userId = ServiceLocator::GetServer()->GetUserSession()->UserId;
 
         $blackoutSeries = BlackoutSeries::Create($userId, $title, $blackoutDate);
@@ -176,6 +180,21 @@ class ManageBlackoutsService implements IManageBlackoutsService
         return $conflictingBlackouts;
     }
 
+    /**
+     * Interval-based recurrence patterns need a repeat-until date to bound generated instances.
+     * Custom repeats are driven by explicit dates and therefore do not require one.
+     */
+    private function HasMissingRequiredTerminationDate(IRepeatOptions $repeatOptions): bool
+    {
+        $requiresTerminationDate = in_array(
+            $repeatOptions->RepeatType(),
+            [RepeatType::Daily, RepeatType::Weekly, RepeatType::Monthly, RepeatType::Yearly],
+            true
+        );
+
+        return $requiresTerminationDate && $repeatOptions->TerminationDate() instanceof NullDate;
+    }
+
     public function Delete($blackoutId, $updateScope)
     {
         if ($updateScope == SeriesUpdateScope::FullSeries) {
@@ -203,6 +222,10 @@ class ManageBlackoutsService implements IManageBlackoutsService
     {
         if (!$blackoutDate->GetEnd()->GreaterThan($blackoutDate->GetBegin())) {
             return new BlackoutDateTimeValidationResult();
+        }
+
+        if ($this->HasMissingRequiredTerminationDate($repeatOptions)) {
+            return new BlackoutDateTimeValidationResult('RecurringWithoutTerminationRule');
         }
 
         $userId = ServiceLocator::GetServer()->GetUserSession()->UserId;

--- a/lib/Application/Reservation/Validation/BlackoutDateTimeValidationResult.php
+++ b/lib/Application/Reservation/Validation/BlackoutDateTimeValidationResult.php
@@ -2,6 +2,13 @@
 
 class BlackoutDateTimeValidationResult implements IBlackoutValidationResult
 {
+    private string $messageKey;
+
+    public function __construct(string $messageKey = 'StartDateBeforeEndDateRule')
+    {
+        $this->messageKey = $messageKey;
+    }
+
     /**
      * @return bool
      */
@@ -15,7 +22,7 @@ class BlackoutDateTimeValidationResult implements IBlackoutValidationResult
      */
     public function Message()
     {
-        return Resources::GetInstance()->GetString('StartDateBeforeEndDateRule');
+        return Resources::GetInstance()->GetString($this->messageKey);
     }
 
     /**

--- a/tests/Application/Reservation/BlackoutsServiceTest.php
+++ b/tests/Application/Reservation/BlackoutsServiceTest.php
@@ -224,6 +224,72 @@ class BlackoutsServiceTest extends TestBase
         $this->assertNotEmpty($result->Message());
     }
 
+    public function testAddReturnsErrorWhenRecurringBlackoutHasNoTerminationDate()
+    {
+        $start = Date::Parse('2011-01-01 01:01:01');
+        $end = Date::Parse('2011-01-01 02:02:02');
+        $date = new DateRange($start, $end);
+        $resourceIds = [1];
+        $title = 'title';
+
+        $repeatWeekly = new RepeatWeekly(1, NullDate::Instance(), [1, 3, 5]);
+
+        $result = $this->service->Add($date, $resourceIds, $title, $this->conflictHandler, $repeatWeekly);
+
+        $this->assertFalse($result->WasSuccessful());
+        $this->assertNotEmpty($result->Message());
+        $this->assertNull($this->blackoutRepository->_Added);
+    }
+
+    public function testUpdateReturnsErrorWhenRecurringBlackoutHasNoTerminationDate()
+    {
+        $start = Date::Parse('2011-01-01 01:01:01');
+        $end = Date::Parse('2011-01-01 02:02:02');
+        $date = new DateRange($start, $end);
+        $resourceIds = [1];
+        $title = 'title';
+        $blackoutInstanceId = 10;
+
+        $repeatWeekly = new RepeatWeekly(1, NullDate::Instance(), [1, 3, 5]);
+
+        $result = $this->service->Update(
+            $blackoutInstanceId,
+            $date,
+            $resourceIds,
+            $title,
+            $this->conflictHandler,
+            $repeatWeekly,
+            SeriesUpdateScope::FullSeries
+        );
+
+        $this->assertFalse($result->WasSuccessful());
+        $this->assertNotEmpty($result->Message());
+        $this->assertNull($this->blackoutRepository->_Updated);
+    }
+
+    public function testAddAllowsCustomRecurringBlackoutWithoutTerminationDate()
+    {
+        $start = Date::Parse('2011-01-01 01:01:01');
+        $end = Date::Parse('2011-01-01 02:02:02');
+        $date = new DateRange($start, $end);
+        $resourceIds = [1];
+        $title = 'title';
+        $repeatCustom = new RepeatCustom([Date::Parse('2011-01-03'), Date::Parse('2011-01-05')]);
+
+        $this->reservationViewRepository->expects($this->exactly(3))
+                                        ->method('GetBlackoutsWithin')
+                                        ->willReturn([]);
+
+        $this->reservationViewRepository->expects($this->exactly(3))
+                                        ->method('GetReservations')
+                                        ->willReturn([]);
+
+        $result = $this->service->Add($date, $resourceIds, $title, $this->conflictHandler, $repeatCustom);
+
+        $this->assertTrue($result->WasSuccessful());
+        $this->assertNotNull($this->blackoutRepository->_Added);
+    }
+
     public function testDeletesBlackoutById()
     {
         $blackoutId = 123;

--- a/tpl/Controls/RecurrenceDiv.tpl
+++ b/tpl/Controls/RecurrenceDiv.tpl
@@ -94,9 +94,10 @@
 
 		<div id="{if isset($prefix)}{$prefix}{/if}repeatUntilDiv" class="d-none recur-toggle d-flex align-items-center">
 			<label class="fw-bold"
-				for="{if isset($prefix)}{$prefix}{/if}EndRepeat">{translate key="RepeatUntilPrompt"}</label>
+				for="{if isset($prefix)}{$prefix}{/if}EndRepeat">{translate key="RepeatUntilPrompt"} <i
+					class="bi bi-asterisk text-danger align-top text-small required-asterisk d-none"></i></label>
 			<input type="text" id="{if isset($prefix)}{$prefix}{/if}EndRepeat" {formname key=end_repeat_date}
-				class="form-control form-control-sm" />
+				class="form-control form-control-sm repeat-termination" />
 		</div>
 
 		<div id="{if isset($prefix)}{$prefix}{/if}customDatesDiv" class="d-none specific-dates">


### PR DESCRIPTION
Fix recurring blackout creation when interval-based recurrence is submitted
without a repeat-until date.

This PR addresses both sides of the problem:

- backend validation now rejects interval-based recurring blackouts that are
  missing a termination date
- the shared recurrence UI now marks `Repeat Until` as required for
  interval-based repeat types and blocks invalid submission before the
  request is sent

Custom recurrence remains allowed without a termination date because it is
driven by explicit dates rather than a repeat-until bound.

Closes: #913