### PR TITLE
chore(dependabot): add a 7 day cooldown for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     versioning-strategy: increase
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "pip"  # Python uses pip
     directory: "/"
@@ -22,6 +24,8 @@ updates:
       day: "saturday"
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/"
@@ -30,6 +34,8 @@ updates:
       day: "saturday"
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -38,3 +44,5 @@ updates:
       day: "saturday"
     commit-message:
       prefix: "chore(deps)"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
To be a bit safer, add a 7 day cooldown for updates. This means we will wait for a package to be released for 7 days, before an update will be proposed.