### PR TITLE
refactor(manage-blackouts): tooltips to appear only on .reservationTitle

### DIFF
--- a/Web/scripts/admin/blackouts.js
+++ b/Web/scripts/admin/blackouts.js
@@ -205,7 +205,7 @@ function BlackoutManagement(opts) {
       .find('.editable')
       .each(function () {
         var refNum = $(this).attr('data-refnum');
-        $(this).attachReservationPopup(refNum, options.popupUrl);
+        $(this).find('.reservationTitle').attachReservationPopup(refNum, options.popupUrl);
       });
 
     $('#reservationTable').on('click', '.editable', function () {

--- a/tpl/Admin/Blackouts/manage_blackouts_response.tpl
+++ b/tpl/Admin/Blackouts/manage_blackouts_response.tpl
@@ -54,8 +54,10 @@
 					{foreach from=$Reservations item=reservation}
 						<tr class="editable" data-refnum="{$reservation->ReferenceNumber|escape:'html'}">
 							<td>{$reservation->FirstName|escape:'html'} {$reservation->LastName|escape:'html'}</td>
-							<td class="reservationTitle">
-								{if !empty($reservation->Title)}{$reservation->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}
+							<td>
+								<span class="reservationTitle" data-bs-custom-class="respopup-tooltip" data-bs-html="true">
+									{if !empty($reservation->Title)}{$reservation->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}
+								</span>
 							</td>
 							<td>{$reservation->ResourceName|escape:'html'}</td>
 							<td>{formatdate date=$reservation->StartDate timezone=$Timezone key=res_popup}</td>


### PR DESCRIPTION
Updated manage_blackouts_response.tpl and blackouts.js so that the tooltip triggers only on the field with class .reservationTitle. Prevents the reservation tooltip from appearing in the entire row.