### PR TITLE
fix(config)!: use section-qualified env names for plugin config

### DIFF
--- a/lib/Config/AbstractConfigKeys.php
+++ b/lib/Config/AbstractConfigKeys.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once(ROOT_DIR . 'lib/Config/ConfigKeysMeta.php');
+
 abstract class AbstractConfigKeys
 {
     /** @var array<class-string, array> */
@@ -120,12 +122,10 @@ abstract class AbstractConfigKeys
 
     public static function hasEnv($config): bool
     {
-        $key = $config['key'] ?? null;
-        if (!is_string($key) || $key === '') {
+        $envKey = ConfigKeysMeta::envKeyForConfig(config: $config);
+        if ($envKey === null) {
             return false;
         }
-
-        $envKey = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $key));
 
         return getenv($envKey) !== false;
     }

--- a/lib/Config/ConfigKeysMeta.php
+++ b/lib/Config/ConfigKeysMeta.php
@@ -3,6 +3,34 @@
 class ConfigKeysMeta
 {
     /**
+     * Return the canonical config key name for an entry.
+     *
+     * Plugin entries with a section use the fully qualified section.key name.
+     */
+    public static function canonicalKeyName(array $config): ?string
+    {
+        $key = $config['key'] ?? null;
+        if (!is_string($key) || $key === '') {
+            return null;
+        }
+
+        $section = $config['section'] ?? null;
+        if (is_string($section) && $section !== '') {
+            // Main config entries already store fully qualified keys like
+            // "reservation.start.time.constraint" and use "section" only for grouping.
+            if (str_starts_with($key, $section . '.')) {
+                return $key;
+            }
+
+            // Plugin config entries store the leaf key plus a separate section, so
+            // their canonical name needs to be reconstructed as "section.key".
+            return "{$section}.{$key}";
+        }
+
+        return $key;
+    }
+
+    /**
      * Get the comment text for a config entry.
      *
      * Prefers 'config_file_comment' field, falls back to 'description'.
@@ -69,13 +97,16 @@ class ConfigKeysMeta
     }
 
     /**
-     * Derive the environment variable name for a config key.
-     *
-     * Matches the logic in AbstractConfigKeys::hasEnv().
+     * Derive the environment variable name for a config entry definition.
      */
-    public static function envKey(string $configKey): string
+    public static function envKeyForConfig(array $config): ?string
     {
-        return strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $configKey));
+        $canonicalKey = self::canonicalKeyName(config: $config);
+        if ($canonicalKey === null) {
+            return null;
+        }
+
+        return strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $canonicalKey));
     }
 
     public const SECTION_TITLES = [

--- a/lib/Config/Configuration.php
+++ b/lib/Config/Configuration.php
@@ -525,8 +525,8 @@ class ConfigurationFile implements IConfigurationFile
         $section = $configDef['section'] ?? null;
         $converter = $converter ?? $this->GetDefaultConverter($configDef);
 
-        $envKey = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $configDef['key']));
-        $envValue = env($envKey);
+        $envKey = ConfigKeysMeta::envKeyForConfig(config: $configDef);
+        $envValue = $envKey !== null ? env($envKey) : null;
 
         if (!empty($envValue)) {
             $value = $envValue;

--- a/lib/Config/EnvExampleGenerator.php
+++ b/lib/Config/EnvExampleGenerator.php
@@ -138,7 +138,10 @@ class EnvExampleGenerator
         $comment = ConfigKeysMeta::getComment(entry: $entry);
         $choices = $entry['choices'] ?? null;
         $type = $entry['type'] ?? 'string';
-        $envKey = ConfigKeysMeta::envKey(configKey: $entry['key']);
+        $envKey = ConfigKeysMeta::envKeyForConfig(config: $entry);
+        if ($envKey === null) {
+            throw new \LogicException('Env example entry is missing a canonical config key name.');
+        }
 
         if ($comment !== '') {
             $hasExplicitComment = isset($entry['config_file_comment']) && $entry['config_file_comment'] !== '';

--- a/tests/Infrastructure/Config/ConfigTest.php
+++ b/tests/Infrastructure/Config/ConfigTest.php
@@ -367,6 +367,51 @@ PHP
         $this->assertEquals('UCT', $config->GetDefaultTimezone());
     }
 
+    public function testPluginEnvUsesSectionQualifiedNames(): void
+    {
+        putenv('LB_SERVER1_KEY=env-section-qualified');
+        putenv('LB_KEY=legacy-bare-name');
+        putenv('LB_KEY1');
+
+        try {
+            Configuration::Instance()->Register(
+                ROOT_DIR . 'tests/data/test_plugin_config.php',
+                '',
+                TestPluginConfigKeys::CONFIG_ID,
+                false,
+                TestPluginConfigKeys::class
+            );
+            $pluginConfig = Configuration::Instance()->File(TestPluginConfigKeys::CONFIG_ID);
+
+            $this->assertSame('env-section-qualified', $pluginConfig->GetKey(TestPluginConfigKeys::SERVER1_KEY));
+            $this->assertSame('value1', $pluginConfig->GetKey(TestPluginConfigKeys::KEY1));
+        } finally {
+            putenv('LB_SERVER1_KEY');
+            putenv('LB_KEY');
+            putenv('LB_KEY1');
+        }
+    }
+
+    public function testPluginHasEnvUsesSectionQualifiedNames(): void
+    {
+        putenv('LB_SERVER2_KEY=value-from-env');
+        putenv('LB_KEY1');
+
+        try {
+            $this->assertTrue(TestPluginConfigKeys::hasEnv(TestPluginConfigKeys::SERVER2_KEY));
+            $this->assertFalse(TestPluginConfigKeys::hasEnv(TestPluginConfigKeys::KEY1));
+        } finally {
+            putenv('LB_SERVER2_KEY');
+            putenv('LB_KEY1');
+        }
+    }
+
+    public function testConfigKeysMetaEnvKeyForConfigUsesCanonicalPluginKey(): void
+    {
+        $this->assertSame('LB_SERVER1_KEY', ConfigKeysMeta::envKeyForConfig(TestPluginConfigKeys::SERVER1_KEY));
+        $this->assertSame('LB_KEY1', ConfigKeysMeta::envKeyForConfig(TestPluginConfigKeys::KEY1));
+    }
+
     // /**
     //  * Test that the actual config.dist.php loads correctly
     //  * and all its nested values are accessible

--- a/tests/lib/Config/EnvExampleGeneratorTest.php
+++ b/tests/lib/Config/EnvExampleGeneratorTest.php
@@ -23,7 +23,7 @@ class EnvExampleGeneratorTest extends TestBase
         $content = EnvExampleGenerator::render();
 
         foreach (ConfigKeys::all() as $entry) {
-            $envKey = ConfigKeysMeta::envKey(configKey: $entry['key']);
+            $envKey = ConfigKeysMeta::envKeyForConfig(config: $entry);
             $this->assertStringContainsString(
                 $envKey . '=',
                 $content,
@@ -34,11 +34,11 @@ class EnvExampleGeneratorTest extends TestBase
 
     public function testEnvKeyFormatMatchesAbstractConfigKeys(): void
     {
-        // Verify our envKey derivation matches the one used at runtime
+        // Verify canonical env keys follow the expected LB_* naming convention
         foreach (ConfigKeys::all() as $entry) {
             $key = $entry['key'];
             $expected = strtoupper('LB_' . preg_replace('/[.\-]+/', '_', $key));
-            $actual = ConfigKeysMeta::envKey(configKey: $key);
+            $actual = ConfigKeysMeta::envKeyForConfig(config: $entry);
 
             $this->assertSame(
                 $expected,


### PR DESCRIPTION
Resolve plugin config environment variable lookup from the canonical section-qualified key instead of the bare leaf key.

Plugin config entries store their section and key separately, but env resolution previously derived names from only the leaf key. That caused ambiguous names such as LB_BINDPW, LB_HOST, and LB_PORT, which could collide across plugins and did not match the plugin config model used elsewhere in the system.

This change centralizes canonical config key name derivation and uses it for runtime env lookup, env presence checks, and env example generation logic. Main config behavior is preserved, while plugin config entries now resolve env vars from their fully qualified names.

Also add regression coverage for section-qualified plugin env resolution and bare-name rejection.

Closes: #1322

BREAKING CHANGE: plugin config environment variables must now use section-qualified names. For example, use LB_LDAP_BINDPW instead of LB_BINDPW, LB_LDAP_HOST instead of LB_HOST, and LB_LDAP_PORT instead of LB_PORT. Bare plugin env var names are no longer recognized.