### PR TITLE
refactor(participation): tooltips to appear only on .reservationTitle

### DIFF
--- a/Web/scripts/participation.js
+++ b/Web/scripts/participation.js
@@ -28,8 +28,8 @@ function Participation(opts) {
       RespondToInvitation($(this).val(), referenceNumber, $(this));
     });
 
-    $('.reservation').each(function () {
-      var refNum = $(this).attr('referenceNumber');
+    $('.reservationTitle').each(function () {
+      var refNum = $(this).attr('data-reference-number');
       $(this).attachReservationPopup(refNum);
     });
   };

--- a/tpl/MyAccount/participation.tpl
+++ b/tpl/MyAccount/participation.tpl
@@ -27,7 +27,8 @@
 					{foreach from=$Reservations item=reservation name=invitations}
 						{assign var=referenceNumber value=$reservation->ReferenceNumber}
 						<tr>
-							<td>{$reservation->Title|default:{translate key="NoTitleLabel"}}
+							<td><span class="reservationTitle"
+									data-reference-number="{$referenceNumber|escape:'html'}">{if !empty($reservation->Title)}{$reservation->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}</span>
 							</td>
 							<td>
 								<a href="{Pages::RESERVATION}?{QueryStringKeys::REFERENCE_NUMBER}={$referenceNumber}"


### PR DESCRIPTION
Updated participation.tpl and participation.js so that the tooltip triggers only on the field with class .reservationTitle. Prevents the reservation tooltip from appearing in the entire row.