### PR TITLE
fix(config): avoid empty buckets when rewriting legacy keys

### DIFF
--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -373,7 +373,7 @@ class ConfigurationFile implements IConfigurationFile
                         $section = $entry['section'] ?? null;
                         $finalKey = $entry['key'];
 
-                        if ($section !== null) {
+                        if ($section !== null && $section !== '') {
                             // Always rewrite sectioned keys into the canonical section bucket,
                             // e.g. legacy 'delete.old.data.years.old.data' -> canonical 'cleanup'.
                             $subKeyNew = str_starts_with($finalKey, $section . '.')
@@ -405,7 +405,7 @@ class ConfigurationFile implements IConfigurationFile
                 $finalKey = $entry['key'];
                 $section = $entry['section'] ?? null;
 
-                if ($section && str_starts_with($finalKey, $section . '.')) {
+                if ($section !== null && $section !== '' && str_starts_with($finalKey, $section . '.')) {
                     $keyWithinSection = substr($finalKey, strlen($section) + 1);
                     $rewritten[$section][$keyWithinSection] = $value;
                 } else {

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -148,6 +148,23 @@ PHP
         $this->assertSame(3, $config->GetValues()['cleanup']['years.old.data']);
     }
 
+    public function testNestedLegacyKeysDoNotCreateEmptyTopLevelBucket(): void
+    {
+        $config = $this->createConfigurationFileFromContents(
+            <<<'PHP'
+<?php
+$conf['settings']['google.analytics']['tracking.id'] = 'G-TEST123';
+$conf['settings']['slack']['token'] = 'xoxb-test-token';
+PHP
+        );
+
+        $values = $config->GetValues();
+
+        $this->assertArrayNotHasKey('', $values);
+        $this->assertSame('G-TEST123', $values['google.analytics.tracking.id']);
+        $this->assertSame('xoxb-test-token', $values['slack.token']);
+    }
+
     public function testMainConfigValidation()
     {
         $errorLogs = $this->captureErrorLog(function () {


### PR DESCRIPTION
Treat empty-string config sections as unsectioned keys when rewriting legacy config values into their canonical form.

This fixes legacy nested keys such as slack[token] and google.analytics[tracking.id], which could otherwise be rewritten into an empty top-level section and trigger blank migration warnings. Add regression coverage for nested legacy keys with empty canonical sections, along with the related section-rewrite cases already covered.