### PR TITLE
fix(validators): allow empty schedule filter params

### DIFF
--- a/lib/Common/Validators/URI/IParamsValidatorMethods.php
+++ b/lib/Common/Validators/URI/IParamsValidatorMethods.php
@@ -44,6 +44,27 @@ interface IParamsValidatorMethods
     public static function simpleDateValidatorList(string $param, string $requestURI): bool;
 
     /**
+     * Checks whether the parameter is empty or a valid comma-separated list
+     * of dates in YYYY-MM-DD or YYYY-M-D format.
+     *
+     * @param string $param         Query parameter in the URI
+     * @param string $requestURI    Request URI to check
+     *
+     * @return bool True if the parameter is valid
+     */
+    public static function optionalSimpleDateValidator(string $param, string $requestURI): bool;
+
+    /**
+     * Checks whether the parameter is empty or a numerical value.
+     *
+     * @param string $param         Query parameter in the URI
+     * @param string $requestURI    Request URI to check
+     *
+     * @return bool True if the parameter is valid
+     */
+    public static function optionalNumericValidator(string $param, string $requestURI): bool;
+
+    /**
      * Check if params is a valid date (YYYY-MM-DD HH:MM), hours and minutes can have one or two digits
      *
      * @param string $param         - Query param in URI
@@ -82,7 +103,6 @@ interface IParamsValidatorMethods
      * @return bool Returns true if is valid
      */
     public static function booleanValidator(string $param, string $requestURI): bool;
-
 
     /**
      * Check if param match with expecter value

--- a/lib/Common/Validators/URI/ParamsValidator.php
+++ b/lib/Common/Validators/URI/ParamsValidator.php
@@ -139,8 +139,14 @@ class ParamsValidator
             case ParamsValidatorKeys::EXISTS:
                 return ParamsValidatorMethods::existsInURLValidator($param, $requestURI);
 
+            case ParamsValidatorKeys::OPTIONAL_SIMPLEDATE:
+                return ParamsValidatorMethods::optionalSimpleDateValidator($param, $requestURI);
+
             case ParamsValidatorKeys::REDIRECT_GUEST_RESERVATION:
                 return ParamsValidatorMethods::redirectGuestReservationValidator($requestURI);
+
+            case ParamsValidatorKeys::OPTIONAL_NUMERIC:
+                return ParamsValidatorMethods::optionalNumericValidator($param, $requestURI);
 
             case ParamsValidatorKeys::BOOLEAN:
                 return ParamsValidatorMethods::booleanValidator($param, $requestURI);

--- a/lib/Common/Validators/URI/ParamsValidatorMethods.php
+++ b/lib/Common/Validators/URI/ParamsValidatorMethods.php
@@ -46,6 +46,29 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
     }
 
     /**
+     * Validates that a query parameter is either empty or numeric.
+     *
+     * Used for optional filter fields (e.g., schedule filter) where the param
+     * may be present with an empty value when the user has not set a filter.
+     */
+    public static function optionalNumericValidator(string $param, string $requestURI): bool
+    {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return false;
+        }
+        if ($value === '') {
+            return true; // empty is valid for optional filter fields
+        }
+
+        return ctype_digit($value);
+    }
+
+    /**
      * Validates that a query parameter is present and has a non-empty value.
      */
     public static function existsInURLValidator(string $param, string $requestURI): bool
@@ -58,7 +81,6 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
 
         return $value !== null && $value !== '';
     }
-
 
     /**
      * Validates that a query parameter is present and its value is a date in YYYY-MM-DD format.
@@ -104,6 +126,27 @@ class ParamsValidatorMethods implements IParamsValidatorMethods
         }
 
         return true;
+    }
+
+    /**
+     * Validates that a query parameter is present and either empty or a comma-separated
+     * list of dates in YYYY-M-D format (leading zeros optional for month and day).
+     */
+    public static function optionalSimpleDateValidator(string $param, string $requestURI): bool
+    {
+        if (self::validatePossibleScripts($requestURI)) {
+            return false; // Reject URLs containing potential XSS payloads
+        }
+
+        $value = self::getQueryParam($param, $requestURI);
+        if ($value === null) {
+            return false;
+        }
+        if ($value === '') {
+            return true;
+        }
+
+        return self::simpleDateValidatorList($param, $requestURI);
     }
 
 

--- a/lib/Server/ParamsValidatorKeys.php
+++ b/lib/Server/ParamsValidatorKeys.php
@@ -16,4 +16,6 @@ class ParamsValidatorKeys
     public const OPTIONAL = 'o';
     public const BOOLEAN = 'b';
     public const MATCH = 'm';
+    public const OPTIONAL_NUMERIC = 'optional_numeric';
+    public const OPTIONAL_SIMPLEDATE = 'optional_simpledate';
 }

--- a/lib/Server/RouteParamsKeys.php
+++ b/lib/Server/RouteParamsKeys.php
@@ -23,14 +23,14 @@ class RouteParamsKeys
     ];
 
     public const VIEW_SCHEDULE = [
-        FormKeys::PARTICIPANT_ID => ParamsValidatorKeys::NUMERICAL,
-        FormKeys::USER_ID => ParamsValidatorKeys::NUMERICAL,
+        FormKeys::PARTICIPANT_ID => ParamsValidatorKeys::OPTIONAL_NUMERIC,
+        FormKeys::USER_ID => ParamsValidatorKeys::OPTIONAL_NUMERIC,
         QueryStringKeys::SCHEDULE_ID => ParamsValidatorKeys::NUMERICAL,
         QueryStringKeys::START_DATE => ParamsValidatorKeys::DATE,
         'clearFilter' => ParamsValidatorKeys::NUMERICAL,
-        QueryStringKeys::START_DATES => ParamsValidatorKeys::SIMPLE_DATE,
-        FormKeys::RESOURCE_TYPE_ID => ParamsValidatorKeys::NUMERICAL,
-        FormKeys::MAX_PARTICIPANTS => ParamsValidatorKeys::NUMERICAL,
+        QueryStringKeys::START_DATES => ParamsValidatorKeys::OPTIONAL_SIMPLEDATE,
+        FormKeys::RESOURCE_TYPE_ID => ParamsValidatorKeys::OPTIONAL_NUMERIC,
+        FormKeys::MAX_PARTICIPANTS => ParamsValidatorKeys::OPTIONAL_NUMERIC,
         FormKeys::SUBMIT => ParamsValidatorKeys::BOOLEAN,
         QueryStringKeys::DATA_REQUEST => [ParamsValidatorKeys::MATCH => ['reservations']]
     ];

--- a/tests/Infrastructure/Common/URIParamValidatorTest.php
+++ b/tests/Infrastructure/Common/URIParamValidatorTest.php
@@ -221,6 +221,8 @@ class URIParamValidatorTest extends TestBase
             'boolean' => ParamsValidatorMethods::booleanValidator($param, $uri),
             'date' => ParamsValidatorMethods::dateValidator($param, $uri),
             'simpleDateList' => ParamsValidatorMethods::simpleDateValidatorList($param, $uri),
+            'optionalSimpleDate' => ParamsValidatorMethods::optionalSimpleDateValidator($param, $uri),
+            'optionalNumeric' => ParamsValidatorMethods::optionalNumericValidator($param, $uri),
         };
         $this->assertFalse($result, "Array param should be rejected by $validator for URI: $uri");
     }
@@ -235,6 +237,105 @@ class URIParamValidatorTest extends TestBase
             'boolean rejects array' => ['boolean', 'show', '/Web/view-schedule.php?show[]=true'],
             'date rejects array' => ['date', 'sd', '/Web/reservation.php?sd[]=2026-03-23'],
             'simpleDateList rejects array' => ['simpleDateList', 'sd', '/Web/reservation.php?sd[]=2026-03-23'],
+            'optionalSimpleDate rejects array' => ['optionalSimpleDate', 'sd', '/Web/schedule.php?sd[]='],
+            'optionalNumeric rejects array' => ['optionalNumeric', 'uid', '/Web/view-schedule.php?uid[]=123'],
         ];
+    }
+
+    /**
+     * @dataProvider optionalSimpleDateProvider
+     */
+    public function testOptionalSimpleDateValidator(string $uri, bool $expected)
+    {
+        $result = ParamsValidatorMethods::optionalSimpleDateValidator('sds', $uri);
+        $this->assertSame($expected, $result, "Failed for URI: $uri");
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function optionalSimpleDateProvider(): array
+    {
+        return [
+            'empty string is valid' => ['/Web/schedule.php?sds=', true],
+            'single date is valid' => ['/Web/schedule.php?sds=2026-03-31', true],
+            'date list is valid' => ['/Web/schedule.php?sds=2026-03-31,2026-04-01', true],
+            'missing param rejected' => ['/Web/schedule.php?sd=2026-03-31', false],
+            'invalid date rejected' => ['/Web/schedule.php?sds=bad-date', false],
+            'array param rejected' => ['/Web/schedule.php?sds[]=', false],
+            'xss rejected' => ['/Web/schedule.php?sds=&x=%3Cscript%3E', false],
+        ];
+    }
+
+    /**
+     * @dataProvider optionalNumericProvider
+     */
+    public function testOptionalNumericValidator(string $uri, bool $expected)
+    {
+        $result = ParamsValidatorMethods::optionalNumericValidator('uid', $uri);
+        $this->assertSame($expected, $result, "Failed for URI: $uri");
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function optionalNumericProvider(): array
+    {
+        return [
+            'valid digits' => ['/Web/schedule.php?uid=123', true],
+            'zero is valid' => ['/Web/schedule.php?uid=0', true],
+            'empty string is valid' => ['/Web/schedule.php?uid=', true],
+            'trailing alpha rejected' => ['/Web/schedule.php?uid=123abc', false],
+            'leading alpha rejected' => ['/Web/schedule.php?uid=abc123', false],
+            'alpha rejected' => ['/Web/schedule.php?uid=abc', false],
+            'float rejected' => ['/Web/schedule.php?uid=1.5', false],
+            'negative rejected' => ['/Web/schedule.php?uid=-1', false],
+            'missing param rejected' => ['/Web/schedule.php?other=123', false],
+            'array param rejected' => ['/Web/schedule.php?uid[]=123', false],
+            'xss script tag rejected' => ['/Web/schedule.php?uid=123&x=%3Cscript%3E', false],
+            'xss double quotes rejected' => ['/Web/schedule.php?uid=123&x=%22alert%22', false],
+        ];
+    }
+
+    /**
+     * Regression test: schedule filter with empty optional params must not fail validation.
+     */
+    public function testScheduleFilterWithEmptyOptionalParamsPassesValidation()
+    {
+        $requestURI = '/Web/schedule.php?RESOURCE_TYPE_ID=&maxParticipants=&sid=1&sd=2026-03-31&sds=&SUBMIT=true&clearFilter=0';
+        $result = ParamsValidator::validate(
+            params: RouteParamsKeys::VIEW_SCHEDULE,
+            requestURI: $requestURI,
+            optional: true,
+        );
+        $this->assertTrue($result, 'Schedule filter with empty optional params should pass validation');
+    }
+
+    /**
+     * Schedule filter with valid numeric optional params must pass validation.
+     */
+    public function testScheduleFilterWithNumericOptionalParamsPassesValidation()
+    {
+        $requestURI = '/Web/schedule.php?RESOURCE_TYPE_ID=5&maxParticipants=10&sid=1&sd=2026-03-31&sds=2026-03-31&SUBMIT=true&clearFilter=0';
+        $result = ParamsValidator::validate(
+            params: RouteParamsKeys::VIEW_SCHEDULE,
+            requestURI: $requestURI,
+            optional: true,
+        );
+        $this->assertTrue($result, 'Schedule filter with numeric optional params should pass validation');
+    }
+
+    /**
+     * Schedule filter with non-numeric optional params must fail validation.
+     */
+    public function testScheduleFilterWithInvalidOptionalParamsFailsValidation()
+    {
+        $requestURI = '/Web/schedule.php?RESOURCE_TYPE_ID=abc&sid=1&sd=2026-03-31&sds=2026-03-31&SUBMIT=true&clearFilter=0';
+        $result = ParamsValidator::validate(
+            params: RouteParamsKeys::VIEW_SCHEDULE,
+            requestURI: $requestURI,
+            optional: true,
+        );
+        $this->assertFalse($result, 'Schedule filter with non-numeric RESOURCE_TYPE_ID should fail validation');
     }
 }


### PR DESCRIPTION
Add optional numeric and simpledate URI validator for schedule and calendar filter query params that may be submitted as empty strings in GET forms.

Use the new validator for the optional VIEW_SCHEDULE filter fields (user, participant, resource type, and max participants) so empty filter inputs no longer fail validation and trigger a redirect to the bare page.

Keep ParamsValidator::validate() unchanged so required guest reservation routes remain strict.

Add validator and route-level regression tests covering empty, numeric, invalid, array, and XSS-shaped inputs.

This basically restores how things were validated before:

commit 47860f150610e57c15028997099be04e7441e8f2
fix(validators): remove redundant EXISTS from combined route validators

and

commit 1f9a739409b9cf9596e7e6c2e894b0bf6f3ee56a
fix(reservation): correct guest reservation URI validation from calendar and schedule view

Closes: #1269