### PR TITLE
feat(config): add DeprecatedConfigKeys registry for removed config keys

### DIFF
--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -389,8 +389,13 @@ class ConfigurationFile implements IConfigurationFile
                             error_log("[CONFIG] Deprecated config key '$fullKey' used. It maps to '$finalKey'. Support for legacy keys will be removed in a future release.");
                         }
                     } else {
-                        // Unknown subkey - preserve in original structure for validation
-                        $rewritten[$key][$subKey] = $subValue;
+                        $removedReason = DeprecatedConfigKeys::findReason($fullKey);
+                        if ($removedReason !== null) {
+                            error_log("[CONFIG] Config key '$fullKey' has been deprecated and removed. Please remove it from your config file. Reason: $removedReason");
+                        } else {
+                            // Unknown subkey - preserve in original structure for validation
+                            $rewritten[$key][$subKey] = $subValue;
+                        }
                     }
                 }
 
@@ -418,8 +423,13 @@ class ConfigurationFile implements IConfigurationFile
 
                 continue;
             } else {
-                // Unknown key — pass through (validate will drop)
-                $rewritten[$key] = $value;
+                $removedReason = DeprecatedConfigKeys::findReason($key);
+                if ($removedReason !== null) {
+                    error_log("[CONFIG] Config key '$key' has been deprecated and removed. Please remove it from your config file. Reason: $removedReason");
+                } else {
+                    // Unknown key — pass through (validate will log a warning but keep it)
+                    $rewritten[$key] = $value;
+                }
             }
         }
 
@@ -462,8 +472,14 @@ class ConfigurationFile implements IConfigurationFile
             $configDef = $configKeysClass::findByKey($fullKey);
 
             if (!$configDef) {
-                error_log("[CONFIG] Unknown config key: '$fullKey'. Skipping.");
-                $validated[$key] = $value; // Keep unknown keys as-is
+                $removedReason = DeprecatedConfigKeys::findReason($fullKey);
+                if ($removedReason !== null) {
+                    // Intentionally not added to $validated — no code reads this key anymore
+                    error_log("[CONFIG] Config key '$fullKey' has been deprecated and removed. Please remove it from your config file. Reason: $removedReason");
+                } else {
+                    error_log("[CONFIG] Unknown config key: '$fullKey'. Skipping.");
+                    $validated[$key] = $value; // Keep unknown keys as-is
+                }
                 continue;
             }
 

--- a/lib/Config/DeprecatedConfigKeys.php
+++ b/lib/Config/DeprecatedConfigKeys.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Registry of configuration keys that have been deprecated and removed.
+ *
+ * When a config key is removed from ConfigKeys, add it here so that
+ * existing config files using the old key produce a helpful deprecation
+ * message instead of an "Unknown config key" warning.
+ */
+class DeprecatedConfigKeys
+{
+    /**
+     * Maps removed canonical config keys to the reason they were removed.
+     *
+     * Format: 'key' => 'reason for removal'
+     *
+     * Keys MUST be lowercase — findReason() normalizes lookups via
+     * strtolower(), so mixed-case entries here will never match.
+     *
+     * @var array<string, string>
+     */
+    private const DEPRECATED_KEYS = [
+    ];
+
+    /**
+     * Maps removed legacy config keys to the reason they were removed.
+     *
+     * These are the legacy (pre-rewrite) forms of removed keys
+     * (e.g. 'security.security.x-xss' for canonical 'security.x-xss').
+     * Separated so that when legacy key support is removed entirely,
+     * this constant can simply be deleted.
+     *
+     * Keys MUST be lowercase.
+     *
+     * @var array<string, string>
+     */
+    private const DEPRECATED_LEGACY_KEYS = [
+    ];
+
+    /**
+     * Checks if a key has been deprecated and removed.
+     * Returns the removal reason if found, or null if the key is not
+     * a known deprecated key.
+     */
+    public static function findReason(string $key): ?string
+    {
+        $normalizedKey = strtolower($key);
+
+        return self::DEPRECATED_KEYS[$normalizedKey]
+            ?? self::DEPRECATED_LEGACY_KEYS[$normalizedKey]
+            ?? null;
+    }
+}

--- a/lib/Config/namespace.php
+++ b/lib/Config/namespace.php
@@ -2,5 +2,6 @@
 
 require_once(ROOT_DIR . 'lib/Config/AbstractConfigKeys.php');
 require_once(ROOT_DIR . 'lib/Config/ConfigKeys.php');
+require_once(ROOT_DIR . 'lib/Config/DeprecatedConfigKeys.php');
 require_once(ROOT_DIR . 'lib/Config/PluginConfigKeys.php');
 require_once(ROOT_DIR . 'lib/Config/Configuration.php');


### PR DESCRIPTION
Add infrastructure to gracefully handle config keys that have been
deprecated and removed. When a removed key is found in a user's config
file, the system logs a helpful message asking them to remove it,
instead of an "Unknown config key" warning. Removed keys are
intentionally dropped from the validated config since no code reads
them.

Also fix an inaccurate comment in RewriteLegacyKeys that claimed
ValidateConfig would drop unknown keys, when it actually keeps them.
