### PR TITLE
refactor(tooltips): to appear only on .reservationTitle

### DIFF
--- a/Web/scripts/admin/blackouts.js
+++ b/Web/scripts/admin/blackouts.js
@@ -205,7 +205,7 @@ function BlackoutManagement(opts) {
       .find('.editable')
       .each(function () {
         var refNum = $(this).attr('data-refnum');
-        $(this).attachReservationPopup(refNum, options.popupUrl);
+        $(this).find('.reservationTitle').attachReservationPopup(refNum, options.popupUrl);
       });
 
     $('#reservationTable').on('click', '.editable', function () {

--- a/Web/scripts/admin/reservations.js
+++ b/Web/scripts/admin/reservations.js
@@ -142,7 +142,7 @@ function ReservationManagement(opts, approval) {
 
     elements.reservationTable.find('tr.editable').each(function () {
       var refNum = $(this).attr('data-refnum');
-      $(this).attachReservationPopup(refNum, options.popupUrl);
+      $(this).find('.reservationTitle').attachReservationPopup(refNum, options.popupUrl);
 
       /*$(this).hover(function (e) {
                 $(this).find('td').addClass('highlight');

--- a/Web/scripts/dashboard.js
+++ b/Web/scripts/dashboard.js
@@ -16,10 +16,10 @@ function Dashboard(opts) {
 
     var reservations = $('.reservation');
 
-    function attachReservationTooltip(reservations, options) {
-      reservations.on('mouseenter', function () {
+    function attachReservationTooltip(reservationTitles, options) {
+      reservationTitles.on('mouseenter', function () {
         var me = $(this);
-        var refNum = me.attr('id');
+        var refNum = me.closest('.reservation').attr('id');
 
         me.attr('data-bs-toggle', 'tooltip').tooltip('show');
 
@@ -35,18 +35,18 @@ function Dashboard(opts) {
           });
       });
 
-      reservations.on('mouseleave', function () {
+      reservationTitles.on('mouseleave', function () {
         $(this).tooltip('hide');
       });
     }
 
     $(document).ready(function () {
-      var reservations = $('.reservation');
+      var reservationTitles = $('.reservationTitle');
       var options = {
         summaryPopupUrl: 'ajax/respopup.php',
       };
 
-      attachReservationTooltip(reservations, options);
+      attachReservationTooltip(reservationTitles, options);
 
       $('[data-bs-toggle="tooltip"]').tooltip();
     });

--- a/Web/scripts/participation.js
+++ b/Web/scripts/participation.js
@@ -28,8 +28,8 @@ function Participation(opts) {
       RespondToInvitation($(this).val(), referenceNumber, $(this));
     });
 
-    $('.reservation').each(function () {
-      var refNum = $(this).attr('referenceNumber');
+    $('.reservationTitle').each(function () {
+      var refNum = $(this).attr('data-reference-number');
       $(this).attachReservationPopup(refNum);
     });
   };

--- a/Web/scripts/reservation-search.js
+++ b/Web/scripts/reservation-search.js
@@ -64,7 +64,7 @@ function ReservationSearch(options) {
 
     elements.reservationResults.find('tr.editable').each(function () {
       var refNum = $(this).attr('data-refnum');
-      $(this).attachReservationPopup(refNum, options.popupUrl);
+      $(this).find('.reservationTitle').attachReservationPopup(refNum, options.popupUrl);
     });
   };
 

--- a/tpl/Admin/Blackouts/manage_blackouts_response.tpl
+++ b/tpl/Admin/Blackouts/manage_blackouts_response.tpl
@@ -54,8 +54,10 @@
 					{foreach from=$Reservations item=reservation}
 						<tr class="editable" data-refnum="{$reservation->ReferenceNumber|escape:'html'}">
 							<td>{$reservation->FirstName|escape:'html'} {$reservation->LastName|escape:'html'}</td>
-							<td class="reservationTitle">
-								{if !empty($reservation->Title)}{$reservation->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}
+							<td>
+								<span class="reservationTitle" data-bs-custom-class="respopup-tooltip" data-bs-html="true">
+									{if !empty($reservation->Title)}{$reservation->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}
+								</span>
 							</td>
 							<td>{$reservation->ResourceName|escape:'html'}</td>
 							<td>{formatdate date=$reservation->StartDate timezone=$Timezone key=res_popup}</td>

--- a/tpl/Admin/Reservations/manage_reservations.tpl
+++ b/tpl/Admin/Reservations/manage_reservations.tpl
@@ -220,8 +220,7 @@
 							{/if}
 							{assign var=reservationId value=$reservation->ReservationId}
 							<tr class="{$rowCss} {if $IsDesktop}editable{/if}" data-seriesId="{$reservation->SeriesId}"
-								data-refnum="{$reservation->ReferenceNumber}" data-bs-custom-class="respopup-tooltip"
-								data-bs-html="true">
+								data-refnum="{$reservation->ReferenceNumber}">
 								<td class="id d-none">{$reservationId}</td>
 								<td class="user">
 									{fullname first=$reservation->FirstName|unescape:'html' last=$reservation->LastName|unescape:'html' ignorePrivacy=true}
@@ -238,7 +237,9 @@
 										{*<span class="reservationResourceStatusReason">{$StatusReasons[$reservation->ResourceStatusReasonId]->Description()}</span>*}
 									{*{/if}*}
 								</td>
-								<td class="reservationTitle">{$reservation->Title|escape:'html'}</td>
+								<td><span class="reservationTitle" data-bs-custom-class="respopup-tooltip"
+										data-bs-html="true">{if $reservation->Title}{$reservation->Title|escape:'html'}{else}{translate key=NoTitleLabel}{/if}</span>
+								</td>
 								<td class="description">{$reservation->Description|escape:'html'}</td>
 								<td class="date">
 									{formatdate date=$reservation->StartDate timezone=$Timezone key=short_reservation_date}

--- a/tpl/Dashboard/dashboard_reservation.tpl
+++ b/tpl/Dashboard/dashboard_reservation.tpl
@@ -3,9 +3,10 @@
 {assign var=class value=""}
 {if $reservation->RequiresApproval}{assign var=class value="pending"}{/if}
 <div class="reservation row gx-0 {$class} border-bottom p-2 border-bottom align-items-center {if isset($orangePending)}bg-white{/if}"
-    id="{$reservation->ReferenceNumber}" data-bs-custom-class="respopup-tooltip" data-bs-html="true">
+    id="{$reservation->ReferenceNumber}">
     {*doesn't show pending approval reservations as orange in the Pending Approval Reservations displayer in the dashboard*}
-    <div class="col-sm-3 col-12">{$reservation->Title|escape:'html'|default:$DefaultTitle}</div>
+    <div class="col-sm-3 col-12"><span class="reservationTitle" data-bs-custom-class="respopup-tooltip"
+            data-bs-html="true">{$reservation->Title|escape:'html'|default:$DefaultTitle}</span></div>
     <div class="col-sm-3 col-12">
         {fullname first=$reservation->FirstName|unescape:'html' last=$reservation->LastName|unescape:'html' ignorePrivacy=$reservation->IsUserOwner($UserId)}
         {if !$reservation->IsUserOwner($UserId)}<i class="bi bi-people-fill"></i> {/if}</div>

--- a/tpl/MyAccount/participation.tpl
+++ b/tpl/MyAccount/participation.tpl
@@ -27,7 +27,9 @@
 					{foreach from=$Reservations item=reservation name=invitations}
 						{assign var=referenceNumber value=$reservation->ReferenceNumber}
 						<tr>
-							<td>{$reservation->Title|default:{translate key="NoTitleLabel"}}
+							<td><span class="reservationTitle" data-reference-number="{$referenceNumber|escape:'html'}"
+									data-bs-custom-class="respopup-tooltip"
+									data-bs-html="true">{$reservation->Title|escape:'html'|default:{translate key="NoTitleLabel"}}</span>
 							</td>
 							<td>
 								<a href="{Pages::RESERVATION}?{QueryStringKeys::REFERENCE_NUMBER}={$referenceNumber}"

--- a/tpl/Search/search-reservations-results.tpl
+++ b/tpl/Search/search-reservations-results.tpl
@@ -29,7 +29,9 @@
 								{fullname first=$reservation->FirstName last=$reservation->LastName ignorePrivacy=($reservation->OwnerId==$UserId)}
 							</td>
 							<td class="resource">{$reservation->ResourceName}</td>
-							<td class="title">{$reservation->Title}</td>
+							<td class="title"><span class="reservationTitle" data-bs-custom-class="respopup-tooltip"
+									data-bs-html="true">{if $reservation->Title}{$reservation->Title|escape:'html'}{else}{translate key=NoTitleLabel}{/if}</span>
+							</td>
 							<td class="description">{$reservation->Description}</td>
 							<td class="date">
 								{formatdate date=$reservation->StartDate timezone=$Timezone key=short_reservation_date}</td>


### PR DESCRIPTION
This PR adjusts the behavior of tooltips in the reservation, ensuring that tooltips only appear on fields with the .reservationTitle class.

Main changes:

Updated templates (.tpl) and scripts (.js) for 5 pages.
Each tooltip is now restricted exclusively to the reservation title field, preventing it from appearing on other fields.
Improves user experience by removing unwanted tooltips.
When there is no title, the 'NoTitleLabel' key is rendered.

<img width="511" height="301" alt="Captura de pantalla 2026-04-02 124439" src="https://github.com/user-attachments/assets/177f0032-0d48-45c6-9402-faf7d1cb3e4b" />
