### PR TITLE
feat(api): Return 404 for non-existent scheduleId in GET Resources en…

### DIFF
--- a/Web/Services/index.php
+++ b/Web/Services/index.php
@@ -152,7 +152,13 @@ function RegisterResources(SlimServer $server, SlimWebServiceRegistry $registry)
 {
     $resourceRepository = new ResourceRepository();
     $attributeService = new AttributeService(new AttributeRepository());
-    $webService = new ResourcesWebService($server, $resourceRepository, $attributeService, new ReservationViewRepository());
+    $webService = new ResourcesWebService(
+        server: $server,
+        resourceRepository: $resourceRepository,
+        attributeService: $attributeService,
+        reservationRepository: new ReservationViewRepository(),
+        scheduleRepository: new ScheduleRepository()
+    );
     $writeWebService = new ResourcesWriteWebService($server, new ResourceSaveController($resourceRepository, new ResourceRequestValidator($attributeService)));
 
     $roGroupId = GetConfigGroup(ConfigKeys::API_RESOURCES_RO_GROUP);

--- a/WebServices/ResourcesWebService.php
+++ b/WebServices/ResourcesWebService.php
@@ -16,42 +16,19 @@ require_once(ROOT_DIR . 'WebServices/Responses/Resource/ResourceGroupsResponse.p
 
 class ResourcesWebService
 {
-    /**
-     * @var IRestServer
-     */
-    private $server;
-
-    /**
-     * @var IResourceRepository
-     */
-    private $resourceRepository;
-
-    /**
-     * @var IAttributeService
-     */
-    private $attributeService;
-
-    /**
-     * @var IReservationViewRepository
-     */
-    private $reservationRepository;
-
     public function __construct(
-        IRestServer $server,
-        IResourceRepository $resourceRepository,
-        IAttributeService $attributeService,
-        IReservationViewRepository $reservationRepository
+        private IRestServer $server,
+        private IResourceRepository $resourceRepository,
+        private IAttributeService $attributeService,
+        private IReservationViewRepository $reservationRepository,
+        private IScheduleRepository $scheduleRepository
     ) {
-        $this->server = $server;
-        $this->resourceRepository = $resourceRepository;
-        $this->attributeService = $attributeService;
-        $this->reservationRepository = $reservationRepository;
     }
 
     /**
      * @name GetAllResources
      * @description Loads all resources
-     * Optional query string parameter: scheduleId. One or more schedule IDs, comma-separated (e.g. scheduleId=1,2,3). If provided, only resources belonging to those schedules will be returned. Each value must be a positive integer (greater than zero); if any value is non-integer or zero, a 400 Bad Request is returned.
+     * Optional query string parameter: scheduleId. One or more schedule IDs, comma-separated (e.g. scheduleId=1,2,3). If provided, only resources belonging to those schedules will be returned. Each value must be a positive integer (greater than zero); if any value is non-integer or zero, a 400 Bad Request is returned. If any schedule ID does not exist, a 404 Not Found is returned.
      * Optional query string parameter: groupId. One or more resource group IDs, comma-separated (e.g. groupId=1,2,3). If provided, only resources belonging to those groups (including sub-groups) will be returned. Each value must be a positive integer (greater than zero); if any value is non-integer or zero, a 400 Bad Request is returned. If any group ID does not exist, a 404 Not Found is returned.
      * @response ResourcesResponse
      * @return void
@@ -68,6 +45,18 @@ class ResourcesWebService
             return;
         }
 
+        if ($scheduleIds !== null) {
+            foreach ($scheduleIds as $scheduleId) {
+                if ($this->scheduleRepository->LoadById($scheduleId) === null) {
+                    $this->server->WriteResponse(
+                        restResponse: RestResponse::NotFound(),
+                        statusCode: RestResponse::NOT_FOUND_CODE
+                    );
+                    return;
+                }
+            }
+        }
+
         $resources = $this->resourceRepository->GetUserResourceList();
 
         if ($scheduleIds !== null) {
@@ -81,6 +70,7 @@ class ResourcesWebService
         }
 
         if ($groupIds !== null) {
+            // GetResourceGroups() returns the full tree, used for both existence checks and sub-group traversal.
             $groupTree = $this->resourceRepository->GetResourceGroups();
             $groupList = $groupTree->GetGroupList();
             $groupResourceIds = [];
@@ -89,6 +79,7 @@ class ResourcesWebService
                     $this->server->WriteResponse(RestResponse::NotFound(), RestResponse::NOT_FOUND_CODE);
                     return;
                 }
+                // GetResourceIds() recurses into sub-groups.
                 $groupResourceIds = array_merge($groupResourceIds, $groupTree->GetResourceIds($groupId));
             }
             $groupResourceIds = array_unique($groupResourceIds);
@@ -242,6 +233,7 @@ class ResourcesWebService
 
     /**
      * Parses a comma-separated list of positive integers from a query string parameter.
+     * Duplicate values are removed; the returned array is unique and re-indexed.
      *
      * @return int[]|false|null int[] on success, null if param absent/empty, false if invalid
      *                          (a 400 response has already been written)
@@ -264,7 +256,7 @@ class ResourcesWebService
             }
         }
 
-        return array_map('intval', $rawIds);
+        return array_values(array_unique(array_map('intval', $rawIds)));
     }
 
     /**

--- a/docs/source/API.rst
+++ b/docs/source/API.rst
@@ -2171,7 +2171,8 @@ Optional query string parameter: ``scheduleId``. One or more schedule IDs,
 comma-separated (e.g. ``scheduleId=1,2,3``). If provided, only resources
 belonging to those schedules will be returned. Each value must be a positive
 integer (greater than zero); if any value is non-integer or zero, a ``400 Bad
-Request`` is returned.
+Request`` is returned. If any schedule ID does not exist, a ``404 Not Found``
+is returned.
 
 Optional query string parameter: ``groupId``. One or more resource group IDs,
 comma-separated (e.g. ``groupId=1,2,3``). If provided, only resources belonging

--- a/tests/WebServices/ResourcesWebServiceTest.php
+++ b/tests/WebServices/ResourcesWebServiceTest.php
@@ -17,6 +17,8 @@ class ResourcesWebServiceTest extends TestBase
 
     private IAttributeService&\PHPUnit\Framework\MockObject\MockObject $attributeService;
 
+    private IScheduleRepository&\PHPUnit\Framework\MockObject\MockObject $scheduleRepository;
+
     /**
      * @var ResourcesWebService
      */
@@ -30,8 +32,15 @@ class ResourcesWebServiceTest extends TestBase
         $this->repository = $this->createMock('IResourceRepository');
         $this->reservationRepository = $this->createMock('IReservationViewRepository');
         $this->attributeService = $this->createMock('IAttributeService');
+        $this->scheduleRepository = $this->createMock('IScheduleRepository');
 
-        $this->service = new ResourcesWebService($this->server, $this->repository, $this->attributeService, $this->reservationRepository);
+        $this->service = new ResourcesWebService(
+            server: $this->server,
+            resourceRepository: $this->repository,
+            attributeService: $this->attributeService,
+            reservationRepository: $this->reservationRepository,
+            scheduleRepository: $this->scheduleRepository
+        );
     }
 
     public function testGetsResourceById()
@@ -121,6 +130,11 @@ class ResourcesWebServiceTest extends TestBase
 
         $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, $scheduleId);
 
+        $this->scheduleRepository->expects($this->once())
+                                 ->method('LoadById')
+                                 ->with($scheduleId)
+                                 ->willReturn(new Schedule(id: $scheduleId, name: null, isDefault: false, weekdayStart: null, daysVisible: null));
+
         $this->repository->expects($this->once())
                          ->method('GetUserResourceList')
                          ->willReturn([$matchingResource, $otherResource]);
@@ -161,6 +175,13 @@ class ResourcesWebServiceTest extends TestBase
 
         $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, "$scheduleId1,$scheduleId2");
 
+        $this->scheduleRepository->expects($this->exactly(2))
+                                 ->method('LoadById')
+                                 ->willReturnMap([
+                                     [$scheduleId1, new Schedule(id: $scheduleId1, name: null, isDefault: false, weekdayStart: null, daysVisible: null)],
+                                     [$scheduleId2, new Schedule(id: $scheduleId2, name: null, isDefault: false, weekdayStart: null, daysVisible: null)],
+                                 ]);
+
         $this->repository->expects($this->once())
                          ->method('GetUserResourceList')
                          ->willReturn([$resource1, $resource2, $otherResource]);
@@ -180,6 +201,71 @@ class ResourcesWebServiceTest extends TestBase
             new ResourcesResponse($this->server, [$resource1, $resource2], $attributes),
             $this->server->_LastResponse
         );
+    }
+
+    public function testReturns404ForNonExistentScheduleId()
+    {
+        $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, '999');
+
+        $this->scheduleRepository->expects($this->once())
+                                 ->method('LoadById')
+                                 ->with(999)
+                                 ->willReturn(null);
+
+        $this->repository->expects($this->never())
+                         ->method('GetUserResourceList');
+
+        $this->service->GetAll();
+
+        $this->assertEquals(RestResponse::NOT_FOUND_CODE, $this->server->_LastResponseCode);
+        $this->assertEquals(RestResponse::NotFound(), $this->server->_LastResponse);
+    }
+
+    public function testReturns404WhenOneOfMultipleScheduleIdsDoesNotExist()
+    {
+        // ID 1 exists, ID 999 does not — the endpoint must return 404 regardless.
+        $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, '1,999');
+
+        $this->scheduleRepository->expects($this->exactly(2))
+                                 ->method('LoadById')
+                                 ->willReturnMap([
+                                     [1, new Schedule(id: 1, name: null, isDefault: false, weekdayStart: null, daysVisible: null)],
+                                     [999, null],
+                                 ]);
+
+        $this->repository->expects($this->never())
+                         ->method('GetUserResourceList');
+
+        $this->service->GetAll();
+
+        $this->assertEquals(RestResponse::NOT_FOUND_CODE, $this->server->_LastResponseCode);
+        $this->assertEquals(RestResponse::NotFound(), $this->server->_LastResponse);
+    }
+
+    public function testDeduplicatesScheduleIds()
+    {
+        $scheduleId = 1;
+        $resource = new FakeBookableResource(resourceId: 1, name: 'resource-1');
+        $resource->SetScheduleId($scheduleId);
+
+        // Three duplicate IDs — parsePositiveIntegerIds should reduce these to one.
+        $this->server->SetQueryString(WebServiceQueryStringKeys::SCHEDULE_ID, '1,1,1');
+
+        // The core assertion: LoadById must be called exactly once, not three times,
+        // proving de-duplication happened before the existence-check loop.
+        $this->scheduleRepository->expects($this->once())
+                                 ->method('LoadById')
+                                 ->with($scheduleId)
+                                 ->willReturn(new Schedule(id: $scheduleId, name: null, isDefault: false, weekdayStart: null, daysVisible: null));
+
+        $this->repository->expects($this->once())
+                         ->method('GetUserResourceList')
+                         ->willReturn([$resource]);
+
+        // Stub with an empty AttributeList so the response can be built; content is not under test here.
+        $this->attributeService->method('GetAttributes')->willReturn(new AttributeList());
+
+        $this->service->GetAll();
     }
 
     public function testReturns400ForNonIntegerScheduleId()

--- a/tests/fakes/FakeResource.php
+++ b/tests/fakes/FakeResource.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 class FakeBookableResource extends BookableResource
 {
-    public function __construct($id, $name = null)
+    public function __construct($resourceId, $name = null)
     {
-        $this->_resourceId = $id;
+        $this->_resourceId = $resourceId;
         $this->_name = $name;
     }
 


### PR DESCRIPTION
…dpoint

Add existence check for scheduleId filter values against the schedule repository before fetching resources. Returns 404 Not Found if any requested schedule ID does not exist, consistent with the existing behaviour of the groupId filter.

Injects IScheduleRepository into ResourcesWebService and converts the constructor to use constructor property promotion.

Updates docs and existing schedule filter tests to stub GetAll(), and adds testReturns404ForNonExistentScheduleId.