### PR TITLE
refactor(reservation): migrate PDF generation to pdfmake

### DIFF
--- a/Pages/Ajax/ReservationAttributesPrintPage.php
+++ b/Pages/Ajax/ReservationAttributesPrintPage.php
@@ -51,6 +51,7 @@ class ReservationAttributesPrintPage extends Page implements IReservationAttribu
         $userSession = ServiceLocator::GetServer()->GetUserSession();
         $this->presenter->PageLoad($userSession);
         $this->Set('ReadOnly', BooleanConverter::ConvertValue($this->GetIsReadOnly()));
+        $this->Set('CustomAttributeTypeDateTime', CustomAttributeTypes::DATETIME);
         $this->Display('Ajax/reservation/reservation_attributes_print.tpl');
     }
 

--- a/Pages/Reservation/ReservationPage.php
+++ b/Pages/Reservation/ReservationPage.php
@@ -219,6 +219,7 @@ abstract class ReservationPage extends Page implements IReservationPage
                 'weekly' => ['key' => 'Weekly', 'everyKey' => 'weeks'],
                 'monthly' => ['key' => 'Monthly', 'everyKey' => 'months'],
                 'yearly' => ['key' => 'Yearly', 'everyKey' => 'years'],
+                'custom' => ['key' => 'Custom', 'everyKey' => ''],
             ]
         );
         $this->Set(
@@ -233,6 +234,11 @@ abstract class ReservationPage extends Page implements IReservationPage
                 6 => 'DaySaturdayAbbr',
             ]
         );
+        $this->Set(
+            'DayNamesFull',
+            Resources::GetInstance()->GetDays('full')
+        );
+        $this->Set('CustomAttributeTypeCheckbox', CustomAttributeTypes::CHECKBOX);
 
         $this->Set('TitleRequired', $config->GetKey(ConfigKeys::RESERVATION_TITLE_REQUIRED, new BooleanConverter()));
         $this->Set('DescriptionRequired', $config->GetKey(ConfigKeys::RESERVATION_DESCRIPTION_REQUIRED, new BooleanConverter()));

--- a/Web/scripts/reservation-pdf.js
+++ b/Web/scripts/reservation-pdf.js
@@ -1,0 +1,490 @@
+(function () {
+  'use strict';
+
+  function getConfig() {
+    return window.ReservationPdfConfig || null;
+  }
+
+  function getCheckboxAttributeType(config) {
+    return Number(config.customAttributeTypeCheckbox);
+  }
+
+  function getSelectedResourceIds() {
+    const resourceIds = [];
+    const primaryResource = document.getElementById('primaryResourceId');
+    if (primaryResource) {
+      resourceIds.push(parseInt(primaryResource.value, 10));
+    }
+
+    document.querySelectorAll('#additionalResources .resourceId').forEach((element) => {
+      resourceIds.push(parseInt(element.value, 10));
+    });
+
+    return resourceIds.filter((resourceId) => !isNaN(resourceId));
+  }
+
+  async function loadCustomAttributesData() {
+    const uid = document.getElementById('userId');
+    const rn = document.getElementById('referenceNumber');
+    const ro = document.getElementById('reservation-box');
+    const params = new URLSearchParams({
+      uid: uid ? uid.value : '',
+      rn: rn ? rn.value : '',
+      ro: String(ro ? ro.classList.contains('readonly') : false),
+    });
+
+    getSelectedResourceIds().forEach((resourceId) => params.append('rid[]', resourceId));
+
+    try {
+      const response = await fetch('ajax/reservation_attributes_print.php?' + params.toString(), {
+        credentials: 'same-origin',
+        headers: { Accept: 'application/json' },
+      });
+
+      if (!response.ok) {
+        throw new Error('fetch failed');
+      }
+
+      return (await response.json()) || {};
+    } catch (error) {
+      console.warn('Error loading attributes', error);
+      return {};
+    }
+  }
+
+  function loadImageDataUrl(url) {
+    return new Promise((resolve) => {
+      const image = new Image();
+
+      image.crossOrigin = 'anonymous';
+      image.onload = function () {
+        try {
+          const canvas = document.createElement('canvas');
+          canvas.width = image.naturalWidth || image.width;
+          canvas.height = image.naturalHeight || image.height;
+          canvas.getContext('2d').drawImage(image, 0, 0);
+          resolve(canvas.toDataURL('image/png'));
+        } catch {
+          resolve(null);
+        }
+      };
+      image.onerror = function () {
+        resolve(null);
+      };
+      image.src = url;
+    });
+  }
+
+  function pdfCell(text, style, extra) {
+    const cell = {
+      text: text == null ? '' : String(text),
+    };
+
+    if (style) {
+      cell.style = style;
+    }
+
+    if (extra) {
+      Object.assign(cell, extra);
+    }
+
+    return cell;
+  }
+
+  function pdfSpanCell(text, style, span, extra) {
+    const cell = pdfCell(text, style, extra);
+    cell.colSpan = span;
+    return cell;
+  }
+
+  function pdfEmptyCells(count) {
+    return Array.from({ length: count }, function () {
+      return {};
+    });
+  }
+
+  function pdfTable(body, widths, headerRows) {
+    return {
+      margin: [0, 0, 0, 6],
+      layout: {
+        hLineWidth: function () {
+          return 0.4;
+        },
+        vLineWidth: function () {
+          return 0.4;
+        },
+        hLineColor: function () {
+          return '#c9d1dc';
+        },
+        vLineColor: function () {
+          return '#c9d1dc';
+        },
+        paddingLeft: function () {
+          return 6;
+        },
+        paddingRight: function () {
+          return 6;
+        },
+        paddingTop: function () {
+          return 4;
+        },
+        paddingBottom: function () {
+          return 4;
+        },
+      },
+      table: {
+        headerRows: headerRows || 0,
+        widths: widths,
+        body: body,
+      },
+    };
+  }
+
+  function buildHeader(config, logoDataUrl) {
+    const content = [];
+
+    content.push({
+      columns: [
+        logoDataUrl ? { image: logoDataUrl, fit: [64, 40], width: 64, margin: [0, 0, 10, 0] } : { text: '' },
+        {
+          width: '*',
+          stack: [
+            { text: config.appTitle, style: 'documentTitle' },
+            { text: config.reservationDetailsTitle, style: 'documentSubtitle' },
+          ],
+          margin: [0, 2, 0, 0],
+        },
+      ],
+      columnGap: 10,
+      margin: [0, 0, 0, 4],
+    });
+
+    content.push({
+      canvas: [
+        {
+          type: 'line',
+          x1: 0,
+          y1: 0,
+          x2: 530,
+          y2: 0,
+          lineWidth: 0.8,
+          lineColor: '#8b99ad',
+        },
+      ],
+      margin: [0, 0, 0, 8],
+    });
+
+    content.push({
+      text: config.referenceNumberLabel + ': ' + config.referenceNumber,
+      style: 'sectionHeading',
+      alignment: 'left',
+    });
+
+    if (config.showUserDetailsAndReservationDetails) {
+      content.push(
+        pdfTable(
+          [[pdfCell(config.userLabel, 'labelCell'), pdfCell(config.reservationUserName, 'valueCell')]],
+          [150, '*']
+        )
+      );
+    }
+
+    return content;
+  }
+
+  function buildDetails(config, durationText) {
+    const isCustomRepeat = config.isRecurring && config.isCustomRepeat;
+    const detailsBody = [
+      [
+        pdfCell(config.beginDateLabel, 'labelCell'),
+        pdfCell(config.beginDateValue, 'valueCell'),
+        pdfCell(config.endDateLabel, 'labelCell'),
+        pdfCell(config.endDateValue, 'valueCell'),
+      ],
+      [pdfCell(config.reservationLengthLabel, 'labelCell'), pdfSpanCell(durationText, 'valueCell', 3)].concat(
+        pdfEmptyCells(2)
+      ),
+      [pdfCell(config.repeatPromptLabel, 'labelCell')]
+        .concat(
+          config.isRecurring && !isCustomRepeat
+            ? [
+                pdfCell(config.repeatTypeLabel, 'valueCell'),
+                pdfCell(config.repeatInterval, 'valueCell'),
+                pdfCell(config.repeatEveryLabel, 'valueCell'),
+              ]
+            : [pdfSpanCell(config.repeatTypeLabel, 'valueCell', 3)]
+        )
+        .concat(config.isRecurring && !isCustomRepeat ? [] : pdfEmptyCells(2)),
+    ];
+
+    if (config.isRecurring) {
+      if (isCustomRepeat && config.repeatCustomDates.length > 0) {
+        detailsBody.push(
+          [
+            pdfCell(config.repeatOnLabel, 'labelCell'),
+            pdfSpanCell(config.repeatCustomDates.join(', '), 'valueCell', 3),
+          ].concat(pdfEmptyCells(2))
+        );
+      }
+
+      if (!isCustomRepeat && config.repeatMonthlyTypeLabel) {
+        detailsBody.push(
+          [pdfCell(config.typeLabel, 'labelCell'), pdfSpanCell(config.repeatMonthlyTypeLabel, 'valueCell', 3)].concat(
+            pdfEmptyCells(2)
+          )
+        );
+      }
+
+      if (!isCustomRepeat && config.repeatWeekdays.length > 0) {
+        detailsBody.push(
+          [
+            pdfCell(config.daysLabel, 'labelCell'),
+            pdfSpanCell(config.repeatWeekdays.join(', '), 'valueCell', 3),
+          ].concat(pdfEmptyCells(2))
+        );
+      }
+
+      if (!isCustomRepeat && config.repeatUntilDate) {
+        detailsBody.push(
+          [
+            pdfCell(config.repeatUntilPromptLabel, 'labelCell'),
+            pdfSpanCell(config.repeatUntilDate, 'valueCell', 3),
+          ].concat(pdfEmptyCells(2))
+        );
+      }
+    }
+
+    return pdfTable(detailsBody, [95, '*', 85, '*']);
+  }
+
+  function buildAttributes(config, attributesData) {
+    if (!attributesData || Object.keys(attributesData).length === 0) {
+      return null;
+    }
+
+    const attributesBody = [
+      [pdfSpanCell(config.additionalAttributesLabel, 'tableHeader', 2, { alignment: 'left' }), {}],
+    ];
+    const checkboxAttributeType = getCheckboxAttributeType(config);
+
+    Object.values(attributesData).forEach((attribute) => {
+      const attributeType = Number(attribute[0]);
+      const attributeValue = String(attribute[2] ?? '').toLowerCase();
+      const isChecked = attributeValue === '1' || attributeValue === 'true' || attributeValue === 'on';
+
+      if (attributeType === checkboxAttributeType) {
+        attributesBody.push([
+          pdfCell(attribute[1], 'labelCell'),
+          pdfCell(isChecked ? 'X' : '', 'valueCell', { alignment: 'left' }),
+        ]);
+        return;
+      }
+
+      attributesBody.push([pdfCell(attribute[1], 'labelCell'), pdfCell(attribute[2], 'valueCell')]);
+    });
+
+    return pdfTable(attributesBody, [220, '*'], 1);
+  }
+
+  function buildReservationPdfDefinition(config, logoDataUrl, attributesData) {
+    const durationElement = document.getElementsByClassName('durationText').item(0);
+    const durationText = durationElement ? durationElement.innerText : '';
+    const reminders = [];
+    const content = [];
+
+    Array.prototype.push.apply(content, buildHeader(config, logoDataUrl));
+    content.push(buildDetails(config, durationText));
+
+    const resourcesBody = [
+      [
+        pdfCell(config.resourcesHeaderLabel, 'tableHeader'),
+        pdfCell(config.requiresApprovalLabel, 'tableHeaderCenter'),
+        pdfCell(config.requiresCheckInNotificationLabel, 'tableHeaderCenter'),
+        pdfCell(config.releasedInLabel, 'tableHeaderCenter'),
+      ],
+    ];
+
+    config.resources.forEach(function (resource) {
+      resourcesBody.push([
+        pdfCell(resource.name, 'valueCell'),
+        pdfCell(resource.requiresApproval ? 'X' : '', 'centerCell'),
+        pdfCell(resource.requiresCheckIn ? 'X' : '', 'centerCell'),
+        pdfCell(resource.releasedIn, 'centerCell'),
+      ]);
+    });
+
+    content.push(pdfTable(resourcesBody, ['*', 72, 88, 72], 1));
+
+    if (config.showAccessories && config.accessories.length > 0) {
+      const accessoriesBody = [
+        [pdfCell(config.accessoriesHeaderLabel, 'tableHeader'), pdfCell(config.quantityLabel, 'tableHeaderCenter')],
+      ];
+
+      config.accessories.forEach(function (accessory) {
+        accessoriesBody.push([pdfCell(accessory.name, 'valueCell'), pdfCell(accessory.quantity, 'centerCell')]);
+      });
+
+      content.push(pdfTable(accessoriesBody, ['*', 75], 1));
+    }
+
+    if (config.showParticipants && config.participants.length > 0) {
+      const participantsBody = [
+        [pdfCell(config.participantsHeaderLabel, 'tableHeader'), pdfCell(config.emailLabel, 'tableHeader')],
+      ];
+
+      config.participants.forEach(function (participant) {
+        participantsBody.push([pdfCell(participant.fullName, 'valueCell'), pdfCell(participant.email, 'valueCell')]);
+      });
+
+      content.push(pdfTable(participantsBody, ['*', '*'], 1));
+    }
+
+    if (config.showInvitees && config.invitees.length > 0) {
+      const inviteesBody = [
+        [pdfCell(config.invitationListHeaderLabel, 'tableHeader'), pdfCell(config.emailLabel, 'tableHeader')],
+      ];
+
+      config.invitees.forEach(function (invitee) {
+        inviteesBody.push([pdfCell(invitee.fullName, 'valueCell'), pdfCell(invitee.email, 'valueCell')]);
+      });
+
+      content.push(pdfTable(inviteesBody, ['*', '*'], 1));
+    }
+
+    content.push(
+      pdfTable(
+        [
+          [pdfCell(config.reservationTitleLabel, 'tableHeader')],
+          [pdfCell(config.reservationTitle, 'valueCell')],
+          [pdfCell(config.reservationDescriptionLabel, 'tableHeader')],
+          [pdfCell(config.reservationDescription, 'valueCell')],
+        ],
+        ['*']
+      )
+    );
+
+    const attributesTable = buildAttributes(config, attributesData);
+    if (attributesTable) {
+      content.push(attributesTable);
+    }
+
+    if (config.remindersEnabled && config.reminders.length > 0) {
+      config.reminders.forEach(function (reminder) {
+        reminders.push([reminder.time, reminder.interval, reminder.text].join(' '));
+      });
+
+      content.push(
+        pdfTable(
+          [[pdfCell(config.sendReminderLabel, 'labelCell'), pdfCell(reminders.join('\n'), 'valueCell')]],
+          [150, '*']
+        )
+      );
+    }
+
+    if (config.attachments.length > 0) {
+      const attachmentsBody = [
+        [pdfCell(config.attachmentsLabel + ' (' + config.attachments.length + ')', 'tableHeader')],
+      ];
+
+      config.attachments.forEach(function (attachmentName) {
+        attachmentsBody.push([pdfCell(attachmentName, 'valueCell')]);
+      });
+
+      content.push(pdfTable(attachmentsBody, ['*']));
+    }
+
+    if (config.showTermsAcceptance) {
+      content.push(pdfTable([[pdfCell(config.acceptTermsLabel, 'labelCell'), pdfCell('X', 'centerCell')]], ['*', 40]));
+    }
+
+    return {
+      pageSize: 'A4',
+      pageMargins: [24, 24, 24, 24],
+      content: content,
+      defaultStyle: {
+        fontSize: 9,
+        lineHeight: 1.15,
+      },
+      styles: {
+        documentTitle: {
+          fontSize: 14,
+          bold: true,
+          color: '#1f2a3d',
+        },
+        documentSubtitle: {
+          fontSize: 9,
+          color: '#51627a',
+          margin: [0, 2, 0, 0],
+        },
+        sectionHeading: {
+          fontSize: 10,
+          bold: true,
+          color: '#2e3b4e',
+          margin: [0, 2, 0, 6],
+        },
+        labelCell: {
+          bold: true,
+          fillColor: '#f1f4f8',
+          color: '#2e3b4e',
+        },
+        valueCell: {
+          color: '#1f2a3d',
+        },
+        tableHeader: {
+          bold: true,
+          fillColor: '#dfe6ef',
+          color: '#1f2a3d',
+        },
+        tableHeaderCenter: {
+          bold: true,
+          alignment: 'center',
+          fillColor: '#dfe6ef',
+          color: '#1f2a3d',
+          fontSize: 8,
+        },
+        centerCell: {
+          alignment: 'center',
+          color: '#1f2a3d',
+        },
+      },
+      info: {
+        title: 'Reservation ' + config.referenceNumber,
+        author: config.appTitle,
+        subject: config.reservationDetailsTitle,
+        creator: 'pdfmake',
+      },
+    };
+  }
+
+  function init() {
+    const config = getConfig();
+    const pdfMakeInstance = window.pdfMake;
+
+    if (!config || !pdfMakeInstance) {
+      return;
+    }
+
+    document.querySelectorAll('.btnPDF').forEach(function (btn) {
+      btn.addEventListener('click', async function (e) {
+        e.preventDefault();
+        const previewWindow = window.open('', '_blank');
+        const attributesData = await loadCustomAttributesData();
+        const logoDataUrl = await loadImageDataUrl(config.logoUrl);
+        const documentDefinition = buildReservationPdfDefinition(config, logoDataUrl, attributesData);
+
+        if (previewWindow) {
+          pdfMakeInstance.createPdf(documentDefinition).open({}, previewWindow);
+          return;
+        }
+
+        pdfMakeInstance.createPdf(documentDefinition).open();
+      });
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/tpl/Ajax/reservation/reservation_attributes_print.tpl
+++ b/tpl/Ajax/reservation/reservation_attributes_print.tpl
@@ -1,14 +1,14 @@
 {ldelim}
 {if $Attributes|default:array()|count > 0}
 	{foreach from=$Attributes item=attribute name=attributes}
-		 "{$attribute->Id()}" :
-		[ "{$attribute->Type()}" ,
-		"{$attribute->Label()|default:''|escape:'json'}" ,
-		{if $attribute->Type() eq '5'}
-			"{if $attribute->Value() neq null}{formatdate date=$attribute->Value() key=embedded_datetime}{/if}" ] {if $smarty.foreach.attributes.last}{else},{/if}
-		{else}
-			"{$attribute->Value()|default:''|escape:'json'}" ] {if $smarty.foreach.attributes.last}{else},{/if}
+		{assign var='attributeValue' value=$attribute->Value()|default:''}
+		{if $attribute->Type() eq $CustomAttributeTypeDateTime && $attribute->Value() neq null}
+			{capture assign='attributeValue'}{formatdate date=$attribute->Value() key=general_datetime}{/capture}
 		{/if}
+		{$attribute->Id()|cat:''|json_encode} :
+		[ {$attribute->Type()|json_encode} ,
+		{$attribute->Label()|default:''|json_encode} ,
+		{$attributeValue|json_encode} ] {if $smarty.foreach.attributes.last}{else},{/if}
 	{/foreach}
 {/if}
 {rdelim}

--- a/tpl/Reservation/create.tpl
+++ b/tpl/Reservation/create.tpl
@@ -538,9 +538,11 @@
 {jsfile src="force-numeric.js"}
 {jsfile src="reservation-reminder.js"}
 {jsfile src="ajax-helpers.js"}
+{jsfile src="reservation-pdf.js"}
 {vendor_js src="jqtree/1.8.11/js/tree.jquery.js"}
 
 {include file="Reservation/pdf_libraries.tpl"}
+{include file="Reservation/pdf.tpl"}
 <script type="text/javascript">
     $(function() {
         var scopeOptions = {
@@ -640,10 +642,6 @@
         });
 
         $('#userName').bindUserDetails();
-
-        // jsPDF
-        {include file="Reservation/pdf.tpl"}
-        //
 
         translateTooltips();
 

--- a/tpl/Reservation/pdf.tpl
+++ b/tpl/Reservation/pdf.tpl
@@ -1,299 +1,125 @@
-var allAttributes;
+<script type="text/javascript">
+	window.ReservationPdfConfig = {
+			appTitle: "{$AppTitle|escape:'javascript'}",
+			reservationDetailsTitle: "{translate key=ReservationDetails|capitalize|escape:'javascript'}",
+			referenceNumberLabel: "{translate key=ReferenceNumber|escape:'javascript'}",
+			referenceNumber: "{$ReferenceNumber|escape:'javascript'}",
+			userLabel: "{translate key='User'|escape:'javascript'}",
+			reservationUserName: "{$ReservationUserName|unescape:'html'|escape:'javascript'}",
+			showUserDetailsAndReservationDetails: {if $ShowUserDetails && $ShowReservationDetails}true{else}false{/if},
 
-function GetSelectedResourceIds() {
-	var resourceIds = [parseInt($('#primaryResourceId').val())];
-	$('#additionalResources').find('.resourceId').each(function (i, element) {
-		resourceIds.push(parseInt($(element).val()));
-	});
-	return resourceIds;
-}
+			beginDateLabel: "{translate key='BeginDate'|escape:'javascript'}",
+			beginDateValue: "{formatdate date=$StartDate key=dashboard|escape:'javascript'}",
+			endDateLabel: "{translate key='EndDate'|escape:'javascript'}",
+			endDateValue: "{formatdate date=$EndDate key=dashboard|escape:'javascript'}",
+			reservationLengthLabel: "{translate key=ReservationLength|escape:'javascript'}",
+			repeatPromptLabel: "{translate key=RepeatPrompt|escape:'javascript'}",
+			isRecurring: {if $IsRecurring}true{else}false{/if},
+			isCustomRepeat: {if $RepeatType eq 'custom'}true{else}false{/if},
+			repeatTypeLabel: "{translate key=$RepeatOptions[$RepeatType]['key']|escape:'javascript'}",
+			repeatInterval: "{$RepeatInterval|escape:'javascript'}",
+			repeatEveryLabel: "{if $RepeatType neq 'custom'}{translate key=$RepeatOptions[$RepeatType]['everyKey']|escape:'javascript'}{/if}",
+			repeatOnLabel: "{translate key=RepeatOn|escape:'javascript'}",
+			typeLabel: "{translate key=Type|escape:'javascript'}",
+			repeatMonthlyTypeLabel: "{if $RepeatMonthlyType neq ''}{if $RepeatMonthlyType == 'dayOfMonth'}{translate key=repeatDayOfMonth|escape:'javascript'}{else}{translate key=repeatDayOfWeek|escape:'javascript'}{/if}{/if}",
+			daysLabel: "{translate key=RepeatDaysPrompt|capitalize|escape:'javascript'}",
+			repeatWeekdays: [{foreach from=$RepeatWeekdays item=day name=repeatDaysLoop}"{$DayNamesFull[$day]|escape:'javascript'}"{if !$smarty.foreach.repeatDaysLoop.last},{/if}{/foreach}],
+			repeatCustomDates: [{foreach from=$CustomRepeatDates item=date name=repeatCustomDatesLoop}"{formatdate date=$date key=schedule_daily timezone=$Timezone|escape:'javascript'}"{if !$smarty.foreach.repeatCustomDatesLoop.last},{/if}{/foreach}],
+			repeatUntilPromptLabel: "{translate key=RepeatUntilPrompt|escape:'javascript'}",
+			repeatUntilDate: "{formatdate date=$RepeatTerminationDate key=dashboard|escape:'javascript'}",
 
-function LoadCustomAttributesData() {
-	var url = 'ajax/reservation_attributes_print.php?uid=' + $('#userId').val() + '&rn=' + $('#referenceNumber').val() + '&ro=' + $('#reservation-box').hasClass('readonly');
+			additionalAttributesLabel: "{translate key='AdditionalAttributes'|escape:'javascript'}",
+			customAttributeTypeCheckbox: {$CustomAttributeTypeCheckbox|default:0|escape:'javascript'},
 
-	var resourceIds = GetSelectedResourceIds();
-	_.each(resourceIds, function (n) {
-		url += '&rid[]=' + n;
-	});
+			resourcesHeaderLabel: "{translate key='Resources'|escape:'javascript'}",
+			requiresApprovalLabel: "{translate key='RequiresApproval'|escape:'javascript'}",
+			requiresCheckInNotificationLabel: "{translate key='RequiresCheckInNotification'|escape:'javascript'}",
+			releasedInLabel: "{translate key='ReleasedIn'|escape:'javascript'} ({translate key='minutes'|escape:'javascript'})",
+			resources: [{
+						name: "{$Resource->Name|escape:'javascript'}",
+						requiresApproval: {if $Resource->GetRequiresApproval()}true{else}false{/if},
+						requiresCheckIn: {if $Resource->IsCheckInEnabled()}true{else}false{/if},
+						releasedIn: "{if $Resource->IsAutoReleased()}{$Resource->GetAutoReleaseMinutes()|escape:'javascript'}{else}{/if}"
+						}{foreach from=$AvailableResources item=resource}
+							{if is_array($AdditionalResourceIds) && in_array($resource->Id, $AdditionalResourceIds)},
+								{
+									name: "{$resource->Name|escape:'javascript'}",
+									requiresApproval: {if $resource->GetRequiresApproval()}true{else}false{/if},
+									requiresCheckIn: {if $resource->IsCheckInEnabled()}true{else}false{/if},
+									releasedIn: "{if $resource->IsAutoReleased()}{$resource->GetAutoReleaseMinutes()|escape:'javascript'}{else} - {/if}"
+								}{/if}
+							{/foreach}
+						],
 
-	return $.ajax({
-        global: false,
-        url: url,
-        dataType: 'json',
-	    success: function (data) {
-            allAttributes = data;
-        }
-    });
-}
+						showAccessories: {if $ShowReservationDetails && is_array($Accessories) && $Accessories|default:array()|count > 0}true{else}false{/if},
+						accessoriesHeaderLabel: "{translate key='Accessories'|escape:'javascript'}",
+						quantityLabel: "{translate key='Quantity'|escape:'javascript'}",
+						accessories: [
+								{foreach from=$Accessories item=accessory name=accessoriesLoop}
+									{
+										name: "{$accessory->Name|escape:'javascript'}",
+										quantity: "{$accessory->QuantityReserved|escape:'javascript'}"
+										}{if !$smarty.foreach.accessoriesLoop.last},{/if}
+									{/foreach}
+								],
 
-LoadCustomAttributesData();
+								showParticipants: {if $ShowReservationDetails && $ShowParticipation && $Participants|default:array()|count > 0}true{else}false{/if},
+								participantsHeaderLabel: "{translate key='Participants'|escape:'javascript'}",
+								emailLabel: "{translate key='Email'|escape:'javascript'}",
+								participants: [
+									{foreach from=$Participants item=user name=participantsLoop}
+										{
+											fullName: "{$user->FullName|unescape:'html'|escape:'javascript'}",
+											email: "{$user->Email|escape:'javascript'}"
+											}{if !$smarty.foreach.participantsLoop.last},{/if}
+										{/foreach}
+									],
 
-$('.btnPDF').click(function (e) {
-	e.preventDefault();
+									showInvitees: {if $ShowReservationDetails && $ShowParticipation && $Invitees|default:array()|count > 0}true{else}false{/if},
+									invitationListHeaderLabel: "{translate key='InvitationList'|escape:'javascript'}",
+									invitees: [
+										{foreach from=$Invitees item=user name=inviteesLoop}
+											{
+												fullName: "{$user->FullName|unescape:'html'|escape:'javascript'}",
+												email: "{$user->Email|escape:'javascript'}"
+												}{if !$smarty.foreach.inviteesLoop.last},{/if}
+											{/foreach}
+										],
 
-	LoadCustomAttributesData().done(function() {
-		window.jsPDF = window.jspdf.jsPDF;
+										reservationTitleLabel: "{translate key='ReservationTitle'|escape:'javascript'}",
+										reservationTitle: "{if isset($ReservationTitle)}{$ReservationTitle|unescape:'html'|escape:'javascript'}{/if}",
+										reservationDescriptionLabel: "{translate key='ReservationDescription'|escape:'javascript'}",
+										reservationDescription: "{if isset($Description)}{$Description|unescape:'html'|escape:'javascript'}{/if}",
 
-		var pdfDocument = new jsPDF();
+										remindersEnabled: {if $RemindersEnabled}true{else}false{/if},
+										sendReminderLabel: "{translate key='SendReminder'|escape:'javascript'}",
+										reminders: [
+											{if $ReminderTimeStart neq ''}
+												{
+													time: "{$ReminderTimeStart|escape:'javascript'}",
+													interval: "{translate key=$ReminderIntervalStart|escape:'javascript'}",
+													text: "{translate key=ReminderBeforeStart|escape:'javascript'}"
+													}{if $ReminderTimeEnd neq ''},{/if}
+												{/if}
+												{if $ReminderTimeEnd neq ''}
+													{
+														time: "{$ReminderTimeEnd|escape:'javascript'}",
+														interval: "{translate key=$ReminderIntervalEnd|escape:'javascript'}",
+														text: "{translate key=ReminderBeforeEnd|escape:'javascript'}"
+													}
+												{/if}
+											],
 
-		var logo = new Image();
-		logo.src = '{$ScriptUrl}/img/{$LogoUrl}';
+											attachmentsLabel: "{translate key=Attachments|escape:'javascript'}",
+											attachments: [
+												{foreach from=$Attachments item=attachment name=attachmentsLoop}
+													"{$attachment->FileName()|escape:'javascript'}"{if !$smarty.foreach.attachmentsLoop.last},{/if}
+												{/foreach}
+											],
 
-		pdfDocument.autoTable({
-		  columnStyles: { title: { halign: 'center'  , valign: 'center', fontSize: 14}},
-		  theme: 'plain',
-		  body: [
-			{ logo: '', title: '- {$AppTitle|escape:'javascript'} - '},
-			{ blank: ''},
-		  ],
-		  didDrawCell: data => {
-			if (data.section == 'body' && data.column.index == 0 && data.row.index == 0){
-				pdfDocument.addImage(logo, data.cell.x, data.cell.y + 1, 0, 17);
-			}
-		  }
-		});
+											showTermsAcceptance: {if $Terms != null && $TermsAccepted}true{else}false{/if},
+											acceptTermsLabel: "{translate key=IAccept|escape:'javascript'} {translate key=TheTermsOfService|escape:'javascript'}",
 
-		pdfDocument.autoTable({
-		  styles: { halign: 'center'  , valign: 'center', fontSize: 12},
-		  theme: 'plain',
-		  body: [
-			['{translate key=ReservationDetails|capitalize}'],
-		  ],
-		});
-
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  columnStyles: { reftitle: { fontStyle: 'bold'}},
-		  theme: 'plain',
-			body: [
-			{ reftitle: '{translate key=ReferenceNumber}', refnumb: '{$ReferenceNumber}'},
-		  ],
-		});
-
-		{if $ShowUserDetails && $ShowReservationDetails}
-			pdfDocument.autoTable({
-			  styles: { lineWidth: 0.02},
-			  theme: 'plain',
-			  body: [
-				{ user: '{$ReservationUserName|unescape:'html'|escape:'javascript'}'},
-			  ],
-			  columns: [
-				{ header: '{translate key='User'}', dataKey: 'user' },
-			  ],
-			});
-		{/if}
-
-		var durationText = document.getElementsByClassName('durationText').item(0).innerText;
-		var daysText = "{translate key=days}";
-		daysText = daysText.charAt(0).toUpperCase() + daysText.slice(1);
-
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  theme: 'plain',
-			body: [
-			[{ content: '{translate key='BeginDate'}', styles: { fontStyle: 'bold'}},
-			 { content: '{formatdate date=$StartDate key=embedded_datetime}'},
-			 { content: '{translate key='EndDate'}', styles: { fontStyle: 'bold'}},
-			 { content: '{formatdate date=$EndDate key=embedded_datetime}'},
-			],
-			[{ content: '{translate key=ReservationLength}', styles: { fontStyle: 'bold'}},
-			 { colSpan: 3, content: durationText},
-			],
-			[{ content: '{translate key=RepeatPrompt}', styles: { fontStyle: 'bold'}},
-			{if $IsRecurring}
-			 { content: '{translate key=$RepeatOptions[$RepeatType]['key']}'},
-			 { content: '{$RepeatInterval}'},
-			 { content: '{translate key=$RepeatOptions[$RepeatType]['everyKey']}'},
-			{else}
-			 { colSpan: 3, content: '{translate key=$RepeatOptions[$RepeatType]['key']}'},
-			{/if}
-			],
-			{if $IsRecurring}
-				{if $RepeatMonthlyType neq ''}
-					[{ content: '{translate key=Type}', styles: { fontStyle: 'bold'}},
-					{if $RepeatMonthlyType == 'dayOfMonth'}
-						{ colSpan: 3, content: '{translate key=repeatDayOfMonth}'},
-					{else}
-						{ colSpan: 3, content: '{translate key=repeatDayOfWeek}'},
-					{/if}
-					],
-				{/if}
-				{if (is_array($RepeatWeekdays) && count($RepeatWeekdays) gt 0)}
-					[{ content: daysText, styles: { fontStyle: 'bold'}},
-					{ colSpan: 3, content: '{foreach from=$RepeatWeekdays item=day name=weekdaysLoop}{if $smarty.foreach.weekdaysLoop.last}{translate key=$DayNames[$day]}{else}{translate key=$DayNames[$day]},{/if} {/foreach}'},
-					],
-				{/if}
-				[{ content: '{{translate key=RepeatUntilPrompt}|escape:'javascript'}', styles: { fontStyle: 'bold'}},
-				 { colSpan: 3, content: '{formatdate date=$RepeatTerminationDate}'},
-				],
-			{/if}
-			],
-		});
-
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  columnStyles: { 1: { cellWidth: 16}, 2: { cellWidth: 18},3: { cellWidth: 20}},
-		  theme: 'plain',
-			body: [
-			[{ content: '{translate key="Resources"}', styles: { fontStyle: 'bold'}},
-			 { content: '{translate key="RequiresApproval"}', styles: { fontStyle: 'bold', fontSize: 7, halign: 'center'}},
-			 { content: '{translate key="RequiresCheckInNotification"}', styles: { fontStyle: 'bold', fontSize: 7, halign: 'center'}},
-			 { content: '{translate key="ReleasedIn"} ({translate key="minutes"})', styles: { fontStyle: 'bold', fontSize: 7, halign: 'center'}},
-			],
-			[{ content: '{$Resource->Name|escape:'javascript'}'},
-			 { content: '{if $Resource->GetRequiresApproval()}X{/if}', styles: { halign: 'center'}},
-			 { content: '{if $Resource->IsCheckInEnabled()}X{/if}', styles: { halign: 'center'}},
-			 { content: '{if $Resource->IsAutoReleased()}{$Resource->GetAutoReleaseMinutes()}{/if}', styles: { halign: 'center'}},
-			],
-			{foreach from=$AvailableResources item=resource}
-				{if is_array($AdditionalResourceIds) && in_array($resource->Id, $AdditionalResourceIds)}
-					[{ content: '{$resource->Name|escape:'javascript'}'},
-					 { content: '{if $resource->GetRequiresApproval()}X{/if}', styles: { fontStyle: 'bold', halign: 'center'}},
-					 { content: '{if $resource->IsCheckInEnabled()}X{/if}', styles: { fontStyle: 'bold', halign: 'center'}},
-					 { content: '{if $resource->IsAutoReleased()}{$resource->GetAutoReleaseMinutes()}{else} - {/if}', styles: { halign: 'center'}},
-					],
-				{/if}
-			{/foreach}
-			],
-		});
-
-		{if $ShowReservationDetails && is_array($Accessories) && $Accessories|default:array()|count > 0}
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  columnStyles: { 1: { cellWidth: 18}},
-		  theme: 'plain',
-			body: [
-			[{ content: '{translate key="Accessories"}', styles: { fontStyle: 'bold'}},
-			 { content: '{translate key="Quantity"}', styles: { fontStyle: 'bold', fontSize: 7, halign: 'center'}},
-			],
-			{foreach from=$Accessories item=accessory}
-				[{ content: '{$accessory->Name|escape:'javascript'}'},
-				 { content: '{$accessory->QuantityReserved}', styles: { halign: 'center'}},
-				],
-			{/foreach}
-			]
-		});
-		{/if}
-
-		{if $ShowReservationDetails && $ShowParticipation && $Participants|default:array()|count > 0}
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  columnStyles: { 1: { cellWidth: 80}},
-		  theme: 'plain',
-			body: [
-			[{ content: '{translate key="Participants"}', styles: { fontStyle: 'bold'}},
-			 { content: '{translate key="Email"}', styles: { fontStyle: 'bold', fontSize: 7}},
-			],
-			{foreach from=$Participants item=user}
-				[{ content: '{$user->FullName|unescape:'html'|escape:'javascript'}'},
-				 { content: '{$user->Email}'},
-				],
-			{/foreach}
-			]
-		});
-		{/if}
-
-		{if $ShowReservationDetails && $ShowParticipation && $Invitees|default:array()|count > 0}
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  columnStyles: { 1: { cellWidth: 80}},
-		  theme: 'plain',
-			body: [
-			[{ content: '{translate key="InvitationList"}', styles: { fontStyle: 'bold'}},
-			 { content: '{translate key="Email"}', styles: { fontStyle: 'bold', fontSize: 7}},
-			],
-			{foreach from=$Invitees item=user}
-				[{ content: '{$user->FullName|unescape:'html'|escape:'javascript'}'},
-				 { content: '{$user->Email}'},
-				],
-			{/foreach}
-			]
-		});
-		{/if}
-
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  columnStyles: { 1: { cellWidth: 80}},
-		  theme: 'plain',
-			body: [
-			[{ content: '{translate key="ReservationTitle"}', styles: { fontStyle: 'bold'}},
-			],
-			[{ content: '{if isset($ReservationTitle)}{$ReservationTitle|unescape:'html'|escape:'javascript'}{/if}'},
-			],
-			[{ content: '{translate key="ReservationDescription"}', styles: { fontStyle: 'bold'}},
-			],
-			[{ content: '{if isset($Description)}{$Description|unescape:'html'|escape:'javascript'}{/if}'},
-			],
-			]
-		});
-
-		var bodyAttributes = [[{ content: '{translate key="AdditionalAttributes"}', styles: { fontStyle: 'bold'}}, { content: ''}]];
-
-		if (allAttributes && Object.keys(allAttributes).length != 0) {
-			for (var obj in allAttributes) {
-				if (allAttributes[obj][0] == "4") {
-					if (allAttributes[obj][2] == "1") {
-						bodyAttributes.push([{ content: allAttributes[obj][1], styles: { fontStyle: 'bold'}}, { content: 'X', styles: { fontStyle: 'bold', halign: 'center'}}]);
-					}
-				} else {
-					bodyAttributes.push([{ colSpan: 2, content: allAttributes[obj][1], styles: { fontStyle: 'bold'}}]);
-					bodyAttributes.push([{ colSpan: 2, content: allAttributes[obj][2]}]);
-				}
-			}
-			pdfDocument.autoTable({
-				styles: { lineWidth: 0.02},
-				columnStyles: { 1: { cellWidth: 10}},
-				theme: 'plain',
-				body: bodyAttributes,
-			});
-		}
-
-		{if $RemindersEnabled}
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  theme: 'plain',
-			body: [
-			[{ content: '{translate key="SendReminder"}', styles: { fontStyle: 'bold'}},
-			{if $ReminderTimeStart neq ''}
-			{assign var="ReminderBeforeStart" value="{translate key=ReminderBeforeStart}"}
-			{ content: '{$ReminderTimeStart} {translate key=$ReminderIntervalStart} {$ReminderBeforeStart|escape:'javascript'}'},
-			{/if}
-			{if $ReminderTimeEnd neq ''}
-			{assign var="ReminderBeforeEnd" value="{translate key=ReminderBeforeEnd}"}
-			{ content: '{$ReminderTimeEnd} {translate key=$ReminderIntervalEnd} {$ReminderBeforeEnd|escape:'javascript'}'},
-			{/if}
-			],
-			]
-		});
-		{/if}
-
-		{if $Attachments|default:array()|count > 0}
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  theme: 'plain',
-			body: [
-			[{ content: '{{translate key=Attachments}|escape:'javascript'} ({$Attachments|default:array()|count})', styles: { fontStyle: 'bold'}},
-			],
-			{foreach from=$Attachments item=attachment}
-			[{ content: '{$attachment->FileName()|escape:'javascript'}'},
-			],
-			{/foreach}
-			]
-		});
-		{/if}
-
-		{if $Terms != null & $TermsAccepted}
-		pdfDocument.autoTable({
-		  styles: { lineWidth: 0.02},
-		  columnStyles: { 1: { cellWidth: 10}},
-		  theme: 'plain',
-			body: [
-			[{ content: "{translate key=IAccept|escape:'javascript'} {translate key=TheTermsOfService}", styles: { fontStyle: 'bold'}},
-			 { content: 'X', styles: { fontStyle: 'bold', halign: 'center'}},
-			],
-			]
-		});
-		{/if}
-		window.open(URL.createObjectURL(pdfDocument.output("blob")))
-	});
-});
+											logoUrl: "{$ScriptUrl|escape:'javascript'}/img/{$LogoUrl|escape:'javascript'}"
+										};
+</script>

--- a/tpl/Reservation/pdf_libraries.tpl
+++ b/tpl/Reservation/pdf_libraries.tpl
@@ -1,2 +1,2 @@
-{vendor_js src="jspdf/2.3.0/js/jspdf.umd.min.js"}
-{vendor_js src="jspdf-autotable/3.5.14/js/jspdf.plugin.autotable.min.js"}
+{vendor_js src="pdfmake/0.1.53/js/pdfmake.min.js"}
+{vendor_js src="pdfmake/0.1.53/js/vfs_fonts.js"}

--- a/tpl/Reservation/view.tpl
+++ b/tpl/Reservation/view.tpl
@@ -377,9 +377,11 @@
 {jsfile src="force-numeric.js"}
 {jsfile src="reservation-reminder.js"}
 {jsfile src="ajax-helpers.js"}
+{jsfile src="reservation-pdf.js"}
 {vendor_js src="jqtree/1.8.11/js/tree.jquery.js"}
 
 {include file="Reservation/pdf_libraries.tpl"}
+{include file="Reservation/pdf.tpl"}
 
 <script type="text/javascript">
     $(document).ready(function() {
@@ -430,9 +432,6 @@
             return false;
         });
 
-        // jsPDF
-        {include file="Reservation/pdf.tpl"}
-        //
     });
 </script>
 {include file='globalfooter.tpl'}


### PR DESCRIPTION
…ery with pdfmake and native browser APIs for generating reservation PDFs

- Remove global `allAttributes` variable; attribute data now flows
  as an explicit parameter through LoadCustomAttributesData() →
  BuildReservationPdfDefinition()
- Replace $.ajax and jQuery event binding with async/await, fetch,
  URLSearchParams and addEventListener
- Extract section builder functions: buildHeader(), buildDetails(),
  buildAttributes()
- Fix invalid Smarty modifier escape:'json' → |json_encode
- Replace magic number '5' (DATETIME) and 4 (CHECKBOX)
- Expose DayNamesFull to templates for repeat weekday names in PDF
- The use of the embedded_datetime format is removed and schedule_daily and dashboard are used
- An error is corrected that the dates were not displayed correctly when the repeatability was of the custom type
After:
<img width="722" height="146" alt="Captura de pantalla 2026-04-11 111719" src="https://github.com/user-attachments/assets/8aa12758-ac96-4056-bf62-753bcdd21805" />

Before:
<img width="749" height="123" alt="Captura de pantalla 2026-04-11 111751" src="https://github.com/user-attachments/assets/6502444e-b84b-4df4-9daa-ed0076e0375d" />
