### PR TITLE
refactor(dashboard-tooltip): show reservation tooltip only on .reserv…

### DIFF
--- a/Web/scripts/dashboard.js
+++ b/Web/scripts/dashboard.js
@@ -16,37 +16,13 @@ function Dashboard(opts) {
 
     var reservations = $('.reservation');
 
-    function attachReservationTooltip(reservations, options) {
-      reservations.on('mouseenter', function () {
-        var me = $(this);
-        var refNum = me.attr('id');
-
-        me.attr('data-bs-toggle', 'tooltip').tooltip('show');
-
-        $.ajax({
-          url: options.summaryPopupUrl,
-          data: { id: refNum },
-        })
-          .done(function (html) {
-            me.attr('data-bs-original-title', html).tooltip('show');
-          })
-          .fail(function (xhr, status, error) {
-            me.attr('data-bs-original-title', status + ': ' + error).tooltip('show');
-          });
-      });
-
-      reservations.on('mouseleave', function () {
-        $(this).tooltip('hide');
-      });
-    }
-
     $(document).ready(function () {
-      var reservations = $('.reservation');
-      var options = {
-        summaryPopupUrl: 'ajax/respopup.php',
-      };
+      var reservationTitles = $('.reservationTitle');
 
-      attachReservationTooltip(reservations, options);
+      reservationTitles.each(function () {
+        var refNum = $(this).closest('.reservation').attr('id');
+        $(this).attachReservationPopup(refNum, options.summaryPopupUrl);
+      });
 
       $('[data-bs-toggle="tooltip"]').tooltip();
     });

--- a/tpl/Dashboard/dashboard_reservation.tpl
+++ b/tpl/Dashboard/dashboard_reservation.tpl
@@ -3,9 +3,10 @@
 {assign var=class value=""}
 {if $reservation->RequiresApproval}{assign var=class value="pending"}{/if}
 <div class="reservation row gx-0 {$class} border-bottom p-2 border-bottom align-items-center {if isset($orangePending)}bg-white{/if}"
-    id="{$reservation->ReferenceNumber}" data-bs-custom-class="respopup-tooltip" data-bs-html="true">
+    id="{$reservation->ReferenceNumber}">
     {*doesn't show pending approval reservations as orange in the Pending Approval Reservations displayer in the dashboard*}
-    <div class="col-sm-3 col-12">{$reservation->Title|escape:'html'|default:$DefaultTitle}</div>
+    <div class="col-sm-3 col-12"><span class="reservationTitle" data-bs-custom-class="respopup-tooltip"
+            data-bs-html="true">{$reservation->Title|escape:'html'|default:$DefaultTitle}</span></div>
     <div class="col-sm-3 col-12">
         {fullname first=$reservation->FirstName|unescape:'html' last=$reservation->LastName|unescape:'html' ignorePrivacy=$reservation->IsUserOwner($UserId)}
         {if !$reservation->IsUserOwner($UserId)}<i class="bi bi-people-fill"></i> {/if}</div>

--- a/tpl/dashboard.tpl
+++ b/tpl/dashboard.tpl
@@ -9,6 +9,7 @@
 
 	{include file="javascript-includes.tpl"}
 
+	{jsfile src="reservationPopup.js"}
 	{jsfile src="dashboard.js"}
 	{jsfile src="resourcePopup.js"}
 	{jsfile src="ajax-helpers.js"}


### PR DESCRIPTION
…ationTitle

Updated dashboard_reservation.tpl and dashboard.js so that the tooltip triggers only on the field with class .reservationTitle. This prevents the reservation popup from appearing in the entire row.