### PR TITLE
style: add missing block data-bs-theme for cake_blue theme

### DIFF
--- a/Web/css/librebooking.css
+++ b/Web/css/librebooking.css
@@ -47,6 +47,13 @@
   --text-color-btn: #ffffff;
 }
 
+[data-bs-theme='cake_blue'] {
+  --primary: #003873;
+  --primary-hover: #002042;
+  --primary-disabled: #909090;
+  --text-color-btn: #ffffff;
+}
+
 [data-bs-theme='orange'] {
   --primary: #b05e2a;
   --primary-hover: color-mix(in oklab, var(--primary) 80%, black);


### PR DESCRIPTION
CSS theme "Cake blue" can be selected in Application Configuration / Settings, however the CSS rule for this theme has been missing.

Fixes invisible primary buttons (e.g. Update-Button in Application Configuration)

Suggests a dark blue ocean colour for primary elements