### PR TITLE
style(jqtree): add Bootstrap form-check-input to missing checkboxes

### DIFF
--- a/Web/scripts/admin/resource.js
+++ b/Web/scripts/admin/resource.js
@@ -638,13 +638,13 @@ function ResourceManagement(opts) {
         var id = 'group_id' + node.id;
 
         var label = $(
-          '<div class="checkbox inline"><input group-id="' +
+          '<div class="form-check"><input group-id="' +
             node.id +
-            '" name="group_id[]" type="checkbox" id="' +
+            '" name="group_id[]" class="form-check-input" type="checkbox" id="' +
             id +
             '" value="' +
             node.id +
-            '"/><label for="' +
+            '"/><label class="form-check-label" for="' +
             id +
             '">' +
             itemName +

--- a/Web/scripts/schedule.js
+++ b/Web/scripts/schedule.js
@@ -1178,9 +1178,9 @@ function Schedule(opts, resourceGroups) {
       onCreateLi: function (node, $li) {
         var span = $li.find('span');
         var itemName = span.text();
-        var label = $('<label><input type="checkbox" name="resourceId[]"/> ' + itemName + '</label>');
-
-        var checkbox = label.find('input');
+        var checkbox = $('<input type="checkbox" class="form-check-input" name="resourceId[]"/>');
+        var label = $('<label class="form-check-label"></label>');
+        label.append(checkbox).append(document.createTextNode(' ' + itemName));
 
         if (node.type == 'resource') {
           checkbox.attr('resource-id', node.resource_id);


### PR DESCRIPTION
Bootstrap classes have been added to two jqTree checkboxes that didn't have them to ensure visual consistency with other form controls. There are no functional changes.

Before:
<img width="507" height="328" alt="image" src="https://github.com/user-attachments/assets/8b9f547d-4831-4212-b5f1-ea34a9e18cb2" />

After:
<img width="546" height="315" alt="image" src="https://github.com/user-attachments/assets/f998b515-0db1-4097-82e9-61bf2bb09851" />
