### PR TITLE
docs: add AI attribution policy and fix target branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,39 @@ Add a new schedules endpoint which allows getting the resources of a schedule.
 Closes: #2222
 ```
 
+### AI Attribution
+
+When an AI coding assistant contributed meaningfully to a commit (writing or
+significantly modifying code, suggesting the fix, generating tests, etc.),
+add an `Assisted-by` trailer to the commit message footer:
+
+```text
+Assisted-by: <AgentName>:<ModelVersion>
+```
+
+**Rules**:
+
+- Place `Assisted-by` in the commit footer, alongside any `Closes:` or
+  `BREAKING CHANGE:` lines
+- Use the agent name and model version that did the work (e.g.
+  `Claude:claude-sonnet-4-6`)
+- Omit the tag when the AI contribution was trivial (e.g. a one-word
+  suggestion accepted unchanged, or only autocomplete)
+- Do **not** add `Assisted-by` for purely mechanical operations (running
+  linters, reformatting, applying `composer fix`)
+
+**Example**:
+
+```text
+fix(reservations): correct overlap check for multi-day bookings
+
+The start-of-day boundary was calculated in UTC rather than the
+schedule's local timezone, causing false conflicts.
+
+Closes: #1234
+Assisted-by: Claude:claude-sonnet-4-6
+```
+
 ### Pull Request Guidelines
 
 1. **Target branch**: PRs should target `develop` (not main/master)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ about.
 
 ## Getting Started
 
-* *Ensure you have an up-to-date `main` branch:** Fork the repository and make
-sure your `main` branch is synced with the upstream project before creating
+* **Ensure you have an up-to-date `develop` branch:** Fork the repository and make
+sure your `develop` branch is synced with the upstream project before creating
 your feature branch.
 * **Create a new branch** for your changes: `git checkout -b feature/your-feature-name` or `git checkout -b bugfix/issue-number-and-fix`.
 * **Make your changes** and **add tests** if applicable.
@@ -58,7 +58,7 @@ your feature branch.
 * **Ensure your code lints**
 * **Commit your changes** with a clear and descriptive commit message.
 * **Push your branch** to your fork: `git push origin feature/your-feature-name`.
-* **Open a Pull Request** against our `main` branch.
+* **Open a Pull Request** against our `develop` branch.
 
 ## Reporting Bugs
 
@@ -126,6 +126,32 @@ feat(API): Add new schedules endpoint
 Add a new schedules endpoint which allows getting the resources of a schedule.
 
 Closes: #2222
+```
+
+### AI Attribution
+
+When an AI coding assistant contributed meaningfully to a commit (writing or
+significantly modifying code, suggesting the fix, generating tests, etc.),
+add an `Assisted-by` trailer to the commit footer:
+
+```text
+Assisted-by: <AgentName>:<ModelVersion>
+```
+
+Place it alongside any `Closes:` or `BREAKING CHANGE:` lines. Omit it when
+the AI contribution was trivial (e.g. a one-word suggestion or only
+autocomplete) or purely mechanical (running linters, reformatting).
+
+Example:
+
+```text
+fix(reservations): correct overlap check for multi-day bookings
+
+The start-of-day boundary was calculated in UTC rather than the
+schedule's local timezone, causing false conflicts.
+
+Closes: #1234
+Assisted-by: Claude:claude-sonnet-4-6
 ```
 
 ### Revert


### PR DESCRIPTION
Add an Assisted-by trailer convention (inspired by the Linux kernel coding-assistants policy [1]) to both AGENTS.md and CONTRIBUTING.md so that AI agents and human contributors know when and how to attribute AI assistance in commit messages.

Also correct the PR target branch in CONTRIBUTING.md from `main` to `develop`, consistent with the rest of the project documentation.

1. https://docs.kernel.org/process/coding-assistants.html