### PR TITLE
Fix for Issue #1352: 404 Not found when clicking on the plus icon

### DIFF
--- a/tpl/Schedule/schedule-week-condensed.tpl
+++ b/tpl/Schedule/schedule-week-condensed.tpl
@@ -128,7 +128,11 @@
                                         <div class="reservable clickres" ref="{$href}&rd={formatdate date=$date key=url}"
                                             data-href="{$href}" data-start="{$date->Format('Y-m-d H:i:s')|escape:url}"
                                             data-end="{$date->Format('Y-m-d H:i:s')|escape:url}">
-                                            <i class="bi bi-plus-circle-fill"></i> {translate key=CreateReservation}
+                                            <i class="bi bi-plus-circle-fill" ref="{$href}&rd={formatdate date=$date key=url}"
+                                                data-href="{$href}" data-start="{$date->Format('Y-m-d H:i:s')|escape:url}"
+                                                data-end="{$date->Format('Y-m-d H:i:s')|escape:url}">
+                                            </i> 
+                                            {translate key=CreateReservation}
                                             <input type="hidden" class="href" value="{$href}" />
                                         </div>
                                     {/if}


### PR DESCRIPTION
Clicking on the plus icon next to "Create Reservation" in Schedule -> Bookings -> 'condensed week schedule display' led to a 404 Not found. With this fix a click on the plus icon has the same behaviour as a click on "Create Reservation", opening the "New Reservation" page.