### PR TITLE
refactor(config): extract shared config key base class

### DIFF
--- a/lib/Config/AbstractConfigKeys.php
+++ b/lib/Config/AbstractConfigKeys.php
@@ -1,0 +1,110 @@
+<?php
+
+abstract class AbstractConfigKeys
+{
+    /** @var array<class-string, array> */
+    private static array $allCache = [];
+
+    /**
+     * Returns all configuration entries defined in the class.
+     * @return array
+     */
+    public static function all(): array
+    {
+        $class = static::class;
+        if (isset(self::$allCache[$class])) {
+            return self::$allCache[$class];
+        }
+
+        $constants = (new \ReflectionClass($class))->getConstants();
+
+        $all = [];
+        foreach ($constants as $value) {
+            if (is_array($value) && isset($value['key'])) {
+                $all[] = $value;
+            }
+        }
+
+        self::$allCache[$class] = $all;
+
+        return $all;
+    }
+
+    /**
+     * Finds a configuration entry by its key.
+     * @param string $key
+     * @return array|null
+     */
+    public static function findByKey(string $key): ?array
+    {
+        $normalizedKey = strtolower($key);
+
+        foreach (static::all() as $config) {
+            $lookupKey = static::getCanonicalLookupKey(config: $config);
+            if (is_string($lookupKey) && strtolower($lookupKey) === $normalizedKey) {
+                return $config;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Finds a configuration entry by its legacy key.
+     * @param string $legacyKey
+     * @return array|null
+     */
+    public static function findByLegacyKey(string $legacyKey): ?array
+    {
+        if ($legacyKey === '') {
+            return null;
+        }
+
+        $normalizedLegacyKey = strtolower($legacyKey);
+
+        foreach (static::all() as $config) {
+            $legacy = $config['legacy'] ?? null;
+            if (!is_string($legacy) || $legacy === '') {
+                continue;
+            }
+
+            if (strtolower($legacy) === $normalizedLegacyKey) {
+                return $config;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if a configuration entry is private (should not be displayed in UI).
+     * @param array $config
+     * @return bool
+     */
+    public static function isPrivate($config): bool
+    {
+        if (empty($config)) {
+            return false;
+        }
+        return $config['is_private'] ?? false;
+    }
+
+    public static function hasEnv($config): bool
+    {
+        $key = $config['key'] ?? null;
+        if (!is_string($key) || $key === '') {
+            return false;
+        }
+
+        $envKey = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $key));
+
+        return getenv($envKey) !== false;
+    }
+
+    protected static function getCanonicalLookupKey(array $config): ?string
+    {
+        $key = $config['key'] ?? null;
+
+        return is_string($key) && $key !== '' ? $key : null;
+    }
+}

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1,6 +1,8 @@
 <?php
 
-class ConfigKeys
+require_once(ROOT_DIR . 'lib/Config/AbstractConfigKeys.php');
+
+class ConfigKeys extends AbstractConfigKeys
 {
     // Application configuration
 
@@ -1777,79 +1779,6 @@ class ConfigKeys
         'section' => 'api'
     ];
 
-    public static function all(): array
-    {
-        $constants = (new \ReflectionClass(static::class))->getConstants();
-
-        $all = [];
-        foreach ($constants as $name => $value) {
-            if (is_array($value) && isset($value['key'])) {
-                $all[] = $value;
-            }
-        }
-
-        return $all;
-    }
-
-    public static function mapByKey(): array
-    {
-        $map = [];
-        foreach (self::all() as $entry) {
-            $map[$entry['key']] = $entry;
-        }
-
-        return $map;
-    }
-
-    public static function findByKey(string $key): ?array
-    {
-        $normalizedKey = strtolower($key);
-
-        foreach (self::all() as $config) {
-            if (strtolower((string) ($config['key'] ?? '')) === $normalizedKey) {
-                return $config;
-            }
-        }
-
-        return null;
-    }
-
-    public static function findByLegacyKey(string $legacyKey): ?array
-    {
-        if (!is_string($legacyKey) || $legacyKey === '') {
-            return null;
-        }
-
-        $normalizedLegacyKey = strtolower($legacyKey);
-
-        foreach (self::all() as $config) {
-            if (strtolower((string) ($config['legacy'] ?? '')) === $normalizedLegacyKey) {
-                return $config;
-            }
-        }
-
-        return null;
-    }
-
-    public static function isPrivate($configDef): bool
-    {
-        if (empty($configDef)) {
-            return false;
-        }
-        return $configDef['is_private'] ?? false;
-    }
-
-    public static function hasEnv($configDef): bool
-    {
-        $key = $configDef['key'] ?? null;
-        if (!is_string($key) || $key === '') {
-            return false;
-        }
-
-        $loadedEnvVars = getenv();
-        $envKey = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', (string)$key));
-        return array_key_exists($envKey, $loadedEnvVars) ?? false;
-    }
 }
 
 class ConfigSettingType

--- a/lib/Config/PluginConfigKeys.php
+++ b/lib/Config/PluginConfigKeys.php
@@ -1,96 +1,18 @@
 <?php
 
-abstract class PluginConfigKeys
+require_once(ROOT_DIR . 'lib/Config/AbstractConfigKeys.php');
+
+abstract class PluginConfigKeys extends AbstractConfigKeys
 {
-    /**
-     * Returns all configuration entries defined in the class.
-     * @return array
-     */
-    public static function all(): array
+    protected static function getCanonicalLookupKey(array $config): ?string
     {
-        $constants = (new \ReflectionClass(static::class))->getConstants();
+        $configKey = $config['key'] ?? null;
+        $section = $config['section'] ?? null;
 
-        $all = [];
-        foreach ($constants as $name => $value) {
-            if (is_array($value) && isset($value['key'])) {
-                $all[] = $value;
-            }
+        if (is_string($section) && $section !== '' && is_string($configKey) && $configKey !== '') {
+            return "{$section}.{$configKey}";
         }
 
-        return $all;
-    }
-
-    /**
-     * Finds a configuration entry by its key.
-     * @param string $key
-     * @return array|null
-     */
-    public static function findByKey(string $key): ?array
-    {
-        $normalizedKey = strtolower($key);
-
-        foreach (static::all() as $config) {
-            $configKey = $config['key'] ?? null;
-            $section = $config['section'] ?? null;
-
-            // If this config has a section, only match with the full key (section.key)
-            if ($section) {
-                $fullKey = "{$section}.{$configKey}";
-                if (strtolower($fullKey) === $normalizedKey) {
-                    return $config;
-                }
-            } else {
-                if (strtolower((string) $configKey) === $normalizedKey) {
-                    return $config;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Finds a configuration entry by its legacy key.
-     * @param string $legacyKey
-     * @return array|null
-     */
-    public static function findByLegacyKey(string $legacyKey): ?array
-    {
-        if (!is_string($legacyKey) || $legacyKey === '') {
-            return null;
-        }
-
-        $normalizedLegacyKey = strtolower($legacyKey);
-
-        foreach (static::all() as $config) {
-            if (strtolower((string) ($config['legacy'] ?? '')) === $normalizedLegacyKey) {
-                return $config;
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Checks if a configuration entry is private (should not be displayed in UI).
-     * @param array $config
-     * @return bool
-     */
-    public static function isPrivate($config): bool
-    {
-        if (empty($config)) {
-            return false;
-        }
-        return $config['is_private'] ?? false;
-    }
-
-    public static function hasEnv($config): bool
-    {
-        if (empty($config)) {
-            return false;
-        }
-        $loadedEnvVars = getenv();
-        $envKey = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $config['key']));
-        return array_key_exists($envKey, $loadedEnvVars) ?? false;
+        return is_string($configKey) && $configKey !== '' ? $configKey : null;
     }
 }

--- a/lib/Config/namespace.php
+++ b/lib/Config/namespace.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once(ROOT_DIR . 'lib/Config/AbstractConfigKeys.php');
 require_once(ROOT_DIR . 'lib/Config/ConfigKeys.php');
 require_once(ROOT_DIR . 'lib/Config/PluginConfigKeys.php');
 require_once(ROOT_DIR . 'lib/Config/Configuration.php');


### PR DESCRIPTION
Extract shared config key lookup helpers into a new AbstractConfigKeys
base class and update ConfigKeys and PluginConfigKeys to extend it.

This moves the common all(), findByKey(), findByLegacyKey(),
isPrivate(), and hasEnv() logic into one place while preserving the
existing case-insensitive lookup behavior. Plugin config continues to
provide its section-aware canonical key shape through a small override.

Also remove unused `mapByKey` function/method.