### PR TITLE
feat(api): Add groupId filter to GET Resources endpoint

### DIFF
--- a/WebServices/ResourcesWebService.php
+++ b/WebServices/ResourcesWebService.php
@@ -52,6 +52,7 @@ class ResourcesWebService
      * @name GetAllResources
      * @description Loads all resources
      * Optional query string parameter: scheduleId. One or more schedule IDs, comma-separated (e.g. scheduleId=1,2,3). If provided, only resources belonging to those schedules will be returned. Each value must be a positive integer (greater than zero); if any value is non-integer or zero, a 400 Bad Request is returned.
+     * Optional query string parameter: groupId. One or more resource group IDs, comma-separated (e.g. groupId=1,2,3). If provided, only resources belonging to those groups (including sub-groups) will be returned. Each value must be a positive integer (greater than zero); if any value is non-integer or zero, a 400 Bad Request is returned. If any group ID does not exist, a 404 Not Found is returned.
      * @response ResourcesResponse
      * @return void
      */
@@ -73,12 +74,49 @@ class ResourcesWebService
             $scheduleIds = array_map('intval', $rawIds);
         }
 
+        $groupIds = null;
+        $groupIdParam = $this->server->GetQueryString(WebServiceQueryStringKeys::GROUP_ID);
+        if ($groupIdParam !== null && $groupIdParam !== '') {
+            $rawIds = explode(',', $groupIdParam);
+            foreach ($rawIds as $id) {
+                if (!ctype_digit($id) || (int)$id === 0) {
+                    $this->server->WriteResponse(
+                        RestResponse::BadRequest("Invalid groupId '$id': must be a positive integer"),
+                        RestResponse::BAD_REQUEST_CODE
+                    );
+                    return;
+                }
+            }
+            $groupIds = array_map('intval', $rawIds);
+        }
+
         $resources = $this->resourceRepository->GetUserResourceList();
 
         if ($scheduleIds !== null) {
             $filteredResources = [];
             foreach ($resources as $resource) {
                 if (in_array($resource->GetScheduleId(), $scheduleIds)) {
+                    $filteredResources[] = $resource;
+                }
+            }
+            $resources = $filteredResources;
+        }
+
+        if ($groupIds !== null) {
+            $groupTree = $this->resourceRepository->GetResourceGroups();
+            $groupList = $groupTree->GetGroupList();
+            $groupResourceIds = [];
+            foreach ($groupIds as $groupId) {
+                if (!array_key_exists($groupId, $groupList)) {
+                    $this->server->WriteResponse(RestResponse::NotFound(), RestResponse::NOT_FOUND_CODE);
+                    return;
+                }
+                $groupResourceIds = array_merge($groupResourceIds, $groupTree->GetResourceIds($groupId));
+            }
+            $groupResourceIds = array_unique($groupResourceIds);
+            $filteredResources = [];
+            foreach ($resources as $resource) {
+                if (in_array($resource->GetId(), $groupResourceIds)) {
                     $filteredResources[] = $resource;
                 }
             }

--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -62,6 +62,12 @@ To combine multiple parameters::
 
     /Web/Services/index.php/Reservations/?scheduleId=1&userId=5
 
+To filter resources by group::
+
+    /Web/Services/index.php/Resources/?groupId=1
+
+    /Web/Services/index.php/Resources/?groupId=1,2,3
+
 POST Requests
 ~~~~~~~~~~~~~
 
@@ -2166,6 +2172,13 @@ comma-separated (e.g. ``scheduleId=1,2,3``). If provided, only resources
 belonging to those schedules will be returned. Each value must be a positive
 integer (greater than zero); if any value is non-integer or zero, a ``400 Bad
 Request`` is returned.
+
+Optional query string parameter: ``groupId``. One or more resource group IDs,
+comma-separated (e.g. ``groupId=1,2,3``). If provided, only resources belonging
+to those groups (including resources in sub-groups) will be returned. Each value
+must be a positive integer (greater than zero); if any value is non-integer or
+zero, a ``400 Bad Request`` is returned. If any group ID does not exist, a
+``404 Not Found`` is returned.
 
 **Route:** ``/Web/Services/index.php/Resources/``
 

--- a/lib/WebService/WebServiceQueryStringKeys.php
+++ b/lib/WebService/WebServiceQueryStringKeys.php
@@ -6,6 +6,7 @@ class WebServiceQueryStringKeys
     public const DATE_TIME = 'dateTime';
     public const START_DATE_TIME = 'startDateTime';
     public const END_DATE_TIME = 'endDateTime';
+    public const GROUP_ID = 'groupId';
     public const RESOURCE_ID = 'resourceId';
     public const SCHEDULE_ID = 'scheduleId';
     public const UPDATE_SCOPE = 'updateScope';

--- a/tests/WebServices/ResourcesWebServiceTest.php
+++ b/tests/WebServices/ResourcesWebServiceTest.php
@@ -230,6 +230,255 @@ class ResourcesWebServiceTest extends TestBase
         );
     }
 
+    private function buildGroupTree(int $groupId, array $resourceIds): ResourceGroupTree
+    {
+        $tree = new ResourceGroupTree();
+        $tree->AddGroup(new ResourceGroup($groupId, "Group $groupId"));
+        foreach ($resourceIds as $resourceId) {
+            $tree->AddAssignment(new ResourceGroupAssignment(
+                group_id: $groupId,
+                resource_name: "Resource $resourceId",
+                resource_id: $resourceId,
+                resourceAdminGroupId: null,
+                scheduleId: 1,
+                statusId: ResourceStatus::AVAILABLE,
+                scheduleAdminGroupId: null,
+                requiresApproval: false,
+                isCheckInEnabled: false,
+                isAutoReleased: false,
+                autoReleaseMinutes: null,
+                minLength: null,
+                resourceTypeId: null,
+                color: null,
+                maxConcurrentReservations: null
+            ));
+        }
+        return $tree;
+    }
+
+    public function testFiltersResourceListByGroupId()
+    {
+        $groupId = 3;
+        $matchingResourceId = 123;
+        $otherResourceId = 456;
+
+        $matchingResource = new FakeBookableResource($matchingResourceId);
+        $otherResource = new FakeBookableResource($otherResourceId);
+
+        $this->server->SetQueryString(WebServiceQueryStringKeys::GROUP_ID, $groupId);
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceList')
+                         ->willReturn([$matchingResource, $otherResource]);
+
+        $groupTree = $this->buildGroupTree($groupId, [$matchingResourceId]);
+        $this->repository->expects($this->once())
+                         ->method('GetResourceGroups')
+                         ->willReturn($groupTree);
+
+        $attributes = new AttributeList();
+        $this->attributeService->expects($this->once())
+                               ->method('GetAttributes')
+                               ->with(
+                                   $this->equalTo(CustomAttributeCategory::RESOURCE),
+                                   $this->equalTo([$matchingResourceId])
+                               )
+                               ->willReturn($attributes);
+
+        $this->service->GetAll();
+
+        $this->assertEquals(
+            new ResourcesResponse($this->server, [$matchingResource], $attributes),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testFiltersResourceListByMultipleGroupIds()
+    {
+        $groupId1 = 3;
+        $groupId2 = 7;
+        $resourceId1 = 123;
+        $resourceId2 = 456;
+        $otherResourceId = 789;
+
+        $resource1 = new FakeBookableResource($resourceId1);
+        $resource2 = new FakeBookableResource($resourceId2);
+        $otherResource = new FakeBookableResource($otherResourceId);
+
+        $this->server->SetQueryString(WebServiceQueryStringKeys::GROUP_ID, "$groupId1,$groupId2");
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceList')
+                         ->willReturn([$resource1, $resource2, $otherResource]);
+
+        $tree = new ResourceGroupTree();
+        $tree->AddGroup(new ResourceGroup($groupId1, "Group $groupId1"));
+        $tree->AddGroup(new ResourceGroup($groupId2, "Group $groupId2"));
+        $tree->AddAssignment(new ResourceGroupAssignment(
+            group_id: $groupId1,
+            resource_name: "Resource $resourceId1",
+            resource_id: $resourceId1,
+            resourceAdminGroupId: null,
+            scheduleId: 1,
+            statusId: ResourceStatus::AVAILABLE,
+            scheduleAdminGroupId: null,
+            requiresApproval: false,
+            isCheckInEnabled: false,
+            isAutoReleased: false,
+            autoReleaseMinutes: null,
+            minLength: null,
+            resourceTypeId: null,
+            color: null,
+            maxConcurrentReservations: null
+        ));
+        $tree->AddAssignment(new ResourceGroupAssignment(
+            group_id: $groupId2,
+            resource_name: "Resource $resourceId2",
+            resource_id: $resourceId2,
+            resourceAdminGroupId: null,
+            scheduleId: 1,
+            statusId: ResourceStatus::AVAILABLE,
+            scheduleAdminGroupId: null,
+            requiresApproval: false,
+            isCheckInEnabled: false,
+            isAutoReleased: false,
+            autoReleaseMinutes: null,
+            minLength: null,
+            resourceTypeId: null,
+            color: null,
+            maxConcurrentReservations: null
+        ));
+
+        $this->repository->expects($this->once())
+                         ->method('GetResourceGroups')
+                         ->willReturn($tree);
+
+        $attributes = new AttributeList();
+        $this->attributeService->expects($this->once())
+                               ->method('GetAttributes')
+                               ->with(
+                                   $this->equalTo(CustomAttributeCategory::RESOURCE),
+                                   $this->equalTo([$resourceId1, $resourceId2])
+                               )
+                               ->willReturn($attributes);
+
+        $this->service->GetAll();
+
+        $this->assertEquals(
+            new ResourcesResponse($this->server, [$resource1, $resource2], $attributes),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testFiltersResourceListByGroupIdIncludesSubGroups()
+    {
+        $parentGroupId = 3;
+        $childGroupId = 5;
+        $matchingResourceId = 123;
+        $otherResourceId = 456;
+
+        $matchingResource = new FakeBookableResource($matchingResourceId);
+        $otherResource = new FakeBookableResource($otherResourceId);
+
+        $this->server->SetQueryString(WebServiceQueryStringKeys::GROUP_ID, $parentGroupId);
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceList')
+                         ->willReturn([$matchingResource, $otherResource]);
+
+        $tree = new ResourceGroupTree();
+        $tree->AddGroup(new ResourceGroup($parentGroupId, 'Parent'));
+        $tree->AddGroup(new ResourceGroup($childGroupId, 'Child', $parentGroupId));
+        $tree->AddAssignment(new ResourceGroupAssignment(
+            group_id: $childGroupId,
+            resource_name: "Resource $matchingResourceId",
+            resource_id: $matchingResourceId,
+            resourceAdminGroupId: null,
+            scheduleId: 1,
+            statusId: ResourceStatus::AVAILABLE,
+            scheduleAdminGroupId: null,
+            requiresApproval: false,
+            isCheckInEnabled: false,
+            isAutoReleased: false,
+            autoReleaseMinutes: null,
+            minLength: null,
+            resourceTypeId: null,
+            color: null,
+            maxConcurrentReservations: null
+        ));
+
+        $this->repository->expects($this->once())
+                         ->method('GetResourceGroups')
+                         ->willReturn($tree);
+
+        $attributes = new AttributeList();
+        $this->attributeService->expects($this->once())
+                               ->method('GetAttributes')
+                               ->with(
+                                   $this->equalTo(CustomAttributeCategory::RESOURCE),
+                                   $this->equalTo([$matchingResourceId])
+                               )
+                               ->willReturn($attributes);
+
+        $this->service->GetAll();
+
+        $this->assertEquals(
+            new ResourcesResponse($this->server, [$matchingResource], $attributes),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testReturns400ForNonIntegerGroupId()
+    {
+        $this->server->SetQueryString(WebServiceQueryStringKeys::GROUP_ID, '1,abc,2');
+
+        $this->repository->expects($this->never())
+                         ->method('GetUserResourceList');
+
+        $this->service->GetAll();
+
+        $this->assertEquals(RestResponse::BAD_REQUEST_CODE, $this->server->_LastResponseCode);
+        $this->assertEquals(
+            RestResponse::BadRequest("Invalid groupId 'abc': must be a positive integer"),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testReturns400ForZeroGroupId()
+    {
+        $this->server->SetQueryString(WebServiceQueryStringKeys::GROUP_ID, '0');
+
+        $this->repository->expects($this->never())
+                         ->method('GetUserResourceList');
+
+        $this->service->GetAll();
+
+        $this->assertEquals(RestResponse::BAD_REQUEST_CODE, $this->server->_LastResponseCode);
+        $this->assertEquals(
+            RestResponse::BadRequest("Invalid groupId '0': must be a positive integer"),
+            $this->server->_LastResponse
+        );
+    }
+
+    public function testReturns404ForNonExistentGroupId()
+    {
+        $this->server->SetQueryString(WebServiceQueryStringKeys::GROUP_ID, '999');
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceList')
+                         ->willReturn([]);
+
+        $groupTree = new ResourceGroupTree();
+        $this->repository->expects($this->once())
+                         ->method('GetResourceGroups')
+                         ->willReturn($groupTree);
+
+        $this->service->GetAll();
+
+        $this->assertEquals(RestResponse::NOT_FOUND_CODE, $this->server->_LastResponseCode);
+        $this->assertEquals(RestResponse::NotFound(), $this->server->_LastResponse);
+    }
+
     public function testGetsStatuses()
     {
         $this->service->GetStatuses();


### PR DESCRIPTION
Add optional groupId query string parameter to GET /Resources/. Accepts one or more comma-separated positive integer IDs (e.g. ?groupId=1,2,3). Returns only resources belonging to those resource groups, including resources in sub-groups. Returns 400 Bad Request if any value is non-integer or zero. Returns 404 Not Found if a non-existing groupId is used.

Updates API documentation in both the inline @description and docs/source/API.rst.

Closes: #1326