### PR TITLE
ci(release): change monthly release schedule to 17:00 UTC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 
 on:
   schedule:
-    - cron: "0 0 3 * *" # Monthly on day 3 (UTC)
+    # Use this command to see what the time is in your local time zone.
+    # `date -d '17:00 UTC'`
+    - cron: "0 17 3 * *" # Monthly on day 3 at 17:00 UTC (10AM PDT / 9AM PST)
   workflow_dispatch:
 
 # default: least privileged permissions across all jobs


### PR DESCRIPTION
Change the automated release from midnight UTC to 17:00 UTC (10AM PDT / 9AM PST) so it runs during the daytime for most contributors.

You can use this command to see the time in your local timezone:
  date -d '17:00 UTC'

The release still occurs on the 3rd of every month.