### PR TITLE
refactor(manage-reservations): tooltips to appear only on .reservatio…

### DIFF
--- a/Web/scripts/admin/reservations.js
+++ b/Web/scripts/admin/reservations.js
@@ -142,7 +142,7 @@ function ReservationManagement(opts, approval) {
 
     elements.reservationTable.find('tr.editable').each(function () {
       var refNum = $(this).attr('data-refnum');
-      $(this).attachReservationPopup(refNum, options.popupUrl);
+      $(this).find('.reservationTitle').attachReservationPopup(refNum, options.popupUrl);
 
       /*$(this).hover(function (e) {
                 $(this).find('td').addClass('highlight');

--- a/tpl/Admin/Reservations/manage_reservations.tpl
+++ b/tpl/Admin/Reservations/manage_reservations.tpl
@@ -220,8 +220,7 @@
 							{/if}
 							{assign var=reservationId value=$reservation->ReservationId}
 							<tr class="{$rowCss} {if $IsDesktop}editable{/if}" data-seriesId="{$reservation->SeriesId}"
-								data-refnum="{$reservation->ReferenceNumber}" data-bs-custom-class="respopup-tooltip"
-								data-bs-html="true">
+								data-refnum="{$reservation->ReferenceNumber}">
 								<td class="id d-none">{$reservationId}</td>
 								<td class="user">
 									{fullname first=$reservation->FirstName|unescape:'html' last=$reservation->LastName|unescape:'html' ignorePrivacy=true}
@@ -238,7 +237,9 @@
 										{*<span class="reservationResourceStatusReason">{$StatusReasons[$reservation->ResourceStatusReasonId]->Description()}</span>*}
 									{*{/if}*}
 								</td>
-								<td class="reservationTitle">{$reservation->Title|escape:'html'}</td>
+								<td><span
+										class="reservationTitle">{if !empty($reservation->Title)}{$reservation->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}</span>
+								</td>
 								<td class="description">{$reservation->Description|escape:'html'}</td>
 								<td class="date">
 									{formatdate date=$reservation->StartDate timezone=$Timezone key=short_reservation_date}


### PR DESCRIPTION
…nTitle

Updated manage_reservations.tpl and reservations.js so that the tooltip triggers only on the field with class .reservationTitle.  Prevents the reservation tooltip from appearing in the entire row.