### PR TITLE
fix: modify .htaccess redirect rule / remove R=301 from htaccess redirect to prevent port leakage behind reverse proxy

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -7,7 +7,7 @@ RewriteEngine On
 
 # Redirect requests that are not already under /Web to /Web.
 RewriteCond %{REQUEST_URI} !^/Web(/|$)
-RewriteRule ^(.*)$ /Web/$1 [R=301,L]
+RewriteRule ^(.*)$ /Web/$1 [L]
 
 #Header Set Access-Control-Allow-Origin "*"
 #Header add Access-Control-Allow-Headers "origin, x-requested-with, content-type"


### PR DESCRIPTION
Change redirect rule to use [L] flag instead of [R=301].

The R=301 flag causes Apache to build an absolute URL including the port, breaking setups behind a reverse proxy.