### PR TITLE
feat(i18n): add per-language string overrides

### DIFF
--- a/docs/source/CONFIGURATION.rst
+++ b/docs/source/CONFIGURATION.rst
@@ -122,21 +122,49 @@ standard language file has been loaded.
 This is useful when you want to change a few labels or messages for one
 installation without modifying the files in ``lang/``.
 
-Example:
+Global Overrides
+^^^^^^^^^^^^^^^^
+
+The ``$langOverrides`` array applies to all languages:
 
 .. code-block:: php
 
    <?php
 
    $langOverrides = [
-       'Login' => 'Sign in to Room Booking',
+       'LogIn' => 'Sign in to Room Booking',
        'Register' => 'Request an account',
    ];
+
+Per-Language Overrides
+^^^^^^^^^^^^^^^^^^^^^^
+
+The ``$langOverridesByLanguage`` array allows overrides scoped to specific
+languages. Use the language code (e.g. ``en_us``, ``fr_fr``) as the key:
+
+.. code-block:: php
+
+   <?php
+
+   $langOverridesByLanguage = [
+       'fr_fr' => [
+           'LogIn' => 'Se connecter à la réservation',
+           'Register' => 'Demander un compte',
+       ],
+       'fi_fi' => [
+           'LogIn' => 'Kirjaudu huonevaraukseen',
+           'Register' => 'Pyydä tiliä',
+       ],
+       'de_de' => [
+           'LogIn' => 'Anmeldung zur Raumbuchung',
+       ],
+   ];
+
+Both arrays can be used in the same file. Per-language overrides are applied
+after global overrides, so they take precedence when both define the same key.
 
 Notes:
 
 - The file path must be ``config/lang-overrides.php``
-- The file must define a global ``$langOverrides`` array
 - Override keys must match the existing translation string keys used by the application
 - This only overrides string entries; it does not override date, day, or month definitions
-- Overrides are global for the installation and are not scoped per language

--- a/lib/Common/Resources.php
+++ b/lib/Common/Resources.php
@@ -333,8 +333,19 @@ class Resources implements IResourceLocalization
         $overrideFile = ROOT_DIR . 'config/lang-overrides.php';
         if (file_exists($overrideFile)) {
             global $langOverrides;
+            global $langOverridesByLanguage;
             include_once($overrideFile);
-            $this->_lang->Strings = array_merge($this->_lang->Strings, $langOverrides);
+
+            if (!empty($langOverrides)) {
+                $this->_lang->Strings = array_merge($this->_lang->Strings, $langOverrides);
+            }
+
+            if (!empty($langOverridesByLanguage[$this->CurrentLanguage])) {
+                $this->_lang->Strings = array_merge(
+                    $this->_lang->Strings,
+                    $langOverridesByLanguage[$this->CurrentLanguage]
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Extend config/lang-overrides.php to support a $langOverridesByLanguage array that scopes overrides to specific languages. The existing global $langOverrides array continues to work unchanged.

Per-language overrides are merged after global overrides, so they take precedence when both define the same key. Merge order:

  1. Base language strings (from lang/*.php)
  2. Global $langOverrides (all languages)
  3. Per-language $langOverridesByLanguage[$currentLanguage]

Testing was not added as it would require fairly extensive changes.