### PR TITLE
fix(config): make config key lookup case-insensitive

### DIFF
--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1567,7 +1567,6 @@ class ConfigKeys
 
     public const PLUGIN_AUTHENTICATION = [
         'key' => 'plugins.authentication',
-        'legacy' => 'plugins.Authentication',
         'type' => 'string',
         'default' => '',
         'choices' => [
@@ -1591,7 +1590,6 @@ class ConfigKeys
     ];
     public const PLUGIN_AUTHORIZATION = [
         'key' => 'plugins.authorization',
-        'legacy' => 'plugins.Authorization',
         'type' => 'string',
         'default' => '',
         'choices' => [
@@ -1603,7 +1601,6 @@ class ConfigKeys
     ];
     public const PLUGIN_EXPORT = [
         'key' => 'plugins.export',
-        'legacy' => 'plugins.Export',
         'type' => 'string',
         'default' => '',
         'choices' => [
@@ -1615,7 +1612,6 @@ class ConfigKeys
     ];
     public const PLUGIN_PERMISSION = [
         'key' => 'plugins.permission',
-        'legacy' => 'plugins.Permission',
         'type' => 'string',
         'default' => '',
         'choices' => [
@@ -1627,7 +1623,6 @@ class ConfigKeys
     ];
     public const PLUGIN_POSTREGISTRATION = [
         'key' => 'plugins.postregistration',
-        'legacy' => 'plugins.PostRegistration',
         'type' => 'string',
         'default' => '',
         'choices' => [
@@ -1639,7 +1634,6 @@ class ConfigKeys
     ];
     public const PLUGIN_PRERESERVATION = [
         'key' => 'plugins.prereservation',
-        'legacy' => 'plugins.PreReservation',
         'type' => 'string',
         'default' => '',
         'choices' => [
@@ -1653,7 +1647,6 @@ class ConfigKeys
     ];
     public const PLUGIN_POSTRESERVATION = [
         'key' => 'plugins.postreservation',
-        'legacy' => 'plugins.PostReservation',
         'type' => 'string',
         'default' => '',
         'choices' => [
@@ -1666,7 +1659,6 @@ class ConfigKeys
     ];
     public const PLUGIN_STYLING = [
         'key' => 'plugins.styling',
-        'legacy' => 'plugins.Styling',
         'type' => 'string',
         'default' => '',
         'choices' => [
@@ -1698,7 +1690,6 @@ class ConfigKeys
     ];
     public const API_AUTHENTICATION_GROUP = [
         'key' => 'api.authentication.group',
-        'legacy' => 'api.Authentication.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Authentication Group',
@@ -1707,7 +1698,6 @@ class ConfigKeys
     ];
     public const API_ACCESSORIES_RO_GROUP = [
         'key' => 'api.accessories.ro.group',
-        'legacy' => 'api.Accessories.ro.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Accessories Read-Only Group',
@@ -1716,7 +1706,6 @@ class ConfigKeys
     ];
     public const API_ACCOUNTS_RO_GROUP = [
         'key' => 'api.accounts.ro.group',
-        'legacy' => 'api.Accounts.ro.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Accounts Read-Only Group',
@@ -1725,7 +1714,6 @@ class ConfigKeys
     ];
     public const API_ACCOUNTS_RW_GROUP = [
         'key' => 'api.accounts.rw.group',
-        'legacy' => 'api.Accounts.rw.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Accounts Read-Write Group',
@@ -1734,7 +1722,6 @@ class ConfigKeys
     ];
     public const API_ATTRIBUTES_RO_GROUP = [
         'key' => 'api.attributes.ro.group',
-        'legacy' => 'api.Attributes.ro.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Attributes Read-Only Group',
@@ -1743,7 +1730,6 @@ class ConfigKeys
     ];
     public const API_GROUPS_RO_GROUP = [
         'key' => 'api.groups.ro.group',
-        'legacy' => 'api.Groups.ro.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Groups Read-Only Group',
@@ -1752,7 +1738,6 @@ class ConfigKeys
     ];
     public const API_RESERVATIONS_RO_GROUP = [
         'key' => 'api.reservations.ro.group',
-        'legacy' => 'api.Reservations.ro.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Reservations Read-Only Group',
@@ -1761,7 +1746,6 @@ class ConfigKeys
     ];
     public const API_RESERVATIONS_RW_GROUP = [
         'key' => 'api.reservations.rw.group',
-        'legacy' => 'api.Reservations.rw.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Reservations Read-Write Group',
@@ -1770,7 +1754,6 @@ class ConfigKeys
     ];
     public const API_RESOURCES_RO_GROUP = [
         'key' => 'api.resources.ro.group',
-        'legacy' => 'api.Resources.ro.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Resources Read-Only Group',
@@ -1779,7 +1762,6 @@ class ConfigKeys
     ];
     public const API_SCHEDULES_RO_GROUP = [
         'key' => 'api.schedules.ro.group',
-        'legacy' => 'api.Schedules.ro.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Schedules Read-Only Group',
@@ -1788,7 +1770,6 @@ class ConfigKeys
     ];
     public const API_USERS_RO_GROUP = [
         'key' => 'api.users.ro.group',
-        'legacy' => 'api.Users.ro.group',
         'type' => 'string',
         'default' => '',
         'label' => 'API Users Read-Only Group',
@@ -1822,8 +1803,10 @@ class ConfigKeys
 
     public static function findByKey(string $key): ?array
     {
+        $normalizedKey = strtolower($key);
+
         foreach (self::all() as $config) {
-            if (($config['key'] ?? null) === $key) {
+            if (strtolower((string) ($config['key'] ?? '')) === $normalizedKey) {
                 return $config;
             }
         }
@@ -1833,8 +1816,14 @@ class ConfigKeys
 
     public static function findByLegacyKey(string $legacyKey): ?array
     {
+        if (!is_string($legacyKey) || $legacyKey === '') {
+            return null;
+        }
+
+        $normalizedLegacyKey = strtolower($legacyKey);
+
         foreach (self::all() as $config) {
-            if (($config['legacy'] ?? null) === $legacyKey) {
+            if (strtolower((string) ($config['legacy'] ?? '')) === $normalizedLegacyKey) {
                 return $config;
             }
         }

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -363,13 +363,13 @@ class ConfigurationFile implements IConfigurationFile
                         $section = $entry['section'] ?? null;
                         $finalKey = $entry['key'];
 
-                        if ($section === $key) {
-                            // Keep under parent key, rewrite subkey only
+                        if ($section !== null && strcasecmp($section, $key) === 0) {
+                            // Keep under canonical section name, rewrite subkey only
                             $subKeyNew = str_starts_with($finalKey, $section . '.')
                                 ? substr($finalKey, strlen($section) + 1)
                                 : $finalKey;
 
-                            $rewritten[$key][$subKeyNew] = $subValue;
+                            $rewritten[$section][$subKeyNew] = $subValue;
                         } else {
                             $rewritten[$finalKey] = $subValue;
                         }

--- a/lib/Config/PluginConfigKeys.php
+++ b/lib/Config/PluginConfigKeys.php
@@ -27,6 +27,8 @@ abstract class PluginConfigKeys
      */
     public static function findByKey(string $key): ?array
     {
+        $normalizedKey = strtolower($key);
+
         foreach (static::all() as $config) {
             $configKey = $config['key'] ?? null;
             $section = $config['section'] ?? null;
@@ -34,11 +36,11 @@ abstract class PluginConfigKeys
             // If this config has a section, only match with the full key (section.key)
             if ($section) {
                 $fullKey = "{$section}.{$configKey}";
-                if ($fullKey === $key) {
+                if (strtolower($fullKey) === $normalizedKey) {
                     return $config;
                 }
             } else {
-                if ($configKey === $key) {
+                if (strtolower((string) $configKey) === $normalizedKey) {
                     return $config;
                 }
             }
@@ -54,8 +56,14 @@ abstract class PluginConfigKeys
      */
     public static function findByLegacyKey(string $legacyKey): ?array
     {
+        if (!is_string($legacyKey) || $legacyKey === '') {
+            return null;
+        }
+
+        $normalizedLegacyKey = strtolower($legacyKey);
+
         foreach (static::all() as $config) {
-            if (($config['legacy'] ?? null) === $legacyKey) {
+            if (strtolower((string) ($config['legacy'] ?? '')) === $normalizedLegacyKey) {
                 return $config;
             }
         }

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -36,12 +36,43 @@ class ConfigTest extends TestBase
             $this->assertEquals('America/Chicago', $config->GetDefaultTimezone());
             $this->assertEquals(true, $config->GetKey(ConfigKeys::REGISTRATION_ALLOW_SELF, new BooleanConverter()));
             $this->assertEquals('mysql', $config->GetKey(ConfigKeys::DATABASE_TYPE));
+            $this->assertEquals('legacy/images', $config->GetKey(ConfigKeys::UPLOAD_IMAGE_DIRECTORY));
             $this->assertEquals('ActiveDirectory', $config->GetKey(ConfigKeys::PLUGIN_AUTHENTICATION));
         });
 
         $this->assertLogMessage($errorLogs, 'Legacy config format detected', 'legacy config format detection');
         $this->assertLogMessage($errorLogs, "Deprecated config key 'allow.self.registration'", 'deprecated allow.self.registration key');
-        $this->assertLogMessage($errorLogs, "Deprecated config key 'plugins.Authentication'", 'deprecated plugins.Authentication key');
+        $this->assertLogMessage($errorLogs, "Deprecated config key 'image.upload.directory'", 'deprecated image.upload.directory key');
+    }
+
+    public function testMixedCaseSectionNamesResolveCorrectly()
+    {
+        Configuration::Instance()->Register(
+            ROOT_DIR . 'tests/data/test_mixed_case_sections_config.php',
+            '',
+            self::CONFIG_ID,
+            true
+        );
+        $config = Configuration::Instance()->File(self::CONFIG_ID);
+
+        $this->assertEquals('America/Chicago', $config->GetDefaultTimezone());
+        $this->assertEquals('pgsql', $config->GetKey(ConfigKeys::DATABASE_TYPE));
+        $this->assertEquals('mixed-case/images', $config->GetKey(ConfigKeys::UPLOAD_IMAGE_DIRECTORY));
+    }
+
+    public function testMixedCaseSectionNamesNewFormatResolveCorrectly()
+    {
+        Configuration::Instance()->Register(
+            ROOT_DIR . 'tests/data/test_mixed_case_new_format_config.php',
+            '',
+            self::CONFIG_ID,
+            true
+        );
+        $config = Configuration::Instance()->File(self::CONFIG_ID);
+
+        $this->assertEquals('America/Chicago', $config->GetDefaultTimezone());
+        $this->assertEquals('pgsql', $config->GetKey(ConfigKeys::DATABASE_TYPE));
+        $this->assertEquals('mixed-case/images', $config->GetKey(ConfigKeys::UPLOAD_IMAGE_DIRECTORY));
     }
 
     public function testMainConfigValidation()
@@ -90,6 +121,22 @@ class ConfigTest extends TestBase
         $this->assertEquals('value3', $pluginConfig->GetKey(TestPluginConfigKeys::SERVER2_KEY));
     }
 
+
+    public function testMixedCasePluginConfigResolveCorrectly()
+    {
+        Configuration::Instance()->Register(
+            ROOT_DIR . 'tests/data/test_mixed_case_plugin_config.php',
+            '',
+            TestPluginConfigKeys::CONFIG_ID,
+            false,
+            TestPluginConfigKeys::class
+        );
+        $pluginConfig = Configuration::Instance()->File(TestPluginConfigKeys::CONFIG_ID);
+
+        $this->assertEquals('value1', $pluginConfig->GetKey(TestPluginConfigKeys::KEY1));
+        $this->assertEquals('value2', $pluginConfig->GetKey(TestPluginConfigKeys::SERVER1_KEY));
+        $this->assertEquals('value3', $pluginConfig->GetKey(TestPluginConfigKeys::SERVER2_KEY));
+    }
 
     public function testPluginConfigValidation()
     {

--- a/tests/data/test_legacy_config.php
+++ b/tests/data/test_legacy_config.php
@@ -4,5 +4,6 @@ declare(strict_types=1);
 
 $conf['settings']['default.timezone'] = 'America/Chicago';
 $conf['settings']['allow.self.registration'] = 'true';
+$conf['settings']['image.upload.directory'] = 'legacy/images';
 $conf['settings']['database']['type'] = 'mysql';
 $conf['settings']['plugins']['Authentication'] = 'ActiveDirectory';

--- a/tests/data/test_mixed_case_new_format_config.php
+++ b/tests/data/test_mixed_case_new_format_config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'settings' => [
+        'default.timezone' => 'America/Chicago',
+        'Database' => [
+            'type' => 'pgsql',
+        ],
+        'Uploads' => [
+            'image.upload.directory' => 'mixed-case/images',
+        ],
+    ],
+];

--- a/tests/data/test_mixed_case_plugin_config.php
+++ b/tests/data/test_mixed_case_plugin_config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'settings' => [
+        'KEY1' => 'value1',
+        'Server1' => [
+            'KEY' => 'value2',
+        ],
+        'Server2' => [
+            'key' => 'value3',
+        ],
+    ],
+];

--- a/tests/data/test_mixed_case_sections_config.php
+++ b/tests/data/test_mixed_case_sections_config.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Test config file with mixed-case section names to verify
+ * that RewriteLegacyKeys handles case-insensitive section matching.
+ */
+
+$conf['settings']['default.timezone'] = 'America/Chicago';
+$conf['settings']['Database']['type'] = 'pgsql';
+$conf['settings']['Uploads']['image.upload.directory'] = 'mixed-case/images';


### PR DESCRIPTION
Make config schema lookups case-insensitive in ConfigKeys and PluginConfigKeys so mixed-case config entries still resolve to the correct canonical or legacy key definitions.

This updates both findByKey() and findByLegacyKey() to compare normalized key strings without changing the existing lookup precedence in ConfigurationFile.

Remove `legacy` entries that only differed by case.

Updated tests that were case-sensitive.