### PR TITLE
fix(security): remove obsolete X-XSS-Protection header support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -495,9 +495,6 @@ LB_SECURITY_STRICT_TRANSPORT='max-age=31536000'
 # X-Frame-Options header value (e.g., deny, sameorigin)
 LB_SECURITY_X_FRAME='deny'
 
-# X-XSS-Protection header value
-LB_SECURITY_X_XSS='1; mode=block'
-
 # X-Content-Type-Options header value
 LB_SECURITY_X_CONTENT_TYPE='nosniff'
 

--- a/Pages/Page.php
+++ b/Pages/Page.php
@@ -445,7 +445,6 @@ abstract class Page implements IPage
         if ($config->GetKey(ConfigKeys::SECURITY_HEADERS, new BooleanConverter())) {
             header('Strict-Transport-Security: ' . $config->GetKey(ConfigKeys::SECURITY_STRICT_TRANSPORT));
             header('X-Frame-Options: ' . $config->GetKey(ConfigKeys::SECURITY_X_FRAME));
-            header('X-XSS-Protection: ' . $config->GetKey(ConfigKeys::SECURITY_X_XSS));
             header('X-Content-Type-Options: ' . $config->GetKey(ConfigKeys::SECURITY_X_CONTENT_TYPE));
             header('Content-Security-Policy: ' . $config->GetKey(ConfigKeys::SECURITY_CONTENT_SECURITY_POLICY));
         }

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -584,9 +584,6 @@ return [
             # X-Frame-Options header value (e.g., deny, sameorigin)
             'x-frame' => 'deny',
 
-            # X-XSS-Protection header value
-            'x-xss' => '1; mode=block',
-
             # X-Content-Type-Options header value
             'x-content-type' => 'nosniff',
 

--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -643,7 +643,6 @@ Advanced Security Settings
        'headers' => false,
        'strict-transport' => 'max-age=31536000',
        'x-frame' => 'deny',
-       'x-xss' => '1, mode=block',
        'x-content-type' => 'nosniff',
        'content-security-policy' => '',
    ],
@@ -656,9 +655,6 @@ Advanced Security Settings
 
 **security.x-frame**
   X-Frame-Options header (prevents clickjacking).
-
-**security.x-xss**
-  X-XSS-Protection header.
 
 **security.x-content-type**
   X-Content-Type-Options header.

--- a/lib/Config/ConfigKeys.php
+++ b/lib/Config/ConfigKeys.php
@@ -1392,16 +1392,6 @@ class ConfigKeys extends AbstractConfigKeys
         'config_file_comment' => 'X-Frame-Options header value (e.g., deny, sameorigin)',
         'section' => 'security'
     ];
-    public const SECURITY_X_XSS = [
-        'key' => 'security.x-xss',
-        'legacy' => 'security.security.x-xss',
-        'type' => 'string',
-        'default' => '1; mode=block',
-        'label' => 'X-XSS-Protection',
-        'description' => 'Set the X-XSS-Protection header value',
-        'config_file_comment' => 'X-XSS-Protection header value',
-        'section' => 'security'
-    ];
     public const SECURITY_X_CONTENT_TYPE = [
         'key' => 'security.x-content-type',
         'legacy' => 'security.security.x-content-type',

--- a/lib/Config/DeprecatedConfigKeys.php
+++ b/lib/Config/DeprecatedConfigKeys.php
@@ -19,7 +19,8 @@ class DeprecatedConfigKeys
      *
      * @var array<string, string>
      */
-    private const DEPRECATED_KEYS = [
+    public const DEPRECATED_KEYS = [
+        'security.x-xss' => 'X-XSS-Protection header is obsolete and has been removed from all modern browsers',
     ];
 
     /**
@@ -34,7 +35,8 @@ class DeprecatedConfigKeys
      *
      * @var array<string, string>
      */
-    private const DEPRECATED_LEGACY_KEYS = [
+    public const DEPRECATED_LEGACY_KEYS = [
+        'security.security.x-xss' => 'X-XSS-Protection header is obsolete and has been removed from all modern browsers',
     ];
 
     /**

--- a/tests/Infrastructure/Config/DeprecatedConfigKeysTest.php
+++ b/tests/Infrastructure/Config/DeprecatedConfigKeysTest.php
@@ -1,0 +1,61 @@
+<?php
+
+require_once(ROOT_DIR . 'lib/Config/DeprecatedConfigKeys.php');
+
+class DeprecatedConfigKeysTest extends TestBase
+{
+    public function testFindReasonReturnsReasonForCanonicalKey(): void
+    {
+        $reason = DeprecatedConfigKeys::findReason('security.x-xss');
+
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('X-XSS-Protection', $reason);
+    }
+
+    public function testFindReasonReturnsReasonForLegacyKey(): void
+    {
+        $reason = DeprecatedConfigKeys::findReason('security.security.x-xss');
+
+        $this->assertNotNull($reason);
+        $this->assertStringContainsString('X-XSS-Protection', $reason);
+    }
+
+    public function testFindReasonIsCaseInsensitive(): void
+    {
+        $reason = DeprecatedConfigKeys::findReason('Security.X-XSS');
+
+        $this->assertNotNull($reason);
+    }
+
+    public function testFindReasonReturnsNullForUnknownKey(): void
+    {
+        $reason = DeprecatedConfigKeys::findReason('security.unknown-key');
+
+        $this->assertNull($reason);
+    }
+
+    public function testFindReasonReturnsNullForEmptyString(): void
+    {
+        $reason = DeprecatedConfigKeys::findReason('');
+
+        $this->assertNull($reason);
+    }
+
+    public function testAllKeysAreStoredInLowercase(): void
+    {
+        $constants = [
+            'DEPRECATED_KEYS' => DeprecatedConfigKeys::DEPRECATED_KEYS,
+            'DEPRECATED_LEGACY_KEYS' => DeprecatedConfigKeys::DEPRECATED_LEGACY_KEYS,
+        ];
+
+        foreach ($constants as $constName => $keys) {
+            foreach (array_keys($keys) as $key) {
+                $this->assertSame(
+                    strtolower($key),
+                    $key,
+                    "Key '$key' in $constName must be lowercase"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Remove the security.x-xss config key and X-XSS-Protection header. This header is obsolete — the XSS Auditor it controlled has been removed from all modern browsers, and in some cases it could be exploited to introduce vulnerabilities.

The key is registered in DeprecatedConfigKeys so existing config files produce a helpful deprecation message instead of an unknown key warning.