### PR TITLE
fix(en_gb): show only time in popup

### DIFF
--- a/lang/en_gb.php
+++ b/lang/en_gb.php
@@ -20,11 +20,11 @@ class en_gb extends en_us
         $dates['schedule_daily'] = 'l, d/m/Y';
         $dates['reservation_email'] = 'd/m/Y @ H:i (e)';
         $dates['res_popup'] = 'd/m/Y H:i';
+        $dates['res_popup_time'] = 'H:i';
         $dates['dashboard'] = 'l, d/m/Y H:i';
         $dates['period_time'] = 'H:i';
         $dates['general_date_js'] = 'dd/mm/yy';
         $dates['short_datetime'] = 'j/n/y H:i';
-        $dates['res_popup_time'] = 'D, d/n H:i';
         $dates['short_reservation_date'] = 'j/n/y H:i';
         $dates['mobile_reservation_date'] = 'j/n H:i';
         $dates['general_time_js'] = 'H:mm';


### PR DESCRIPTION
Update ['res_popup_time'] in en_gb locale to 'H:i' instead of 'D, d/n H:i', so popup displays only the time. No other locales are affected. The line has been relocated for greater consistency with en_us.php.