### PR TITLE
refactor(config): remove app version from ConfigKeys

### DIFF
--- a/Pages/Export/CalendarExportDisplay.php
+++ b/Pages/Export/CalendarExportDisplay.php
@@ -17,7 +17,7 @@ class CalendarExportDisplay extends Page
     {
         $config = Configuration::Instance();
 
-        $this->Set('bookedVersion', $config->GetKey(ConfigKeys::VERSION));
+        $this->Set('bookedVersion', Configuration::VERSION);
         $this->Set('DateStamp', Date::Now());
 
         /**

--- a/Presenters/Admin/ManageConfigurationPresenter.php
+++ b/Presenters/Admin/ManageConfigurationPresenter.php
@@ -41,6 +41,7 @@ class ManageConfigurationPresenter extends ActionPresenter
      * @var string[]|array[]
      */
     private $deletedSettings = [
+        'version',
         'password.pattern',
         'use.local.jquery',
         'authentification.allow.social.login',

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -61,15 +61,6 @@ class ConfigKeys extends AbstractConfigKeys
         'description' => 'Public URL to the Web directory of this instance'
     ];
 
-    public const VERSION = [
-        'key' => 'version',
-        'type' => 'string',
-        'default' => '',
-        'label' => 'Application Version',
-        'description' => 'The version of the application',
-        'is_hidden' => true
-    ];
-
     // Language and Timezone
     public const DEFAULT_TIMEZONE = [
         'key' => 'default.timezone',

--- a/tests/Presenters/CalendarExportPresenterTest.php
+++ b/tests/Presenters/CalendarExportPresenterTest.php
@@ -147,4 +147,19 @@ class CalendarExportPresenterTest extends TestBase
         $this->assertEquals('Private', $reservationView->Summary);
         $this->assertEquals('Private', $reservationView->Description);
     }
+
+    public function testCalendarExportProdIdUsesApplicationVersionInsteadOfConfigValue()
+    {
+        $this->fakeConfig->SetKey('version', '9.9.9-user-config');
+        $this->fakeConfig->_ScriptUrl = 'https://example.com/Web';
+
+        $display = new CalendarExportDisplay();
+        $calendar = $display->Render([]);
+
+        $this->assertStringContainsString(
+            'PRODID:-//LibreBooking//NONSGML ' . Configuration::VERSION . '//EN',
+            $calendar
+        );
+        $this->assertStringNotContainsString('9.9.9-user-config', $calendar);
+    }
 }


### PR DESCRIPTION
Use Configuration::VERSION as the canonical source for the iCal PRODID header instead of reading a hidden version entry from config. The old ConfigKeys::VERSION path was redundant with the existing application version constant and typically resolved to an unset config value.

Remove the VERSION config key from ConfigKeys, update calendar export to use the application version directly, and treat legacy config version entries as deleted when saving configuration. Add a calendar export test to verify PRODID uses the application version rather than a config override.