### PR TITLE
fix(config): reject case-insensitive key collisions

### DIFF
--- a/lib/Config/AbstractConfigKeys.php
+++ b/lib/Config/AbstractConfigKeys.php
@@ -4,6 +4,8 @@ abstract class AbstractConfigKeys
 {
     /** @var array<class-string, array> */
     private static array $allCache = [];
+    /** @var array<class-string, array> */
+    private static array $allWithEntryIdsCache = [];
 
     /**
      * Returns all configuration entries defined in the class.
@@ -16,18 +18,45 @@ abstract class AbstractConfigKeys
             return self::$allCache[$class];
         }
 
+        $entries = [];
+        foreach (self::allWithEntryIds() as $value) {
+            unset($value['_entry_id']);
+            $entries[] = $value;
+        }
+
+        self::$allCache[$class] = $entries;
+
+        return $entries;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private static function allWithEntryIds(): array
+    {
+        $class = static::class;
+        if (isset(self::$allWithEntryIdsCache[$class])) {
+            return self::$allWithEntryIdsCache[$class];
+        }
+
         $constants = (new \ReflectionClass($class))->getConstants();
 
-        $all = [];
-        foreach ($constants as $value) {
+        $configsWithIds = [];
+        foreach ($constants as $name => $value) {
             if (is_array($value) && isset($value['key'])) {
-                $all[] = $value;
+                // Preserve the constant name so collision detection can distinguish
+                // between different schema entries that may share the same key text,
+                // e.g. SERVER1_KEY and SERVER1_KEY_DUPLICATE_SECTION_CASE both using
+                // 'key' => 'key'.
+                $value['_entry_id'] = $name;
+                $configsWithIds[] = $value;
             }
         }
 
-        self::$allCache[$class] = $all;
+        self::assertNoCaseInsensitiveLookupCollisions(configsWithIds: $configsWithIds);
+        self::$allWithEntryIdsCache[$class] = $configsWithIds;
 
-        return $all;
+        return $configsWithIds;
     }
 
     /**
@@ -106,5 +135,67 @@ abstract class AbstractConfigKeys
         $key = $config['key'] ?? null;
 
         return is_string($key) && $key !== '' ? $key : null;
+    }
+
+    private static function assertNoCaseInsensitiveLookupCollisions(array $configsWithIds): void
+    {
+        $seen = [];
+
+        foreach ($configsWithIds as $configWithId) {
+            // Validate both the canonical lookup key and any legacy alias because
+            // either one can collide once lookups become case-insensitive.
+            self::assertUniqueCaseInsensitiveKey(
+                seen: $seen,
+                rawKey: static::getCanonicalLookupKey(config: $configWithId),
+                configWithId: $configWithId,
+                source: 'key'
+            );
+            self::assertUniqueCaseInsensitiveKey(
+                seen: $seen,
+                rawKey: $configWithId['legacy'] ?? null,
+                configWithId: $configWithId,
+                source: 'legacy'
+            );
+        }
+    }
+
+    private static function assertUniqueCaseInsensitiveKey(array &$seen, ?string $rawKey, array $configWithId, string $source): void
+    {
+        if (!is_string($rawKey) || $rawKey === '') {
+            return;
+        }
+
+        $normalizedKey = strtolower($rawKey);
+        if (!isset($seen[$normalizedKey])) {
+            // Remember the first schema entry that claims this normalized lookup key.
+            $seen[$normalizedKey] = [
+                'rawKey' => $rawKey,
+                'entryId' => $configWithId['_entry_id'],
+                'key' => $configWithId['key'],
+                'source' => $source,
+            ];
+            return;
+        }
+
+        $existing = $seen[$normalizedKey];
+        // Allow the same schema entry to contribute both a canonical key and a
+        // legacy alias that normalize to the same lookup string.
+        if ($existing['entryId'] === $configWithId['_entry_id']) {
+            return;
+        }
+
+        throw new LogicException(sprintf(
+            'Case-insensitive config key collision detected in %s for "%s" between %s "%s" (entry "%s", constant "%s") and %s "%s" (entry "%s", constant "%s")',
+            static::class,
+            $normalizedKey,
+            $existing['source'],
+            $existing['rawKey'],
+            $existing['key'],
+            $existing['entryId'],
+            $source,
+            $rawKey,
+            $configWithId['key'],
+            $configWithId['_entry_id']
+        ));
     }
 }

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 require_once(ROOT_DIR . 'lib/Config/namespace.php');
 require_once(ROOT_DIR . 'tests/data/test_plugin_configclass.php');
+require_once(ROOT_DIR . 'tests/data/test_plugin_configclass_collision.php');
 
 class ConfigTest extends TestBase
 {
@@ -136,6 +137,70 @@ class ConfigTest extends TestBase
         $this->assertEquals('value1', $pluginConfig->GetKey(TestPluginConfigKeys::KEY1));
         $this->assertEquals('value2', $pluginConfig->GetKey(TestPluginConfigKeys::SERVER1_KEY));
         $this->assertEquals('value3', $pluginConfig->GetKey(TestPluginConfigKeys::SERVER2_KEY));
+    }
+
+    public function testPluginConfigRejectsCaseInsensitiveKeyCollisions()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Case-insensitive config key collision detected in %s',
+                TestPluginConfigKeysCollision::class
+            )
+        );
+
+        TestPluginConfigKeysCollision::findByKey('server1.key');
+    }
+
+    public function testPluginConfigRejectsCaseInsensitiveKeyCollisionsWhenEntriesShareTheSameKeyName()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Case-insensitive config key collision detected in %s',
+                TestPluginConfigKeysCollisionSameKey::class
+            )
+        );
+
+        TestPluginConfigKeysCollisionSameKey::findByKey('server1.key');
+    }
+
+    public function testPluginConfigAllowsTheSameKeyNameInDifferentSections()
+    {
+        $this->assertSame(
+            TestPluginConfigKeysNoCollisionSameKeyDifferentSections::SERVER1_KEY,
+            TestPluginConfigKeysNoCollisionSameKeyDifferentSections::findByKey('server1.key')
+        );
+        $this->assertSame(
+            TestPluginConfigKeysNoCollisionSameKeyDifferentSections::SERVER2_KEY,
+            TestPluginConfigKeysNoCollisionSameKeyDifferentSections::findByKey('server2.key')
+        );
+    }
+
+    public function testPluginConfigRejectsCaseInsensitiveLegacyToCanonicalCollisions()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Case-insensitive config key collision detected in %s',
+                TestPluginConfigKeysCollisionLegacyVsCanonical::class
+            )
+        );
+
+        TestPluginConfigKeysCollisionLegacyVsCanonical::findByKey('server1.key');
+    }
+
+    public function testPluginConfigRejectsCaseInsensitiveLegacyToLegacyCollisions()
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            sprintf(
+                'Case-insensitive config key collision detected in %s',
+                TestPluginConfigKeysCollisionLegacyVsLegacy::class
+            )
+        );
+
+        TestPluginConfigKeysCollisionLegacyVsLegacy::findByKey('server1.key1');
     }
 
     public function testPluginConfigValidation()

--- a/tests/data/test_plugin_configclass_collision.php
+++ b/tests/data/test_plugin_configclass_collision.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Config/PluginConfigKeys.php');
+
+class TestPluginConfigKeysCollision extends PluginConfigKeys
+{
+    public const CONFIG_ID = 'test_plugin_collision';
+
+    public const SERVER1_KEY = [
+        'key' => 'Key',
+        'type' => 'string',
+        'default' => 'default1',
+        'section' => 'server1'
+    ];
+
+    public const SERVER1_KEY_DUPLICATE_CASE = [
+        'key' => 'key',
+        'type' => 'string',
+        'default' => 'default2',
+        'section' => 'SERVER1'
+    ];
+}
+
+class TestPluginConfigKeysCollisionSameKey extends PluginConfigKeys
+{
+    public const CONFIG_ID = 'test_plugin_collision_same_key';
+
+    public const SERVER1_KEY = [
+        'key' => 'key',
+        'type' => 'string',
+        'default' => 'default1',
+        'section' => 'server1'
+    ];
+
+    public const SERVER1_KEY_DUPLICATE_SECTION_CASE = [
+        'key' => 'key',
+        'type' => 'string',
+        'default' => 'default2',
+        'section' => 'SERVER1'
+    ];
+}
+
+class TestPluginConfigKeysNoCollisionSameKeyDifferentSections extends PluginConfigKeys
+{
+    public const CONFIG_ID = 'test_plugin_no_collision_same_key';
+
+    public const SERVER1_KEY = [
+        'key' => 'key',
+        'type' => 'string',
+        'default' => 'default1',
+        'section' => 'server1'
+    ];
+
+    public const SERVER2_KEY = [
+        'key' => 'key',
+        'type' => 'string',
+        'default' => 'default2',
+        'section' => 'server2'
+    ];
+}
+
+class TestPluginConfigKeysCollisionLegacyVsCanonical extends PluginConfigKeys
+{
+    public const CONFIG_ID = 'test_plugin_collision_legacy_vs_canonical';
+
+    public const SERVER1_KEY = [
+        'key' => 'key',
+        'type' => 'string',
+        'default' => 'default1',
+        'section' => 'server1',
+        'legacy' => 'server1.legacy-key'
+    ];
+
+    public const SERVER1_LEGACY_KEY = [
+        'key' => 'legacy-key',
+        'type' => 'string',
+        'default' => 'default2',
+        'section' => 'SERVER1'
+    ];
+}
+
+class TestPluginConfigKeysCollisionLegacyVsLegacy extends PluginConfigKeys
+{
+    public const CONFIG_ID = 'test_plugin_collision_legacy_vs_legacy';
+
+    public const SERVER1_KEY = [
+        'key' => 'key1',
+        'type' => 'string',
+        'default' => 'default1',
+        'section' => 'server1',
+        'legacy' => 'server1.shared-legacy'
+    ];
+
+    public const SERVER1_KEY_2 = [
+        'key' => 'key2',
+        'type' => 'string',
+        'default' => 'default2',
+        'section' => 'server1',
+        'legacy' => 'SERVER1.shared-legacy'
+    ];
+}


### PR DESCRIPTION
Reject config schema definitions that collapse to the same lookup key once matching is treated case-insensitively.

Add collision checks to AbstractConfigKeys so both canonical and legacy keys are validated before lookup, and fail fast with a clear exception when two different entries normalize to the same key. Add a focused plugin-schema test and fixture covering the collision case.