### PR TITLE
fix(config): fix the default 'x-xss' value in config.dist.php

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -587,7 +587,7 @@ return [
             'x-frame' => 'deny',
 
             # X-XSS-Protection header value
-            'x-xss' => '1, mode=block',
+            'x-xss' => '1; mode=block',
 
             # X-Content-Type-Options header value
             'x-content-type' => 'nosniff',


### PR DESCRIPTION
This is supposedly a deprecated feature but the default in the `config.dist.php` file was mal-formed.