### PR TITLE
refactor(tooltip): tooltips to appear only on .reservationTitle (sear…

### DIFF
--- a/Web/scripts/reservation-search.js
+++ b/Web/scripts/reservation-search.js
@@ -64,7 +64,7 @@ function ReservationSearch(options) {
 
     elements.reservationResults.find('tr.editable').each(function () {
       var refNum = $(this).attr('data-refnum');
-      $(this).attachReservationPopup(refNum, options.popupUrl);
+      $(this).find('.reservationTitle').attachReservationPopup(refNum, options.popupUrl);
     });
   };
 

--- a/tpl/Search/search-reservations-results.tpl
+++ b/tpl/Search/search-reservations-results.tpl
@@ -29,8 +29,10 @@
 								{fullname first=$reservation->FirstName last=$reservation->LastName ignorePrivacy=($reservation->OwnerId==$UserId)}
 							</td>
 							<td class="resource">{$reservation->ResourceName}</td>
-							<td class="title">{$reservation->Title}</td>
-							<td class="description">{$reservation->Description}</td>
+							<td class="title"><span
+									class="reservationTitle">{if !empty($reservation->Title)}{$reservation->Title|escape:'html'}{else}{translate key='NoTitleLabel'}{/if}</span>
+							</td>
+							<td class="description">{$reservation->Description|escape:'html'}</td>
 							<td class="date">
 								{formatdate date=$reservation->StartDate timezone=$Timezone key=short_reservation_date}</td>
 							<td class="date">


### PR DESCRIPTION
…ch-reservations)

Updated search-reservations-results.tpl and reservation-search.js so that the tooltip triggers only on the field with class .reservationTitle. Prevents the reservation tooltip from appearing in the entire row.