### PR TITLE
fix(database): make 2.9+ upgrades idempotent and raise DB minimums

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This file contains essential information for AI coding agents working on the Lib
 **LibreBooking** is an open-source resource scheduling and booking system written in PHP. It's a fork of Booked Scheduler that has evolved significantly since 2020.
 
 - **Primary Language**: PHP (>=8.2)
-- **Database**: MySQL (>=5.5)
+- **Database**: MySQL >= 8.0 (2018) or MariaDB >= 10.6 (2021)
 - **Architecture**: Model-View-Presenter (MVP) pattern
 - **Template Engine**: Smarty (version 5.8+)
 - **Frontend**: Bootstrap 5, jQuery
@@ -51,7 +51,7 @@ This file contains essential information for AI coding agents working on the Lib
 - PHP >= 8.2 with extensions: ctype, curl, fileinfo, json, ldap, mbstring, mysqli, openssl, pdo, pdo_mysql, tokenizer, xml
 - Optional PHP extensions: bcmath, gd
 - Composer for dependency management
-- MySQL >= 5.5 for database
+- MySQL >= 8.0 (2018) or MariaDB >= 10.6 (2021) for database
 - Git for version control
 
 ### Initial Setup

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![GitHub forks](https://img.shields.io/github/forks/LibreBooking/librebooking?style=flat)](https://github.com/LibreBooking/librebooking/network)
 
 [![PHP](https://img.shields.io/badge/PHP-8.2%2B-brightgreen.svg?logo=php)](https://www.php.net/)
-[![MySQL](https://img.shields.io/badge/MySQL-5.5%2B-blue.svg?logo=mysql)](https://www.mysql.com/)
+[![Database](https://img.shields.io/badge/Database-MySQL%20%3E%3D8.0%20%7C%20MariaDB%20%3E%3D10.6-blue.svg?logo=mysql)](https://www.mysql.com/)
 ![Platform](https://img.shields.io/badge/Platform-Web-lightgrey)
 ![Status](https://img.shields.io/badge/Status-Active-green)
 
@@ -96,7 +96,7 @@ To run LibreBooking from a prebuilt release, your server needs:
 - PHP >= 8.2 with the extensions: ctype, curl, fileinfo, json, mbstring, mysqli, openssl, pdo, pdo_mysql, tokenizer, xml
 - Optional PHP extensions: bcmath (needed for Active Directory authentication), gd (image processing), ldap (LDAP authentication)
 - A web server like Apache or Nginx
-- MySQL >= 5.5
+- MySQL >= 8.0 (2018) or MariaDB >= 10.6 (2021)
 - Composer (for managing PHP dependencies)
 - Git (optional, useful for cloning the repository or managing updates)
 

--- a/database_schema/upgrades/2.9/data.sql
+++ b/database_schema/upgrades/2.9/data.sql
@@ -1,1 +1,8 @@
-insert into `dbversion` values('2.9', now());
+INSERT INTO `dbversion` (`version_number`, `version_date`)
+SELECT 2.9, NOW()
+FROM DUAL
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM `dbversion`
+    WHERE `version_number` = 2.9
+);

--- a/database_schema/upgrades/3.0/data.sql
+++ b/database_schema/upgrades/3.0/data.sql
@@ -1,1 +1,8 @@
-insert into `dbversion` values('3.0', now());
+INSERT INTO `dbversion` (`version_number`, `version_date`)
+SELECT 3.0, NOW()
+FROM DUAL
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM `dbversion`
+    WHERE `version_number` = 3.0
+);

--- a/database_schema/upgrades/3.0/schema.sql
+++ b/database_schema/upgrades/3.0/schema.sql
@@ -1,3 +1,34 @@
-ALTER TABLE `schedules`
-ADD COLUMN `notes` TEXT NULL,
-ADD COLUMN `published` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0;
+-- MariaDB supports `ADD COLUMN IF NOT EXISTS`, but MySQL 8.0's documented
+-- ALTER TABLE syntax does not. Use metadata checks plus dynamic SQL so this
+-- upgrade remains idempotent across both supported database families.
+SET @notes_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'schedules'
+        AND COLUMN_NAME = 'notes'
+);
+SET @notes_sql := IF(
+    @notes_exists = 0,
+    'ALTER TABLE `schedules` ADD COLUMN `notes` TEXT NULL',
+    'SELECT 1'
+);
+PREPARE stmt FROM @notes_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+SET @published_exists := (
+    SELECT COUNT(*)
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'schedules'
+        AND COLUMN_NAME = 'published'
+);
+SET @published_sql := IF(
+    @published_exists = 0,
+    'ALTER TABLE `schedules` ADD COLUMN `published` TINYINT(1) UNSIGNED NOT NULL DEFAULT 0',
+    'SELECT 1'
+);
+PREPARE stmt FROM @published_sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/database_schema/upgrades/4.0/data.sql
+++ b/database_schema/upgrades/4.0/data.sql
@@ -1,1 +1,8 @@
-insert into `dbversion` values('4.0', now());
+INSERT INTO `dbversion` (`version_number`, `version_date`)
+SELECT 4.0, NOW()
+FROM DUAL
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM `dbversion`
+    WHERE `version_number` = 4.0
+);


### PR DESCRIPTION
Make database upgrades from 2.9 onward safe to rerun after success by guarding dbversion inserts and conditionally adding the 3.0 schedules.notes and schedules.published columns.

Also raise the documented minimum supported database versions to MySQL >= 8.0 (2018) or MariaDB >= 10.6 (2021) in the README and agent instructions.