### PR TITLE
docs: Document maintenance mode

### DIFF
--- a/docs/source/ADVANCED-CONFIGURATION.rst
+++ b/docs/source/ADVANCED-CONFIGURATION.rst
@@ -131,6 +131,34 @@ LibreBooking ignores the custom version and logs an error.
 
      git describe --tags --long > config/custom-version.txt
 
+Maintenance Mode
+----------------
+
+LibreBooking can be placed into maintenance mode by creating a file named
+``maint.txt`` in the root directory of the installation.
+
+When ``<INSTALL_DIR>/maint.txt`` exists, normal page rendering is replaced
+with a maintenance notice. This is useful during upgrades, database
+migrations, or other planned maintenance windows where users should not use
+the application.
+
+**Enable maintenance mode**
+
+  .. code-block:: bash
+
+     touch maint.txt
+
+**Disable maintenance mode**
+
+  .. code-block:: bash
+
+     rm maint.txt
+
+The contents of ``maint.txt`` are not used. LibreBooking only checks whether
+the file exists. The maintenance notice text comes from the
+``MaintenanceNotice`` language string and can be customized with
+``config/lang-overrides.php``.
+
 Application Advanced Settings
 -----------------------------
 

--- a/docs/source/CONFIGURATION.rst
+++ b/docs/source/CONFIGURATION.rst
@@ -9,6 +9,7 @@ Basic Configuration
 For new installations and common settings, see :doc:`BASIC-CONFIGURATION`.
 
 This covers:
+
 - Essential settings to get started
 - Database configuration
 - Email setup
@@ -22,10 +23,12 @@ Advanced Configuration
 For detailed configuration and advanced features, see :doc:`ADVANCED-CONFIGURATION`.
 
 This covers:
+
 - All configuration options in detail
 - Advanced email and logging settings
 - Schedule and reservation behavior
 - Security headers and authentication providers
+- Maintenance mode
 - API configuration
 - Plugin system
 - Performance tuning


### PR DESCRIPTION
Add maintenance mode documentation to the advanced configuration guide, including how to enable and disable it with the root-level maint.txt file.

Also fix the configuration overview bullet list formatting so the lists render correctly in the generated documentation.

Assisted-by: OpenAI Codex (GPT-5)