### PR TITLE
Refactor(schedule): use of color-mix, legacy cleanup, and visual impr…

### DIFF
--- a/Web/css/librebooking.css
+++ b/Web/css/librebooking.css
@@ -13,43 +13,43 @@
 
 [data-bs-theme='default'] {
   --primary: #669999;
-  --primary-hover: #527a7a;
-  --primary-disabled: #85adad;
+  --primary-hover: color-mix(in oklab, var(--primary) 80%, black);
+  --primary-disabled: color-mix(in oklab, var(--primary) 40%, white);
   --text-color-btn: #ffffff;
 }
 
 [data-bs-theme='dimgray'] {
   --primary: #696969;
-  --primary-hover: #595959;
-  --primary-disabled: #808080;
+  --primary-hover: color-mix(in oklab, var(--primary) 80%, black);
+  --primary-disabled: color-mix(in oklab, var(--primary) 40%, white);
   --text-color-btn: #ffffff;
 }
 
 [data-bs-theme='dark_red'] {
   --primary: #8b0000;
-  --primary-hover: #660000;
-  --primary-disabled: #b30000;
+  --primary-hover: color-mix(in oklab, var(--primary) 80%, black);
+  --primary-disabled: color-mix(in oklab, var(--primary) 40%, white);
   --text-color-btn: #ffffff;
 }
 
 [data-bs-theme='dark_green'] {
   --primary: #006400;
-  --primary-hover: #003300;
-  --primary-disabled: #009900;
+  --primary-hover: color-mix(in oklab, var(--primary) 80%, black);
+  --primary-disabled: color-mix(in oklab, var(--primary) 40%, white);
   --text-color-btn: #ffffff;
 }
 
 [data-bs-theme='french_blue'] {
   --primary: #0072b5;
-  --primary-hover: #005180;
-  --primary-disabled: #0091e6;
+  --primary-hover: color-mix(in oklab, var(--primary) 80%, black);
+  --primary-disabled: color-mix(in oklab, var(--primary) 40%, white);
   --text-color-btn: #ffffff;
 }
 
 [data-bs-theme='orange'] {
   --primary: #be6e34;
-  --primary-hover: #a05c2c;
-  --primary-disabled: #e4b99b;
+  --primary-hover: color-mix(in oklab, var(--primary) 80%, black);
+  --primary-disabled: color-mix(in oklab, var(--primary) 40%, white);
   --text-color-btn: #ffffff;
 }
 
@@ -552,17 +552,6 @@ input.mid-number {
   font-size: 14px;
   min-width: 450px;
   text-align: left;
-}
-
-.fc-past {
-  background-color: var(--pasttime) !important;
-  color: #333;
-}
-
-.fc-future.hover {
-  background-color: var(--hiliteReservation) !important;
-  color: #ffffff;
-  cursor: pointer;
 }
 
 .resourceName {

--- a/Web/css/schedule.css
+++ b/Web/css/schedule.css
@@ -46,7 +46,7 @@ table.reservations td.resourcename a:hover {
 table.reservations td.resdate {
   width: 150px;
   padding: 0 3px;
-  background-color: #36648b;
+  background-color: color-mix(in srgb, var(--reserved) 60%, black);
   color: #f0f0f0;
 }
 
@@ -207,7 +207,7 @@ td.dropped {
 }
 
 .reserved.hilite {
-  opacity: 0.75;
+  background-color: color-mix(in srgb, var(--reserved), white 30%);
 }
 
 .reserved.mine {
@@ -215,7 +215,7 @@ td.dropped {
 }
 
 .reserved.mine.hilite {
-  opacity: 0.75;
+  background-color: color-mix(in srgb, var(--reservedMine), white 30%);
   color: #ffffff;
 }
 
@@ -224,11 +224,11 @@ td.dropped {
 }
 
 .reserved.participating.hilite {
-  opacity: 0.75;
+  background-color: color-mix(in srgb, var(--reservedParticipating), white 30%);
 }
 
 .past {
-  opacity: 0.6;
+  background-color: color-mix(in srgb, var(--reserved), white 40%);
 }
 
 .reserved.pending {
@@ -237,12 +237,12 @@ td.dropped {
 }
 
 .reserved.pending.hilite {
-  opacity: 0.75;
+  background-color: color-mix(in srgb, var(--reservedPending), white 30%);
 }
 
 .reservable.hilite,
 #reservations .ui-selecting {
-  background-color: #23bf35;
+  background-color: var(--hiliteReservation);
 }
 
 .hilite {
@@ -251,7 +251,7 @@ td.dropped {
 
 .reservable.clicked,
 #reservations .ui-selected {
-  background-color: #259433;
+  background-color: var(--hiliteReservation);
 }
 
 .reserved.clicked {
@@ -414,12 +414,7 @@ ul.jqtree-tree .jqtree-toggler {
 }
 
 #calendar_toggle {
-  color: #585754;
   padding-left: 5px;
-}
-
-#calendar_toggle:hover {
-  color: #72716d;
 }
 
 .schedule_icon {
@@ -434,22 +429,11 @@ img.schedule_icon {
 
 #loading-schedule {
   position: fixed;
-  height: 30px;
-  background-color: rgb(76 175 80 / 0.7);
-  border: solid 2px rgb(32 65 32 / 0.7);
-  top: 300px;
+  top: 50%;
   left: 50%;
-  z-index: 101;
-  width: auto;
-  padding: 0 30px;
-  line-height: 30px;
-  text-align: center;
-  -webkit-border-radius: 2px;
-  -moz-border-radius: 2px;
-  border-radius: 2px;
-  display: inline-block;
-  -webkit-transform: translate(-50%, -50%);
   transform: translate(-50%, -50%);
+  z-index: 101;
+  display: inline-block;
 }
 
 #page-schedule a {
@@ -462,10 +446,6 @@ img.schedule_icon {
   border-radius: 1px;
   padding: 1px 2px;
   margin: 1px;
-}
-
-a.toggle-sidebar {
-  color: #585754;
 }
 
 .no-resource-warning {

--- a/tpl/Schedule/schedule.tpl
+++ b/tpl/Schedule/schedule.tpl
@@ -431,7 +431,13 @@
     {csrf_token}
 </form>
 
-<div id="loading-schedule" class="d-none">Loading reservations...</div>
+<div id="loading-schedule" class="d-none d-flex align-items-center gap-2 p-3 border rounded-2 bg-white
+opacity-75">
+    <div class="spinner-border" role="status">
+        <span class="visually-hidden">{translate key='Working'}</span>
+    </div>
+    <span aria-hidden="true">{translate key='Working'}</span>
+</div>
 
 {include file="javascript-includes.tpl" Select2=true Clear=true DatePicker=true}
 


### PR DESCRIPTION
…ovements

- `color-mix()` is used to calculate `--primary-hover` and `--primary-disabled` from `--primary` in each theme.
- Legacy rules from FullCalendar 3 have been removed.
- `color-mix()` is used to calculate the background of `resdate` from `--reserved`.
- `color-mix()` is used to calculate the background of `hilite` instead of `opacity`.
- `loading-schedule` is styled with a more discreet design.
<img width="1821" height="1109" alt="image" src="https://github.com/user-attachments/assets/f82f07c4-7412-4112-aa93-a87122081671" />

- The text 'Loading reservations...' has been replaced with the translatable text string 'Working'.