### PR TITLE
fix(calendar): pass correct groupSeriesByResource boolean instead of …

### DIFF
--- a/Presenters/Calendar/CalendarPresenter.php
+++ b/Presenters/Calendar/CalendarPresenter.php
@@ -91,14 +91,14 @@ class CalendarPresenter extends CommonCalendarPresenter
         }
 
         $this->page->BindEvents(CalendarReservation::FromScheduleReservationList(
-            $reservations,
-            $blackouts,
-            $availableSlots,
-            $resources,
-            $userSession,
-            $this->privacyFilter,
-            $this->slotLabelFactory,
-            reservationPage: $this->reservationPage
+            reservations: $reservations,
+            blackouts: $blackouts,
+            availablePeriods: $availableSlots,
+            resources: $resources,
+            userSession: $userSession,
+            groupSeriesByResource: true,
+            factory: $this->slotLabelFactory,
+            reservationPage: $this->reservationPage,
         ));
     }
 


### PR DESCRIPTION
…privacyFilter object

CalendarPresenter was passing $this->privacyFilter (an IPrivacyFilter object) as the 6th positional argument to CalendarReservation::FromScheduleReservationList(), which expects a boolean $groupSeriesByResource parameter. The object was silently coerced to true, accidentally enabling series deduplication on the calendar page since at least 2018 (commit c0a16354d).

Since this has been the de facto behavior for years with no bug reports, pass groupSeriesByResource: true explicitly to preserve existing behavior. Convert all arguments to named parameters to prevent future positional drift.

Closes: #1247