### PR TITLE
fix(config): treat empty-string section as unsectioned in GetKey

### DIFF
--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -514,7 +514,7 @@ class ConfigurationFile implements IConfigurationFile
 
         if (!empty($envValue)) {
             $value = $envValue;
-        } elseif ($section !== null) {
+        } elseif ($section !== null && $section !== '') {
             $sectionKey = str_starts_with($fullKey, $section . '.') ? substr($fullKey, strlen($section) + 1) : $fullKey;
             if (isset($this->_values[$section][$sectionKey])) {
                 $value = $this->_values[$section][$sectionKey];

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -165,6 +165,20 @@ PHP
         $this->assertSame('xoxb-test-token', $values['slack.token']);
     }
 
+    public function testGetKeyRetrievesUnsectionedKeysWithEmptySection(): void
+    {
+        $config = $this->createConfigurationFileFromContents(
+            <<<'PHP'
+<?php
+$conf['settings']['google.analytics']['tracking.id'] = 'G-TEST123';
+$conf['settings']['slack']['token'] = 'xoxb-test-token';
+PHP
+        );
+
+        $this->assertSame('G-TEST123', $config->GetKey(ConfigKeys::GOOGLE_ANALYTICS_TRACKING_ID));
+        $this->assertSame('xoxb-test-token', $config->GetKey(ConfigKeys::SLACK_TOKEN));
+    }
+
     public function testMainConfigValidation()
     {
         $errorLogs = $this->captureErrorLog(function () {


### PR DESCRIPTION
Commit e091b3f6 fixed the write path (RewriteLegacyKeys) to treat empty-string sections as unsectioned, but missed the corresponding read path in GetKey. This caused GetKey to look up keys like slack.token under $values['']['token'] instead of $values['slack.token'], silently returning the default empty string instead of the stored value.

Apply the same guard ($section !== null && $section !== '') to the GetKey lookup so it matches the rewrite behavior.