### PR TITLE
fix: Improve 'Info' string for `en_us`

### DIFF
--- a/lang/en_us.php
+++ b/lang/en_us.php
@@ -1075,7 +1075,7 @@ class en_us extends Language
         //End View Resource
 
         //Datatables
-        $strings['Info'] = 'Showing page _PAGE_ of _PAGES_ of _MAX_';
+        $strings['Info'] = 'Showing page _PAGE_ of _PAGES_ (_MAX_ total records)';
         $strings['LengthMenu'] = 'Display _MENU_ records per page';
         //End Datatables
 


### PR DESCRIPTION
Before it would show something like:
  Showing page 1 of 23 of 1,136

Now it will show:
  Showing page 1 of 23 (1,136 total records)