### PR TITLE
feat(config): add config migration script and documentation

### DIFF
--- a/docs/source/CONFIGURATION.rst
+++ b/docs/source/CONFIGURATION.rst
@@ -75,3 +75,38 @@ Migration from Old Format
 If upgrading from an older version that used ``$conf['settings'][...]`` format,
 you'll need to convert your configuration to the new array return format. The
 new format is more modern and provides better IDE support and validation.
+
+LibreBooking includes a migration script for this purpose:
+
+.. code-block:: bash
+
+   php scripts/migrate-config.php config/config.php
+
+By default, this writes a sibling file named ``config/config.migrated.php``.
+You can also provide an explicit output path:
+
+.. code-block:: bash
+
+   php scripts/migrate-config.php config/config.php /tmp/config.new.php
+
+The migration script uses the current config parser and legacy key mappings to:
+
+- convert legacy ``$conf['settings'][...]`` files into the modern ``return [...]`` format
+- rewrite known legacy keys to their canonical modern names
+- preserve values using the canonical nested section structure expected by
+  ``config/config.dist.php``
+- keep keys that are present in your config but not in
+  ``config/config.dist.php``, while warning about them
+
+During migration you may see messages such as:
+
+- ``Legacy config format detected``: the input file is using the old ``$conf`` style
+- ``Deprecated config key ... maps to ...``: a recognized legacy key was
+  rewritten to its modern equivalent
+- ``Unknown config key ...``: the parser does not recognize that key and it
+  should be reviewed manually
+- ``Warning: preserving key not present in config.dist.php``: the key is being
+  kept, but it is not part of the current template
+
+After reviewing the generated file, replace ``config/config.php`` with the
+migrated file when you are satisfied with the result.

--- a/lib/Config/MigrateConfig.php
+++ b/lib/Config/MigrateConfig.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Common/Converters/namespace.php');
+
+class MigrateConfig
+{
+    public static function WriteStderr(string $message): void
+    {
+        fwrite(STDERR, $message . PHP_EOL);
+    }
+
+    public static function Usage(): void
+    {
+        self::WriteStderr('Usage: php scripts/migrate-config.php <old-config.php> [output.php] [--dist=/path/to/config.dist.php]');
+        self::WriteStderr('If output.php is omitted, a sibling file ending in .migrated.php is written.');
+    }
+
+    public static function ExportValue(mixed $value, ?array $configDef = null): string
+    {
+        $configType = is_array($configDef) ? ($configDef['type'] ?? null) : null;
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if ($configType === ConfigSettingType::Boolean) {
+            return BooleanConverter::ConvertValue($value) ? 'true' : 'false';
+        }
+
+        if ($configType === ConfigSettingType::Integer) {
+            return (string) ((int) $value);
+        }
+
+        if (is_int($value)) {
+            return (string) $value;
+        }
+
+        return var_export($value, true);
+    }
+
+    public static function ExportArray(array $array, int $indentLevel = 0, array $pathParts = []): string
+    {
+        $indent = str_repeat('    ', $indentLevel);
+        $nextIndent = str_repeat('    ', $indentLevel + 1);
+        $lines = ['['];
+
+        foreach ($array as $key => $value) {
+            $exportedKey = var_export($key, true);
+            $currentPathParts = $pathParts;
+            if (!($indentLevel === 0 && $key === Configuration::SETTINGS)) {
+                $currentPathParts[] = (string) $key;
+            }
+
+            $exportedValue = is_array($value)
+                ? self::ExportArray($value, $indentLevel + 1, $currentPathParts)
+                : self::ExportValue($value, ConfigKeys::findByKey(implode('.', $currentPathParts)));
+
+            $lines[] = "$nextIndent$exportedKey => $exportedValue,";
+        }
+
+        $lines[] = "$indent]";
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    public static function WriteConfigFile(string $path, array $settings): void
+    {
+        $php = "<?php\n\n";
+        $php .= '// LibreBooking configuration file migrated at ' . date('c') . "\n\n";
+        $php .= 'return ' . self::ExportArray([Configuration::SETTINGS => $settings]) . ";\n";
+
+        if (file_put_contents($path, $php) === false) {
+            throw new RuntimeException('Failed to write migrated config: ' . $path);
+        }
+    }
+
+    public static function LoadSettings(string $configPath): array
+    {
+        // Legacy config files assign to $conf via side-effect instead of using return.
+        $conf = [];
+        $loaded = require $configPath;
+
+        if (is_array($loaded) && isset($loaded['settings'])) {
+            return $loaded['settings'];
+        }
+
+        if (isset($conf['settings'])) {
+            self::WriteStderr('[CONFIG] Legacy config format detected in ' . $configPath . '. Please consider updating to the new format.');
+            return $conf['settings'];
+        }
+
+        throw new RuntimeException("Invalid config file '$configPath': 'settings' section missing");
+    }
+
+    public static function NormalizeSettings(array $settings): array
+    {
+        $configFile = new ConfigurationFile([
+            Configuration::SETTINGS => $settings,
+        ]);
+
+        return $configFile->GetValues();
+    }
+
+    public static function GetNormalizedSettings(string $configPath): array
+    {
+        return self::NormalizeSettings(self::LoadSettings($configPath));
+    }
+
+    public static function MergeSettings(array $currentSettings, array $templateSettings, array $pathParts = []): array
+    {
+        $merged = [];
+
+        foreach ($currentSettings as $key => $currentValue) {
+            $currentPathParts = [...$pathParts, (string) $key];
+            $fullKey = implode('.', $currentPathParts);
+
+            if (array_key_exists($key, $templateSettings)) {
+                $templateValue = $templateSettings[$key];
+
+                if (is_array($currentValue) && is_array($templateValue)) {
+                    $merged[$key] = self::MergeSettings($currentValue, $templateValue, $currentPathParts);
+                } else {
+                    $merged[$key] = $currentValue;
+                }
+            } else {
+                self::WriteStderr('Warning: preserving key not present in config.dist.php: ' . $fullKey);
+                $merged[$key] = $currentValue;
+            }
+        }
+
+        foreach ($templateSettings as $key => $templateValue) {
+            if (!array_key_exists($key, $currentSettings)) {
+                $merged[$key] = $templateValue;
+            }
+        }
+
+        return $merged;
+    }
+
+    public static function Main(array $args): int
+    {
+        $source = null;
+        $output = null;
+        $dist = ROOT_DIR . 'config/config.dist.php';
+
+        foreach (array_slice($args, 1) as $arg) {
+            if ($arg === '--help' || $arg === '-h') {
+                self::Usage();
+                return 0;
+            }
+
+            if (str_starts_with($arg, '--dist=')) {
+                $dist = substr($arg, strlen('--dist='));
+                continue;
+            }
+
+            if ($source === null) {
+                $source = $arg;
+                continue;
+            }
+
+            if ($output === null) {
+                $output = $arg;
+                continue;
+            }
+
+            self::Usage();
+            return 1;
+        }
+
+        if ($source === null) {
+            self::Usage();
+            return 1;
+        }
+
+        $source = realpath($source) ?: $source;
+        $dist = realpath($dist) ?: $dist;
+
+        if (!file_exists($source)) {
+            self::WriteStderr('Source config file not found: ' . $source);
+            return 1;
+        }
+
+        if (!file_exists($dist)) {
+            self::WriteStderr('Template config file not found: ' . $dist);
+            return 1;
+        }
+
+        if ($output === null) {
+            $pathInfo = pathinfo($source);
+            $dirname = $pathInfo['dirname'] ?? '.';
+            $filename = $pathInfo['filename'] ?? 'config';
+            $output = $dirname . '/' . $filename . '.migrated.php';
+        }
+
+        $resolvedOutput = realpath($output) ?: $output;
+        if ($resolvedOutput === $source) {
+            self::WriteStderr('Output file matches the source file and will not be overwritten: ' . $output);
+            return 1;
+        }
+
+        if (file_exists($output)) {
+            self::WriteStderr('Output file already exists and will not be overwritten: ' . $output);
+            return 1;
+        }
+
+        try {
+            $currentSettings = self::GetNormalizedSettings($source);
+            $mergedSettings = self::MergeSettings($currentSettings, self::GetNormalizedSettings($dist));
+
+            self::WriteConfigFile($output, $mergedSettings);
+
+            fwrite(STDOUT, 'Migrated config written to: ' . $output . PHP_EOL);
+        } catch (Throwable $e) {
+            self::WriteStderr($e->getMessage());
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/scripts/.htaccess
+++ b/scripts/.htaccess
@@ -1,0 +1,1 @@
+Require all denied

--- a/scripts/migrate-config.php
+++ b/scripts/migrate-config.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+if (!defined('ROOT_DIR')) {
+    define('ROOT_DIR', dirname(__DIR__) . '/');
+}
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit('This script must be run from the command line.');
+}
+
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
+require_once(ROOT_DIR . 'lib/Config/MigrateConfig.php');
+
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
+    exit(MigrateConfig::Main($argv));
+}

--- a/tests/Infrastructure/Config/MigrateConfigScriptTest.php
+++ b/tests/Infrastructure/Config/MigrateConfigScriptTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'tests/TestBase.php');
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
+require_once(ROOT_DIR . 'lib/Config/MigrateConfig.php');
+
+class MigrateConfigScriptTest extends TestBase
+{
+    /** @var array<int, string> */
+    private array $tempConfigPaths = [];
+
+    public function testLoadSettingsReadsNewFormatConfig(): void
+    {
+        $path = $this->writeTempConfig(
+            <<<'PHP'
+<?php
+return [
+    'settings' => [
+        'app.title' => 'Example',
+    ],
+];
+PHP
+        );
+
+        $this->assertSame(
+            ['app.title' => 'Example'],
+            MigrateConfig::LoadSettings($path)
+        );
+    }
+
+    public function testLoadSettingsReadsLegacyConfigSideEffects(): void
+    {
+        $path = $this->writeTempConfig(
+            <<<'PHP'
+<?php
+$conf['settings']['app.title'] = 'Legacy Example';
+PHP
+        );
+
+        $settings = MigrateConfig::LoadSettings($path);
+
+        $this->assertSame('Legacy Example', $settings['app.title']);
+    }
+
+    public function testLoadSettingsIncludesPathInInvalidConfigException(): void
+    {
+        $path = $this->writeTempConfig(
+            <<<'PHP'
+<?php
+return ['not_settings' => []];
+PHP
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Invalid config file '$path': 'settings' section missing");
+
+        MigrateConfig::LoadSettings($path);
+    }
+
+    public function testMergeSettingsPreservesExistingValuesAndAddsTemplateDefaults(): void
+    {
+        $merged = MigrateConfig::MergeSettings(
+            currentSettings: [
+                'app' => [
+                    'title' => 'Custom',
+                ],
+            ],
+            templateSettings: [
+                'app' => [
+                    'title' => 'Default',
+                    'debug' => false,
+                ],
+                'logging' => [
+                    'level' => 'error',
+                ],
+            ]
+        );
+
+        $this->assertSame('Custom', $merged['app']['title']);
+        $this->assertFalse($merged['app']['debug']);
+        $this->assertSame('error', $merged['logging']['level']);
+    }
+
+    public function testExportArrayUsesSchemaTypesForBooleanIntegerAndStringValues(): void
+    {
+        $exported = MigrateConfig::ExportArray([
+            Configuration::SETTINGS => [
+                'app' => [
+                    'debug' => 'true',
+                ],
+                'inactivity' => [
+                    'timeout' => '30',
+                ],
+                'app.title' => 'true',
+                'install.password' => '1234',
+            ],
+        ]);
+
+        $this->assertStringContainsString("'debug' => true", $exported);
+        $this->assertStringContainsString("'timeout' => 30", $exported);
+        $this->assertStringContainsString("'app.title' => 'true'", $exported);
+        $this->assertStringContainsString("'install.password' => '1234'", $exported);
+    }
+
+    private function writeTempConfig(string $contents): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'migrate-config-test-');
+        if ($path === false) {
+            throw new RuntimeException('Failed to create temporary config file.');
+        }
+
+        if (file_put_contents($path, $contents) === false) {
+            throw new RuntimeException('Failed to write temporary config file.');
+        }
+
+        $this->tempConfigPaths[] = $path;
+
+        return $path;
+    }
+
+    public function tearDown(): void
+    {
+        foreach ($this->tempConfigPaths as $path) {
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
Add a CLI migration tool for converting legacy config.php files to the
current return-array format using the shared config parser and legacy key
mappings.

Introduce a dedicated MigrateConfig class, a scripts/migrate-config.php
entrypoint, and scripts/.htaccess protection. The migrator loads legacy
$conf['settings'][...] configs, rewrites known legacy keys to their
canonical modern names, merges with current template defaults, and
writes a separate migrated config file instead of modifying the source
in place.

Add focused PHPUnit coverage for loading, merging, exporting, invalid
input handling, and schema-typed string/integer/boolean rendering.
Document the migration workflow in the configuration guide, including
usage, output behavior, and expected warnings during conversion.