### PR TITLE
feat(config): add .env.example generator from ConfigKeys metadata

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,12 @@
-##########################
+###########################
 # Application configuration
-##########################
+###########################
 
 # The public name of the application
 LB_APP_TITLE='LibreBooking'
 
-# Enable app debugging to display of runtime errors in the browser (true/false)
+# Enable or disable debug mode for the application
+# if enabled it will enable 'display_errors' and 'display_startup_errors' (true/false)
 LB_APP_DEBUG=false
 
 # Administrator email address
@@ -20,28 +21,37 @@ LB_COMPANY_NAME=
 # URL to the company's website
 LB_COMPANY_URL=
 
-##########################
+#######################
 # Language and Timezone
-##########################
+#######################
 
-# The default timezone.
+# Default timezone.
 # Options: Look up here https://php.net/manual/en/timezones.php
-LB_DEFAULT_TIMEZONE='UTC'
+LB_DEFAULT_TIMEZONE='Europe/London'
 
 # Default language.
 # Options: Find your language in the lang directory
 LB_DEFAULT_LANGUAGE='en_us'
 
-##########################
+# Restrict which languages appear in the language selector.
+# Comma-separated list of language codes (e.g. 'en_us,fr_fr,de_de').
+# Languages appear in the selector in the order listed.
+# Leave empty to show all supported languages.
+# Language codes must match those defined in lang/AvailableLanguages.php.
+# If the value of `default.language` is not included in this list, the
+# application will fall back to 'en_us' and log an error.
+LB_ENABLED_LANGUAGES=
+
+##########
 # Frontend
-##########################
+##########
 
 # Public URL to the Web directory of this instance
 # This is the URL that appears when you are logging in
-#  Leave http: or https: off to auto-detect
+# Leave http: or https: off to auto-detect
 LB_SCRIPT_URL=
 
-# Password to acess installation wizard under Web/install/
+# Password to access installation wizard under Web/install/
 # Leave empty to disable the installation wizard
 LB_INSTALL_PASSWORD=
 
@@ -64,6 +74,10 @@ LB_LOGOUT_URL=
 # Options:  1 = Dashboard, 2 = Schedule, 3 = My Calendar, 4 = Resource Calendar
 LB_DEFAULT_HOMEPAGE=1
 
+# Default number of items per page in listings
+# Use a positive integer. -1 is not supported for performance reasons
+LB_DEFAULT_PAGE_SIZE=50
+
 # Optional path to a custom CSS file
 LB_CSS_EXTENSION_FILE=
 
@@ -74,17 +88,34 @@ LB_CSS_THEME='default'
 # Display format when showing user names
 LB_NAME_FORMAT='{first} {last}'
 
-# Enable configuration page in the admin menu (true/false)
+#######################
+# Analytics Integration
+#######################
+
+# Google Analytics tracking ID (e.g., UA-XXXXXXX or G-XXXXXXXX)
+LB_GOOGLE_ANALYTICS_TRACKING_ID=
+
+###################
+# Slack Integration
+###################
+
+# Slack webhook token for sending notifications
+LB_SLACK_TOKEN=
+
+
+#######
+# Pages
+#######
+
+# Enable or disable the configuration page in the admin panel (true/false)
 LB_PAGES_CONFIGURATION_ENABLED=true
 
-# Database configuration. Only mySQL is supported
+##########
+# Database
+##########
+
+# Database configuration. Only MySQL is supported
 LB_DATABASE_TYPE='mysql'
-
-# Database username with access to the librebooking database
-LB_DATABASE_USER='lb_user'
-
-# Database password for the user
-LB_DATABASE_PASSWORD='password'
 
 # Database host address or IP.
 LB_DATABASE_HOSTSPEC='127.0.0.1'
@@ -92,13 +123,19 @@ LB_DATABASE_HOSTSPEC='127.0.0.1'
 # Database name
 LB_DATABASE_NAME='librebooking'
 
-##########################
+# Database username with access to the librebooking database
+LB_DATABASE_USER='lb_user'
+
+# Database password for the user
+LB_DATABASE_PASSWORD='password'
+
+###########################
 # Email Sending (PHPMailer)
-##########################
+###########################
 
 # Mailer type:
 # Options: mail, smtp or sendmail
-LB_PHPMAILER_MAILER=smtp
+LB_PHPMAILER_MAILER='smtp'
 
 # SMTP host address or IP
 LB_PHPMAILER_SMTP_HOST=
@@ -109,6 +146,9 @@ LB_PHPMAILER_SMTP_PORT=25
 # SMTP encryption
 # Options: tls, ssl
 LB_PHPMAILER_SMTP_SECURE=
+
+# SMTP Auto TLS, if an unencrypted SMTP connection should attempt to use STARTTLS (true/false)
+LB_PHPMAILER_SMTP_AUTOTLS=true
 
 # Enable SMTP authentication (true/false)
 LB_PHPMAILER_SMTP_AUTH=true
@@ -125,15 +165,15 @@ LB_PHPMAILER_SENDMAIL_PATH='/usr/sbin/sendmail'
 # Enable SMTP debug output (true/false)
 LB_PHPMAILER_SMTP_DEBUG=false
 
-##########################
+#######
 # Email
-##########################
+#######
 
-# Enable email sending (true/false)
-LB_EMAIL_ENABLED=false
+# Enable or disable email notifications (true/false)
+LB_EMAIL_ENABLED=true
 
 # Enable custom email templates (true/false)
-LB_EMAIL_ENFORCE_CUSTOM_TEMPLATE=true
+LB_EMAIL_ENFORCE_CUSTOM_TEMPLATE=false
 
 # Default email address to use for outgoing emails
 LB_EMAIL_DEFAULT_FROM_ADDRESS=
@@ -141,24 +181,24 @@ LB_EMAIL_DEFAULT_FROM_ADDRESS=
 # Default name to use for outgoing emails
 LB_EMAIL_DEFAULT_FROM_NAME=
 
-
-##########################
+#########
 # Logging
-##########################
+#########
 
 # Directory where logs are stored
 # Write permission is required
 LB_LOGGING_FOLDER='/var/log/librebooking/log'
 
-# Logging level: none, DEBUG, INFO, WARNING, ERROR
-LB_LOGGING_LEVEL=none
+# Logging level: none, debug, error
+# Options: none, error, debug
+LB_LOGGING_LEVEL='error'
 
 # Enable SQL logging (true/false)
 LB_LOGGING_SQL=false
 
-##########################
+#########
 # Uploads
-##########################
+#########
 
 # Full or relative path to where images will be stored
 LB_UPLOADS_IMAGE_UPLOAD_DIRECTORY='Web/uploads/images'
@@ -173,52 +213,57 @@ LB_UPLOADS_RESERVATION_ATTACHMENTS_ENABLED=false
 LB_UPLOADS_RESERVATION_ATTACHMENT_PATH='uploads/reservation'
 
 # File extensions allowed for reservation attachments
-LB_UPLOADS_RESERVATION_ATTACHMENT_EXTENSIONS='txt,jpg,gif,png,doc,docx,pdf,xls,xlsx,ppt,pptx,csv'
+LB_UPLOADS_RESERVATION_ATTACHMENT_EXTENSIONS='csv,doc,docx,gif,jpeg,jpg,pdf,png,ppt,pptx,txt,xls,xlsx'
 
-#########################################
+########################################
 # Notification Settings for Reservations
-#########################################
+########################################
 
-# Notify application admins when a new application is added (true/false)
+# Send notification to application administrators when a reservation is
+# created (true/false)
 LB_RESERVATION_NOTIFY_APPLICATION_ADMIN_ADD=false
 
-# Notify application admins when an application is updated (true/false)
+# Send notification to application administrators when a reservation is
+# updated (true/false)
 LB_RESERVATION_NOTIFY_APPLICATION_ADMIN_UPDATE=false
 
-# Notify application admins when an application is deleted (true/false)
+# Send notification to application administrators when a reservation is
+# deleted (true/false)
 LB_RESERVATION_NOTIFY_APPLICATION_ADMIN_DELETE=false
 
-# Notify application admins when an application requires approval (true/false)
+# Send notification to application administrators when a reservation requires
+# approval (true/false)
 LB_RESERVATION_NOTIFY_APPLICATION_ADMIN_APPROVAL=false
 
-# Notify group admins when a new group is added (true/false)
+# Send notification to group administrators when a reservation is created (true/false)
 LB_RESERVATION_NOTIFY_GROUP_ADMIN_ADD=false
 
-# Notify group admins when a group is updated (true/false)
+# Send notification to group administrators when a reservation is updated (true/false)
 LB_RESERVATION_NOTIFY_GROUP_ADMIN_UPDATE=false
 
-# Notify group admins when a group is deleted (true/false)
+# Send notification to group administrators when a reservation is deleted (true/false)
 LB_RESERVATION_NOTIFY_GROUP_ADMIN_DELETE=false
 
-# Notify group admins when a group requires approval (true/false)
+# Send notification to group administrators when a reservation requires
+# approval (true/false)
 LB_RESERVATION_NOTIFY_GROUP_ADMIN_APPROVAL=false
 
-# Notify resource admins when a new resource is added (true/false)
+# Send notification to resource administrators when a reservation is created (true/false)
 LB_RESERVATION_NOTIFY_RESOURCE_ADMIN_ADD=false
 
-# Notify resource admins when a resource is updated (true/false)
+# Send notification to resource administrators when a reservation is updated (true/false)
 LB_RESERVATION_NOTIFY_RESOURCE_ADMIN_UPDATE=false
 
-# Notify resource admins when a resource is deleted (true/false)
+# Send notification to resource administrators when a reservation is deleted (true/false)
 LB_RESERVATION_NOTIFY_RESOURCE_ADMIN_DELETE=false
 
-# Notify resource admins when a resource requires approval (true/false)
+# Send notification to resource administrators when a reservation requires
+# approval (true/false)
 LB_RESERVATION_NOTIFY_RESOURCE_ADMIN_APPROVAL=false
 
-
-####################################
+###############################
 # Schedule Display and Behavior
-####################################
+###############################
 
 # Automatically scroll to today's date on load (true/false)
 LB_SCHEDULE_AUTO_SCROLL_TODAY=true
@@ -241,7 +286,6 @@ LB_SCHEDULE_RESERVATION_LABEL='{name}'
 LB_SCHEDULE_USE_PER_USER_COLORS=false
 
 # Number of minutes to highlight updated reservations
-# Set to 0 to disable highlighting
 LB_SCHEDULE_UPDATE_HIGHLIGHT_MINUTES=0
 
 # Enable faster loading for reservation data (may reduce detail) (true/false)
@@ -250,11 +294,12 @@ LB_SCHEDULE_FAST_RESERVATION_LOAD=false
 # Load simplified mobile views on small devices (true/false)
 LB_SCHEDULE_LOAD_MOBILE_VIEWS=true
 
-##########################################
+##############
 # Reservations
-##########################################
+##############
 
-# Prevent participants from being added to reservations (true/false)
+# Disable reservation participation/invitations and hide participant/invitee
+# lists in the reservation UI (true/false)
 LB_RESERVATION_PREVENT_PARTICIPATION=false
 
 # Disable recurring reservations (true/false)
@@ -266,8 +311,13 @@ LB_RESERVATION_ALLOW_GUEST_PARTICIPATION=false
 # Enable a waitlist for fully booked reservations (true/false)
 LB_RESERVATION_ALLOW_WAIT_LIST=false
 
-# Restrict start times (e.g., 'future', 'any', 'same_day')
-LB_RESERVATION_START_TIME_CONSTRAINT=future
+# Restrict start times (e.g., 'future', 'none', 'current')
+# Note: In the standard reservation create/update flow, exemptions from this constraint apply only in specific cases:
+#   - Application admins are always exempt.
+#   - Group admins are exempt only when acting as admin for the reservation user.
+#   - Resource and schedule admins are exempt only when they administer all resources in the reservation.
+# Options: none, future, current
+LB_RESERVATION_START_TIME_CONSTRAINT='future'
 
 # Require approval when an existing reservation is updated (true/false)
 LB_RESERVATION_UPDATES_REQUIRE_APPROVAL=false
@@ -278,11 +328,6 @@ LB_RESERVATION_TITLE_REQUIRED=false
 # Require a description for all reservations (true/false)
 LB_RESERVATION_DESCRIPTION_REQUIRED=false
 
-
-##########################################
-# Reservation Checkin
-##########################################
-
 # Number of minutes before start when check-in is allowed
 LB_RESERVATION_CHECKIN_MINUTES_PRIOR=5
 
@@ -292,22 +337,18 @@ LB_RESERVATION_CHECKIN_ADMIN_ONLY=false
 # Restrict check-out functionality to administrators only (true/false)
 LB_RESERVATION_CHECKOUT_ADMIN_ONLY=false
 
-##########################################
-# Reservation Reminder
-##########################################
-
 # Enable reminder notifications for upcoming reservations (true/false)
 LB_RESERVATION_REMINDERS_ENABLED=false
 
-# Default reminder time before reservation start (in minutes)
+# Default reminder time before reservation start (e.g., '15 minutes', '1 hours', '1 days')
 LB_RESERVATION_DEFAULT_START_REMINDER=
 
-# Default reminder time before reservation end (in minutes)
+# Default reminder time before reservation end (e.g., '15 minutes', '1 hours', '1 days')
 LB_RESERVATION_DEFAULT_END_REMINDER=
 
-##########################################
+#############################
 # Reservation Label Templates
-##########################################
+#############################
 
 # ICS calendar summary text for all reservations
 # Available properties are: {name}, {title}, {description}, {email}, {phone}, {organization}, {position}, {startdate}, {enddate} {resourcename} {participants} {invitees} {reservationAttributes}.
@@ -329,17 +370,16 @@ LB_RESERVATION_LABELS_RESOURCE_CALENDAR='{name}'
 # Label used in display in reservation popups
 LB_RESERVATION_LABELS_RESERVATION_POPUP=
 
-
-##########################################
+############################
 # Reporting and Registration
-##########################################
+############################
 
 # Allow all users to access reports (true/false)
 LB_REPORTS_ALLOW_ALL_USERS=false
 
-##########################################
+##############
 # Registration
-##########################################
+##############
 
 # Enable self-registration for new users (true/false)
 LB_REGISTRATION_ALLOW_SELF_REGISTRATION=true
@@ -374,29 +414,29 @@ LB_REGISTRATION_AUTO_SUBSCRIBE_EMAIL=false
 # Notify the admin when a new user registers (true/false)
 LB_REGISTRATION_NOTIFY_ADMIN=false
 
-##########################################
+##################
 # Resource Options
-##########################################
+##################
 
-# Indicates if the contact must be a registered user
+# Indicates if the contact must be a registered user (true/false)
 LB_RESOURCE_CONTACT_IS_USER=false
 
-##########################################
+#####################
 # Tablet View Options
-##########################################
+#####################
 
-# Allows to make reservations in the tablet view (true/false)
+# Allow users to make reservations in the tablet view (true/false)
 LB_TABLET_VIEW_ALLOW_RESERVATIONS=true
 
-# Allow guest users to make reservations in tablet view (true/false)
+# Allow guests to make reservations from the tablet view (true/false)
 LB_TABLET_VIEW_ALLOW_GUEST_RESERVATIONS=false
 
 # Suggest known email addresses during reservation creation (true/false)
 LB_TABLET_VIEW_AUTO_SUGGEST_EMAILS=false
 
-##########################################
+##############
 # ICS Settings
-##########################################
+##############
 
 # Subscription key secret used for ICS calendar feeds
 LB_ICS_SUBSCRIPTION_KEY=
@@ -407,10 +447,9 @@ LB_ICS_FUTURE_DAYS=30
 # Number of past days to include in ICS feeds
 LB_ICS_PAST_DAYS=0
 
-
-##########################################
+#############################
 # Data Retention and Deletion
-##########################################
+#############################
 
 # Requires  'deleteolddata.php' to run as a cron job
 # Number of years after which old data is considered for deletion
@@ -425,10 +464,9 @@ LB_CLEANUP_DELETE_OLD_BLACKOUTS=false
 # Automatically delete old reservations (true/false)
 LB_CLEANUP_DELETE_OLD_RESERVATIONS=false
 
-
-##########################################
+#################
 # Password Policy
-##########################################
+#################
 
 # Disable the 'Forgot Password' feature (true/false)
 LB_PASSWORD_DISABLE_RESET=false
@@ -442,12 +480,11 @@ LB_PASSWORD_MINIMUM_NUMBERS=0
 # Require both upper and lower case characters in passwords (true/false)
 LB_PASSWORD_UPPER_AND_LOWER=false
 
-
-##########################################
+#########
 # Privacy
-##########################################
+#########
 
-# Allow users to view schedules (true/false)
+# Allow unauthenticated users to view schedules (true/false)
 LB_PRIVACY_VIEW_SCHEDULES=true
 
 # Allow users to view reservation details (true/false)
@@ -462,12 +499,12 @@ LB_PRIVACY_HIDE_RESERVATION_DETAILS=false
 # Allow guest users to make reservations (true/false)
 LB_PRIVACY_ALLOW_GUEST_RESERVATIONS=false
 
-# Number of days in the future shown for the public reservation calendar
+# Set number of days in the future for which reservations can be made by guest users
 LB_PRIVACY_PUBLIC_FUTURE_DAYS=30
 
-##########################################
+###########
 # reCAPTCHA
-##########################################
+###########
 
 # Enable Google reCAPTCHA on login or registration (true/false)
 LB_RECAPTCHA_ENABLED=false
@@ -482,9 +519,9 @@ LB_RECAPTCHA_PRIVATE_KEY=
 # Options: curl, post, socket
 LB_RECAPTCHA_REQUEST_METHOD='curl'
 
-##########################################
+##################
 # Security Headers
-##########################################
+##################
 
 # Enable the following security headers in HTTP responses (true/false)
 LB_SECURITY_HEADERS=false
@@ -499,11 +536,11 @@ LB_SECURITY_X_FRAME='deny'
 LB_SECURITY_X_CONTENT_TYPE='nosniff'
 
 # Set the Content-Security-Policy header value
-LB_SECURITY_CONTENT_SECURITY_POLICY=''
+LB_SECURITY_CONTENT_SECURITY_POLICY=
 
-##########################################
+########################
 # Credit System Settings
-##########################################
+########################
 
 # Enable credit-based reservation system (true/false)
 LB_CREDITS_ENABLED=false
@@ -511,23 +548,9 @@ LB_CREDITS_ENABLED=false
 # Allow users to purchase credits (true/false)
 LB_CREDITS_ALLOW_PURCHASE=false
 
-##########################################
-# Analytics Integration
-##########################################
-
-# Google Analytics tracking ID (e.g., UA-XXXXXXX or G-XXXXXXXX)
-LB_GOOGLE_ANALYTICS_TRACKING_ID=
-
-##########################################
-# Slack Integration
-##########################################
-
-# Slack webhook token for sending notifications
-LB_SLACK_TOKEN=
-
-##########################################
+#########################
 # Authentication Settings
-##########################################
+#########################
 
 # Hide the login prompt (true/false)
 LB_AUTHENTICATION_HIDE_LOGIN_PROMPT=false
@@ -538,25 +561,18 @@ LB_AUTHENTICATION_CAPTCHA_ON_LOGIN=false
 # Restrict registration to specific email domains (comma-separated, e.g., example.com,school.edu)
 LB_AUTHENTICATION_REQUIRED_EMAIL_DOMAINS=
 
-##########################################
-# Google Login Integration
-##########################################
-
 # Enable login via Google (true/false)
 LB_AUTHENTICATION_GOOGLE_LOGIN_ENABLED=false
 
 # Google OAuth2 client credentials
 LB_AUTHENTICATION_GOOGLE_CLIENT_ID=
 
-# Google OAuth2 client secret
+# Client secret for Google OAuth login
 LB_AUTHENTICATION_GOOGLE_CLIENT_SECRET=
+
 # Path to the Google redirect URI
 # /Web/google-auth.php
 LB_AUTHENTICATION_GOOGLE_REDIRECT_URI='/Web/google-auth.php'
-
-##########################################
-# Microsoft Login Integration
-##########################################
 
 # Enable login via Microsoft (true/false)
 LB_AUTHENTICATION_MICROSOFT_LOGIN_ENABLED=false
@@ -570,13 +586,9 @@ LB_AUTHENTICATION_MICROSOFT_TENANT_ID='common'
 # Microsoft OAuth2 client secret
 LB_AUTHENTICATION_MICROSOFT_CLIENT_SECRET=
 
-# # Path to the Google redirect URI
+# Path to the Microsoft redirect URI
 # /Web/microsoft-auth.php
 LB_AUTHENTICATION_MICROSOFT_REDIRECT_URI='/Web/microsoft-auth.php'
-
-##########################################
-# Facebook Login Integration
-##########################################
 
 # Enable login via Facebook (true/false)
 LB_AUTHENTICATION_FACEBOOK_LOGIN_ENABLED=false
@@ -591,32 +603,23 @@ LB_AUTHENTICATION_FACEBOOK_CLIENT_SECRET=
 # /Web/facebook-auth.php
 LB_AUTHENTICATION_FACEBOOK_REDIRECT_URI='/Web/facebook-auth.php'
 
-##########################################
-# Keycloak Login Integration
-##########################################
-
 # Enable login via Keycloak (true/false)
 LB_AUTHENTICATION_KEYCLOAK_LOGIN_ENABLED=false
 
 # Keycloak OAuth2 credentials
 LB_AUTHENTICATION_KEYCLOAK_URL=
 
-# Keycloak OAuth2 realm
+# Realm for Keycloak authentication
 LB_AUTHENTICATION_KEYCLOAK_REALM=
 
-# Keycloak client credentials
+# Client ID for Keycloak OAuth login
 LB_AUTHENTICATION_KEYCLOAK_CLIENT_ID=
 
-# Keycloak client secret
+# Client secret for Keycloak OAuth login
 LB_AUTHENTICATION_KEYCLOAK_CLIENT_SECRET=
 
-# Keycloak OAuth2 redirect URI
-# 'Web/keycloak-auth.php
+# Redirect URI for Keycloak OAuth login
 LB_AUTHENTICATION_KEYCLOAK_CLIENT_URI='/Web/keycloak-auth.php'
-
-##########################################
-# Generic OAuth2 Login Integration
-##########################################
 
 # Enable login via custom OAuth2 provider (true/false)
 LB_AUTHENTICATION_OAUTH2_LOGIN_ENABLED=false
@@ -625,20 +628,33 @@ LB_AUTHENTICATION_OAUTH2_LOGIN_ENABLED=false
 LB_AUTHENTICATION_OAUTH2_NAME='OAuth2'
 
 # OAuth2 endpoint URLs and client credentials
+# If true, the configured authorize URL's trailing slash is removed (true/false)
+LB_AUTHENTICATION_OAUTH2_STRIP_TRAILING_SLASH=true
+
+# Authorization URL for OAuth2 login
 LB_AUTHENTICATION_OAUTH2_URL_AUTHORIZE=
+
+# Token URL for OAuth2 login
 LB_AUTHENTICATION_OAUTH2_URL_TOKEN=
+
+# Userinfo URL for OAuth2 login
 LB_AUTHENTICATION_OAUTH2_URL_USERINFO=
+
+# Client ID for OAuth2 login
 LB_AUTHENTICATION_OAUTH2_CLIENT_ID=
+
+# Client secret for OAuth2 login
 LB_AUTHENTICATION_OAUTH2_CLIENT_SECRET=
+
+# Redirect URI for OAuth2 login
 LB_AUTHENTICATION_OAUTH2_CLIENT_URI='/Web/oauth2-auth.php'
 
-
-##########################################
+######################
 # Plugin Configuration
-##########################################
+######################
 
 # Comma-separated list of plugin class names to use for authentication
-# Available authentication plugins: ActiveDirectory, Apache, CAS, Drupal, Krb5, Ldap, Mellon, Moodle, MoodleAdv, Saml, Shibboleth, WordPress
+# Options: ActiveDirectory, Apache, CAS, Drupal, Krb5, Ldap, Mellon, Moodle, MoodleAdv, Saml, Shibboleth, WordPress
 LB_PLUGINS_AUTHENTICATION=
 
 # Comma-separated list of plugin class names to use for authorization
@@ -654,18 +670,19 @@ LB_PLUGINS_PERMISSION=
 LB_PLUGINS_POSTREGISTRATION=
 
 # Comma-separated list of plugin class names to run before reservation creation
+# Options: AdminCheckOnly, PreReservationExample
 LB_PLUGINS_PRERESERVATION=
 
 # Comma-separated list of plugin class names to run after reservation is created/updated
+# Options: PostReservation
 LB_PLUGINS_POSTRESERVATION=
 
 # Comma-separated list of plugin class names to apply custom styling logic
 LB_PLUGINS_STYLING=
 
-
-##########################################
+###################
 # API Configuration
-##########################################
+###################
 
 # Enable or disable the API (true/false)
 LB_API_ENABLED=false

--- a/.github/workflows/lint-and-analyse-php.yml
+++ b/.github/workflows/lint-and-analyse-php.yml
@@ -126,6 +126,22 @@ jobs:
             exit 1
           fi
 
+      - name: Check .env.example is up-to-date
+        if: matrix.php-version == '8.2'
+        run: |
+          if ! composer env-example:check; then
+            echo ""
+            echo "=========================================="
+            echo "  .env.example is out of date."
+            echo "  To regenerate it locally, run:"
+            echo ""
+            echo "    composer env-example:generate"
+            echo ""
+            echo "  Then commit the changes."
+            echo "=========================================="
+            exit 1
+          fi
+
       - name: Cache php-cs-fixer
         if: matrix.php-version == '8.2'
         uses: actions/cache@v5

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,9 @@
         "preflight": "php lib/preflight.php",
         "test:integration": "./vendor/bin/phpunit --testsuite integration --testdox",
         "config-dist:generate": "php scripts/generate-config-dist.php --write",
-        "config-dist:check": "php scripts/generate-config-dist.php --check"
+        "config-dist:check": "php scripts/generate-config-dist.php --check",
+        "env-example:generate": "php scripts/generate-env-example.php --write",
+        "env-example:check": "php scripts/generate-env-example.php --check"
     },
     "config": {
         "allow-plugins": {

--- a/lib/Config/ConfigKeysMeta.php
+++ b/lib/Config/ConfigKeysMeta.php
@@ -2,6 +2,82 @@
 
 class ConfigKeysMeta
 {
+    /**
+     * Get the comment text for a config entry.
+     *
+     * Prefers 'config_file_comment' field, falls back to 'description'.
+     */
+    public static function getComment(array $entry): string
+    {
+        $comment = $entry['config_file_comment'] ?? null;
+        if (is_string($comment) && $comment !== '') {
+            return $comment;
+        }
+
+        return $entry['description'] ?? '';
+    }
+
+    /**
+     * Get the human-readable title for a section.
+     */
+    public static function sectionTitle(string $section): string
+    {
+        return self::SECTION_TITLES[$section]
+            ?? ucwords(string: str_replace(search: ['.', '-'], replace: ' ', subject: $section));
+    }
+
+    /**
+     * Group flat config entries according to TOP_LEVEL_GROUPS ordering.
+     *
+     * @param array<string, array> $flatEntries
+     * @return array<string, array<string, array>>
+     *
+     * @throws \LogicException if a group references an unknown key, a key is in multiple groups,
+     *                         or flat keys are not covered by any group
+     */
+    public static function groupFlatEntries(array $flatEntries): array
+    {
+        $groups = [];
+        $assignedKeys = [];
+
+        foreach (self::TOP_LEVEL_GROUPS as $groupTitle => $groupKeys) {
+            $groupEntries = [];
+
+            foreach ($groupKeys as $key) {
+                if (!array_key_exists($key, $flatEntries)) {
+                    throw new \LogicException("Top-level group '{$groupTitle}' references unknown flat key '{$key}'");
+                }
+                if (isset($assignedKeys[$key])) {
+                    throw new \LogicException("Flat key '{$key}' is assigned to multiple top-level groups");
+                }
+
+                $groupEntries[$key] = $flatEntries[$key];
+                $assignedKeys[$key] = true;
+            }
+
+            $groups[$groupTitle] = $groupEntries;
+        }
+
+        $unassignedKeys = array_diff(array_keys($flatEntries), array_keys($assignedKeys));
+        if ($unassignedKeys !== []) {
+            throw new \LogicException(
+                'Top-level groups are missing flat keys: ' . implode(', ', $unassignedKeys)
+            );
+        }
+
+        return $groups;
+    }
+
+    /**
+     * Derive the environment variable name for a config key.
+     *
+     * Matches the logic in AbstractConfigKeys::hasEnv().
+     */
+    public static function envKey(string $configKey): string
+    {
+        return strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $configKey));
+    }
+
     public const SECTION_TITLES = [
         'api' => 'API Configuration',
         'authentication' => 'Authentication Settings',

--- a/lib/Config/EnvExampleGenerator.php
+++ b/lib/Config/EnvExampleGenerator.php
@@ -3,79 +3,27 @@
 declare(strict_types=1);
 
 /**
- * Generates config/config.dist.php from ConfigKeys metadata.
+ * Generates .env.example from ConfigKeys metadata.
  *
- * Two layers:
- *  - generateSettingsArray(): canonical default settings structure
- *  - render(): full PHP file text with comments
+ * Produces a .env file with comments and default values,
+ * using the same metadata pipeline as ConfigDistGenerator.
  */
-class ConfigDistGenerator
+class EnvExampleGenerator
 {
-    private const FILE_HEADER = <<<'PHP'
-<?php
-
-/**
- * LibreBooking configuration file
- *
- * This file contains the default configuration for LibreBooking.
- * It is used to set up the application and can be overridden by environment variables.
- * The settings are grouped into sections for easier management.
- */
-
-PHP;
-
     /**
-     * Build the canonical settings array from ConfigKeys.
-     *
-     * Keys preserve ConfigKeys constant declaration order.
-     * Flat keys (no section) and sectioned keys are separated
-     * but maintain their relative declaration order within each group.
-     *
-     * @return array{flat: array<string, array>, sections: array<string, array<string, array>>}
-     */
-    public static function generateSettingsArray(): array
-    {
-        $flat = [];
-        $sections = [];
-
-        foreach (ConfigKeys::all() as $entry) {
-            $key = $entry['key'];
-            $section = $entry['section'] ?? null;
-
-            if ($section === null || $section === '') {
-                $flat[$key] = $entry;
-            } else {
-                $prefix = $section . '.';
-                if (str_starts_with(haystack: $key, needle: $prefix)) {
-                    $nestedKey = substr(string: $key, offset: strlen($prefix));
-                } else {
-                    $nestedKey = $key;
-                }
-                $sections[$section][$nestedKey] = $entry;
-            }
-        }
-
-        return ['flat' => $flat, 'sections' => $sections];
-    }
-
-    /**
-     * Render the full config.dist.php file content.
+     * Render the full .env.example file content.
      */
     public static function render(): string
     {
-        $settings = self::generateSettingsArray();
+        $settings = ConfigDistGenerator::generateSettingsArray();
         $lines = [];
-        $lines[] = self::FILE_HEADER;
-        $lines[] = 'return [';
-        $lines[] = "    'settings' => [";
-        $lines[] = '';
 
         foreach (ConfigKeysMeta::groupFlatEntries(flatEntries: $settings['flat']) as $groupTitle => $entries) {
-            self::appendSectionHeader(lines: $lines, title: $groupTitle, indent: 2);
+            self::appendSectionHeader(lines: $lines, title: $groupTitle);
             $lines[] = '';
 
-            foreach ($entries as $key => $entry) {
-                self::appendEntry(lines: $lines, key: $key, entry: $entry, indent: 2);
+            foreach ($entries as $entry) {
+                self::appendEntry(lines: $lines, entry: $entry);
             }
 
             self::trimTrailingBlankLine(lines: $lines);
@@ -85,27 +33,23 @@ PHP;
         foreach ($settings['sections'] as $sectionName => $entries) {
             $sectionTitle = ConfigKeysMeta::sectionTitle(section: $sectionName);
             $lines[] = '';
-            self::appendSectionHeader(lines: $lines, title: $sectionTitle, indent: 2);
+            self::appendSectionHeader(lines: $lines, title: $sectionTitle);
             $lines[] = '';
-            $lines[] = "        '{$sectionName}' => [";
 
-            foreach ($entries as $nestedKey => $entry) {
-                self::appendEntry(lines: $lines, key: $nestedKey, entry: $entry, indent: 3);
+            foreach ($entries as $entry) {
+                self::appendEntry(lines: $lines, entry: $entry);
             }
 
             self::trimTrailingBlankLine(lines: $lines);
-            $lines[] = '        ],';
         }
 
-        $lines[] = '    ],';
-        $lines[] = '];';
         $lines[] = '';
 
         return implode(separator: "\n", array: $lines);
     }
 
     /**
-     * Write the rendered config to a file path.
+     * Write the rendered .env.example to a file path.
      */
     public static function writeToFile(string $path): void
     {
@@ -152,7 +96,7 @@ PHP;
      */
     public static function main(array $argv): int
     {
-        $defaultPath = dirname(__DIR__, levels: 2) . '/config/config.dist.php';
+        $defaultPath = dirname(__DIR__, levels: 2) . '/.env.example';
         $mode = $argv[1] ?? '--write';
         $outputPath = $argv[2] ?? $defaultPath;
 
@@ -163,7 +107,7 @@ PHP;
                         fwrite(stream: STDOUT, data: "{$outputPath} is up-to-date.\n");
                         return 0;
                     }
-                    fwrite(stream: STDERR, data: "{$outputPath} is out of date. Run: composer config-dist:generate\n");
+                    fwrite(stream: STDERR, data: "{$outputPath} is out of date. Run: composer env-example:generate\n");
                     return 1;
 
                 case '--write':
@@ -172,7 +116,7 @@ PHP;
                     return 0;
 
                 default:
-                    fwrite(stream: STDERR, data: "Usage: generate-config-dist.php [--write|--check] [path]\n");
+                    fwrite(stream: STDERR, data: "Usage: generate-env-example.php [--write|--check] [path]\n");
                     return 2;
             }
         } catch (RuntimeException $e) {
@@ -181,39 +125,36 @@ PHP;
         }
     }
 
-    private static function appendSectionHeader(array &$lines, string $title, int $indent): void
+    private static function appendSectionHeader(array &$lines, string $title): void
     {
-        $pad = str_repeat(string: '    ', times: $indent);
         $border = str_repeat(string: '#', times: strlen($title) + 2);
-        $lines[] = "{$pad}{$border}";
-        $lines[] = "{$pad}# {$title}";
-        $lines[] = "{$pad}{$border}";
+        $lines[] = $border;
+        $lines[] = "# {$title}";
+        $lines[] = $border;
     }
 
-    private static function appendEntry(array &$lines, string $key, array $entry, int $indent): void
+    private static function appendEntry(array &$lines, array $entry): void
     {
-        $pad = str_repeat(string: '    ', times: $indent);
         $comment = ConfigKeysMeta::getComment(entry: $entry);
         $choices = $entry['choices'] ?? null;
         $type = $entry['type'] ?? 'string';
+        $envKey = ConfigKeysMeta::envKey(configKey: $entry['key']);
 
         if ($comment !== '') {
             $hasExplicitComment = isset($entry['config_file_comment']) && $entry['config_file_comment'] !== '';
             foreach (explode(separator: "\n", string: $comment) as $paragraph) {
                 if ($hasExplicitComment) {
-                    // config_file_comment is pre-formatted, don't re-wrap
-                    $lines[] = "{$pad}# {$paragraph}";
+                    $lines[] = "# {$paragraph}";
                 } else {
                     $wrapped = wordwrap(string: $paragraph, width: 76, break: "\n", cut_long_words: false);
                     foreach (explode(separator: "\n", string: $wrapped) as $commentLine) {
-                        $lines[] = "{$pad}# {$commentLine}";
+                        $lines[] = "# {$commentLine}";
                     }
                 }
             }
         }
 
         if ($type === 'boolean' && $comment !== '' && !str_contains(haystack: $comment, needle: 'true/false')) {
-            // Append (true/false) hint to the last comment line
             $lastIndex = count($lines) - 1;
             $lines[$lastIndex] .= ' (true/false)';
         }
@@ -222,12 +163,12 @@ PHP;
             $choiceKeys = array_keys($choices);
             $displayChoices = array_filter($choiceKeys, static fn ($c): bool => $c !== '' && $c !== 0);
             if ($displayChoices !== []) {
-                $lines[] = "{$pad}# Options: " . implode(separator: ', ', array: $displayChoices);
+                $lines[] = '# Options: ' . implode(separator: ', ', array: $displayChoices);
             }
         }
 
         $rendered = self::renderValue(value: $entry['default'], type: $type);
-        $lines[] = "{$pad}'{$key}' => {$rendered},";
+        $lines[] = "{$envKey}={$rendered}";
         $lines[] = '';
     }
 
@@ -236,8 +177,17 @@ PHP;
         return match ($type) {
             'boolean' => $value ? 'true' : 'false',
             'integer' => (string)(int)$value,
-            default => "'" . addcslashes(string: (string)$value, characters: "'\\") . "'",
+            default => self::renderStringValue(value: (string)$value),
         };
+    }
+
+    private static function renderStringValue(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        return "'" . addcslashes(string: $value, characters: "'\\") . "'";
     }
 
     private static function trimTrailingBlankLine(array &$lines): void
@@ -246,5 +196,4 @@ PHP;
             array_pop($lines);
         }
     }
-
 }

--- a/scripts/generate-env-example.php
+++ b/scripts/generate-env-example.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+if (!defined('ROOT_DIR')) {
+    define('ROOT_DIR', dirname(__DIR__) . '/');
+}
+
+if (PHP_SAPI !== 'cli') {
+    http_response_code(403);
+    exit('This script must be run from the command line.');
+}
+
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
+require_once(ROOT_DIR . 'lib/Config/ConfigDistGenerator.php');
+require_once(ROOT_DIR . 'lib/Config/EnvExampleGenerator.php');
+
+if (realpath($_SERVER['SCRIPT_FILENAME'] ?? '') === realpath(__FILE__)) {
+    exit(EnvExampleGenerator::main($argv));
+}

--- a/tests/lib/Config/EnvExampleGeneratorTest.php
+++ b/tests/lib/Config/EnvExampleGeneratorTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+require_once(ROOT_DIR . 'lib/Config/namespace.php');
+require_once(ROOT_DIR . 'lib/Config/ConfigDistGenerator.php');
+require_once(ROOT_DIR . 'lib/Config/EnvExampleGenerator.php');
+
+class EnvExampleGeneratorTest extends TestBase
+{
+    public function testRenderContainsSectionHeaders(): void
+    {
+        $content = EnvExampleGenerator::render();
+
+        $this->assertStringContainsString("# Application configuration\n", $content);
+        $this->assertStringContainsString("# Language and Timezone\n", $content);
+        $this->assertStringContainsString("# Database\n", $content);
+        $this->assertStringContainsString("# Authentication Settings\n", $content);
+    }
+
+    public function testRenderContainsAllConfigKeys(): void
+    {
+        $content = EnvExampleGenerator::render();
+
+        foreach (ConfigKeys::all() as $entry) {
+            $envKey = ConfigKeysMeta::envKey(configKey: $entry['key']);
+            $this->assertStringContainsString(
+                $envKey . '=',
+                $content,
+                "Missing env key: {$envKey} (from config key: {$entry['key']})"
+            );
+        }
+    }
+
+    public function testEnvKeyFormatMatchesAbstractConfigKeys(): void
+    {
+        // Verify our envKey derivation matches the one used at runtime
+        foreach (ConfigKeys::all() as $entry) {
+            $key = $entry['key'];
+            $expected = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $key));
+            $actual = ConfigKeysMeta::envKey(configKey: $key);
+
+            $this->assertSame(
+                $expected,
+                $actual,
+                "envKey mismatch for config key: {$key}"
+            );
+        }
+    }
+
+    public function testRenderOutputHasCorrectTypes(): void
+    {
+        $content = EnvExampleGenerator::render();
+
+        // Boolean defaults render as true/false, not quoted
+        $this->assertMatchesRegularExpression(
+            '/^LB_APP_DEBUG=false$/m',
+            $content
+        );
+
+        // Integer defaults render as integers, not quoted
+        $this->assertMatchesRegularExpression(
+            '/^LB_INACTIVITY_TIMEOUT=30$/m',
+            $content
+        );
+
+        // String defaults render as single-quoted
+        $this->assertMatchesRegularExpression(
+            "/^LB_APP_TITLE='LibreBooking'$/m",
+            $content
+        );
+
+        // Empty string defaults render as bare (no quotes)
+        $this->assertMatchesRegularExpression(
+            '/^LB_COMPANY_NAME=$/m',
+            $content
+        );
+    }
+
+    public function testRenderContainsComments(): void
+    {
+        $content = EnvExampleGenerator::render();
+
+        // config_file_comment is preferred
+        $this->assertStringContainsString('# The public name of the application', $content);
+
+        // Boolean hint is appended
+        $this->assertStringContainsString('(true/false)', $content);
+    }
+
+    public function testRenderContainsChoices(): void
+    {
+        $content = EnvExampleGenerator::render();
+
+        // Choices from config_file_comment (already has Options:) should not duplicate
+        $this->assertStringContainsString('# Options:', $content);
+    }
+
+    public function testHiddenKeysAreIncluded(): void
+    {
+        $content = EnvExampleGenerator::render();
+
+        $this->assertStringContainsString('LB_INSTALL_PASSWORD=', $content);
+    }
+
+    public function testCheckReturnsTrueForMatchingFile(): void
+    {
+        $tmpFile = tempnam(directory: sys_get_temp_dir(), prefix: 'env_example_test_');
+        EnvExampleGenerator::writeToFile(path: $tmpFile);
+
+        try {
+            $this->assertTrue(EnvExampleGenerator::check(path: $tmpFile));
+        } finally {
+            unlink(filename: $tmpFile);
+        }
+    }
+
+    public function testCheckReturnsFalseForMismatchedFile(): void
+    {
+        $tmpFile = tempnam(directory: sys_get_temp_dir(), prefix: 'env_example_test_');
+        file_put_contents(filename: $tmpFile, data: 'LB_FOO=bar');
+
+        try {
+            $this->assertFalse(EnvExampleGenerator::check(path: $tmpFile));
+        } finally {
+            unlink(filename: $tmpFile);
+        }
+    }
+
+    public function testCheckReturnsFalseForMissingFile(): void
+    {
+        $path = sys_get_temp_dir() . '/nonexistent_env_example_test_' . uniqid() . '.env';
+        $this->assertFalse(EnvExampleGenerator::check(path: $path));
+    }
+
+    public function testRenderProducesValidEnvSyntax(): void
+    {
+        $content = EnvExampleGenerator::render();
+
+        foreach (explode(separator: "\n", string: $content) as $lineNum => $line) {
+            if ($line === '' || str_starts_with(haystack: $line, needle: '#')) {
+                continue;
+            }
+
+            $this->assertMatchesRegularExpression(
+                '/^[A-Z][A-Z0-9_]+=/',
+                $line,
+                'Line ' . ($lineNum + 1) . " is not valid .env syntax: {$line}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Replace the hand-maintained .env.example (714 lines) with an auto-generated file derived from ConfigKeys, matching the existing config.dist.php generator approach.

Changes:
- Extract shared helpers (getComment, sectionTitle, groupFlatEntries, envKey) from ConfigDistGenerator into ConfigKeysMeta
- Add EnvExampleGenerator class with render/writeToFile/check/main
- Add scripts/generate-env-example.php CLI wrapper
- Add composer scripts: env-example:generate, env-example:check
- Add CI check in lint-and-analyse-php.yml
- Regenerate .env.example from metadata (adds missing keys like LB_ENABLED_LANGUAGES and LB_DEFAULT_PAGE_SIZE, fixes typos)