### PR TITLE
fix: improve tooltip rendering and fix Smarty issues

### DIFF
--- a/tpl/Ajax/reservation_popup.tpl
+++ b/tpl/Ajax/reservation_popup.tpl
@@ -1,12 +1,12 @@
 {if $authorized}
-    {*CHECK IF USER HAS PERMISSIONS TO THE RESOURCES OF THE RESERVATIONS, HIDE DETAILS IF HE DOESN'T HAVE PERMISSIONS TO ALL OF THEM*}
+    {*CHECK IF USER HAS PERMISSIONS TO ANY OF THE RESERVATION RESOURCES, HIDE DETAILS IF HE DOESN'T HAVE PERMISSIONS TO ANY OF THEM*}
     {assign var=isResourcePermitted value=false}
     {foreach from=$resources item=checkResourcePermission}
         {if in_array($checkResourcePermission->Id(), $CanViewResourceReservations)}
             {assign var=isResourcePermitted value=true}
-            {break};
+            {break}
         {/if}
-    {{/foreach}}
+    {/foreach}
     {*HOWEVER THE USER CAN SEE THE RESERVATION IF HE IS A OWNER, PARTICIPANT OR INVITEE*}
     {if $isResourcePermitted == false}
         {if $UserId == $OwnerId || $IAmParticipating || $IAmInvited}
@@ -21,7 +21,7 @@
                 {if ($hideUserInfo || $hideDetails) || !$isResourcePermitted}
                     {translate key=Private}
                 {else}
-                    {$fullName}
+                    {$fullName|escape:'html'}
                 {/if}
             </div>
         {/capture}
@@ -30,7 +30,7 @@
         {capture "email"}
             <div class="email">
                 {if !$hideUserInfo && !$hideDetails && $isResourcePermitted}
-                    {$email}
+                    {$email|escape:'html'}
                 {/if}
             </div>
         {/capture}
@@ -39,7 +39,7 @@
         {capture "phone"}
             <div class="phone">
                 {if !$hideUserInfo && !$hideDetails && $isResourcePermitted}
-                    {$phone}
+                    {$phone|escape:'html'}
                 {/if}
             </div>
         {/capture}
@@ -56,7 +56,8 @@
 
         {capture "title"}
             {if !$hideDetails && $isResourcePermitted}
-                <div class="title">{if $title neq ''}{$title|escape:'html'}{else}{translate key=NoTitleLabel}{/if}</div>
+                <div class="title">{translate key=Title}:
+                    {if $title neq ''}{$title|escape:'html'}{else}{translate key=NoTitleLabel}{/if}</div>
             {/if}
         {/capture}
         {$formatter->Add('title', $smarty.capture.title)}
@@ -106,8 +107,9 @@
 
         {capture "description"}
             {if !$hideDetails && $isResourcePermitted}
-                <div class="summary">
-                    {if $summary neq ''}{$summary|truncate:300:"..."|escape:'html'|nl2br}{else}{translate key=NoDescriptionLabel}{/if}</div>
+                <div class="summary">{translate key=Description}:
+                    {if $summary neq ''}{$summary|truncate:300:"..."|escape:'html'|nl2br}{else}{translate key=NoDescriptionLabel}{/if}
+                </div>
             {/if}
         {/capture}
         {$formatter->Add('description', $smarty.capture.description)}
@@ -115,15 +117,16 @@
         {capture "attributes"}
             {if !$hideDetails && $isResourcePermitted}
                 {if $attributes|default:array()|count > 0}
-                    <br />
-                    {foreach from=$attributes item=attribute}
-                        {assign var=attr value="att`$attribute->Id()`"}
-                        {capture name="attr"}
-                            <div>{control type="AttributeControl" attribute=$attribute readonly=true}</div>
-                        {/capture}
-                        {$smarty.capture.attr}
-                        {$formatter->Add($attr, $smarty.capture.attr)}
-                    {/foreach}
+                    <div class="attributes-block mt-2">
+                        {foreach from=$attributes item=attribute}
+                            {assign var=attr value="att`$attribute->Id()`"}
+                            {capture name="attr"}
+                                <div>{control type="AttributeControl" attribute=$attribute readonly=true tooltip=true}</div>
+                            {/capture}
+                            {$smarty.capture.attr}
+                            {$formatter->Add($attr, $smarty.capture.attr)}
+                        {/foreach}
+                    </div>
                 {/if}
             {/if}
         {/capture}
@@ -137,7 +140,7 @@
         {$formatter->Add('pending', $smarty.capture.pending)}
 
         {capture "duration"}
-            <div class="duration">{$duration}</div>
+            <div class="duration">{translate key=Duration}: {$duration}</div>
         {/capture}
         {$formatter->Add('duration', $smarty.capture.duration)}
         <!-- {$ReservationId} -->

--- a/tpl/Controls/Attributes/Checkbox.tpl
+++ b/tpl/Controls/Attributes/Checkbox.tpl
@@ -1,6 +1,15 @@
 <div class="form-group {$class}">
     {if $readonly}
-        <label class="customAttribute fw-bold readonly" for="{$attributeId}">{$attribute->Label()}</label>
+        {if isset($tooltip) && $tooltip}
+            <span class="customAttribute readonly">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                    <i class="bi bi-asterisk text-danger align-top text-small"></i>
+                {/if}:</span>
+        {else}
+            <label class="customAttribute fw-bold readonly"
+                for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                    <i class="bi bi-asterisk text-danger align-top text-small"></i>
+                {/if}</label>
+        {/if}
         <span
             class="attributeValue {$class}">{if $attribute->Value() == "1"}{translate key='True'}{else}{translate key='False'}{/if}</span>
     {elseif $searchmode}

--- a/tpl/Controls/Attributes/Date.tpl
+++ b/tpl/Controls/Attributes/Date.tpl
@@ -1,9 +1,15 @@
 <div class="form-group {$class}">
 	{assign value="{$attribute->Value()}" var="attributeValue"}
-	<label class="customAttribute d-block {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
-		for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
-			<i class="bi bi-asterisk text-danger align-top text-small"></i>
-		{/if}</label>
+	{if $readonly && isset($tooltip) && $tooltip}
+		<span class="customAttribute readonly">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+				<i class="bi bi-asterisk text-danger align-top text-small"></i>
+			{/if}:</span>
+	{else}
+		<label class="customAttribute d-block {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
+			for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+				<i class="bi bi-asterisk text-danger align-top text-small"></i>
+			{/if}</label>
+	{/if}
 	{if $readonly}
 		<span class="attributeValue {$class}">{formatdate date=$attributeValue key=general_datetime}</span>
 	{else}

--- a/tpl/Controls/Attributes/MultiLineTextbox.tpl
+++ b/tpl/Controls/Attributes/MultiLineTextbox.tpl
@@ -1,8 +1,14 @@
 <div class="form-group {$class}">
-    <label class="customAttribute {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
-        for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
-            <i class="bi bi-asterisk text-danger align-top text-small"></i>
-        {/if}</label>
+    {if $readonly && isset($tooltip) && $tooltip}
+        <span class="customAttribute readonly">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                <i class="bi bi-asterisk text-danger align-top text-small"></i>
+            {/if}:</span>
+    {else}
+        <label class="customAttribute {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
+            for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                <i class="bi bi-asterisk text-danger align-top text-small"></i>
+            {/if}</label>
+    {/if}
     {if $readonly}
         <span class="attributeValue {$class}">{$attribute->Value()|nl2br}</span>
     {else}

--- a/tpl/Controls/Attributes/SelectList.tpl
+++ b/tpl/Controls/Attributes/SelectList.tpl
@@ -1,8 +1,14 @@
 <div class="form-group {$class}">
-    <label class="customAttribute {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
-        for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
-            <i class="bi bi-asterisk text-danger align-top text-small"></i>
-        {/if}</label>
+    {if $readonly && isset($tooltip) && $tooltip}
+        <span class="customAttribute readonly">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                <i class="bi bi-asterisk text-danger align-top text-small"></i>
+            {/if}:</span>
+    {else}
+        <label class="customAttribute {if $readonly}readonly{elseif $searchmode}search{else}standard{/if} fw-bold"
+            for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+                <i class="bi bi-asterisk text-danger align-top text-small"></i>
+            {/if}</label>
+    {/if}
     {if $readonly}
         <span class="attributeValue {$class}">{$attribute->Value()}</span>
     {else}

--- a/tpl/Controls/Attributes/SingleLineTextbox.tpl
+++ b/tpl/Controls/Attributes/SingleLineTextbox.tpl
@@ -1,9 +1,15 @@
 <div class="form-group {if isset($class)}{$class}{/if}">
-	<label
-		class="customAttribute {if isset($readonly) && $readonly}readonly{elseif isset($searchmode) && $searchmode}search{else}standard{/if} fw-bold"
-		for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
-			<i class="bi bi-asterisk text-danger align-top text-small"></i>
-		{/if}</label>
+	{if isset($readonly) && $readonly && isset($tooltip) && $tooltip}
+		<span class="customAttribute readonly">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+				<i class="bi bi-asterisk text-danger align-top text-small"></i>
+			{/if}:</span>
+	{else}
+		<label
+			class="customAttribute {if isset($readonly) && $readonly}readonly{elseif isset($searchmode) && $searchmode}search{else}standard{/if} fw-bold"
+			for="{$attributeId}">{$attribute->Label()}{if $attribute->Required() && !$searchmode}
+				<i class="bi bi-asterisk text-danger align-top text-small"></i>
+			{/if}</label>
+	{/if}
 	{if isset($readonly) && $readonly}
 		<span class="attributeValue {$class}">{$attribute->Value()}</span>
 	{else}


### PR DESCRIPTION
Enable tooltip flag in AttributeControl to ensure proper rendering of attributes inside tooltips. Update tpl/Controls/Attributes/* to use span instead of label when readonly and tooltip are set. Fix incorrect {break}; syntax in Smarty foreach loops and apply minor formatting adjustments.