### PR TITLE
refactor(availability): simplify template using section config loop

### DIFF
--- a/tpl/Dashboard/resource_availability.tpl
+++ b/tpl/Dashboard/resource_availability.tpl
@@ -6,122 +6,111 @@
             {translate key="ResourceAvailability"}
         </button>
     </div>
+
     <div id="ResourceAvailabilityContents" class="dashboardContents accordion-collapse collapse">
         <div class="accordion-body">
-            <div class="header fw-bold fs-5">{translate key=Available}</div>
-            {foreach from=$Schedules item=s}
-                {assign var=availability value=$Available[$s->GetId()]}
-                {if is_array($availability) && $availability|default:array()|count > 0}
-                    <div class="text-body-secondary fs-4 mt-3 text-center fw-bold">{$s->GetName()}</div>
-                    {foreach from=$availability item=i}
-                        <div class="availabilityItem row gy-2 p-2 border-bottom align-items-center">
-                            <div class="col-12 col-sm-5">
-                                <span class="resourceName px-2 py-1 rounded-1"
-                                    {if $i->GetColor()}style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};" {/if}>
-                                    <i resource-id="{$i->ResourceId()}" class="resourceNameSelector bi bi-info-circle-fill"></i>
-                                    <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
-                                        resource-id="{$i->ResourceId()}" class="resourceNameSelector" {if $i->GetColor()}
-                                        style="color:{$i->GetTextColor()} {/if}">{$i->ResourceName()}</a>
-                                </span>
-                            </div>
-                            <div class="availability col-12 col-sm-4">
-                                {if $i->NextTime() != null}
-                                    {translate key=AvailableUntil}
-                                    {format_date date=$i->NextTime() timezone=$Timezone key=dashboard}
-                                {else}
-                                    <span class="no-data fst-italic">{translate key=AllNoUpcomingReservations args=30}</span>
-                                {/if}
-                            </div>
-                            <div class="reserveButton col-12 col-sm-3 d-grid">
-                                <button class="btn btn-sm btn-primary"
-                                    onclick="window.location.href='{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}'">
-                                    {translate key=Reserve}
-                                </button>
-                            </div>
+
+            {* Section settings *}
+            {assign var=sections value=[
+                [
+                    'title' => 'Available',
+                    'data' => $Available,
+                    'dateField' => 'NextTime',
+                    'label' => 'AvailableUntil',
+                    'urlDate' => false
+                ],
+                [
+                    'title' => 'Unavailable',
+                    'data' => $Unavailable,
+                    'dateField' => 'ReservationEnds',
+                    'label' => 'AvailableBeginningAt',
+                    'urlDate' => true
+                ],
+                [
+                    'title' => 'UnavailableAllDay',
+                    'data' => $UnavailableAllDay,
+                    'dateField' => 'ReservationEnds',
+                    'label' => 'AvailableAt',
+                    'urlDate' => true
+                ]
+            ]}
+
+            {* Main loop *}
+            {foreach from=$sections item=section}
+
+                <div class="header fw-bold fs-5 mt-3">
+                    {translate key=$section.title}
+                </div>
+
+                {assign var=hasData value=false}
+
+                {foreach from=$Schedules item=s}
+                    {assign var=availability value=$section.data[$s->GetId()]}
+
+                    {if is_array($availability) && $availability|count > 0}
+                        {assign var=hasData value=true}
+
+                        <div class="text-body-secondary fs-4 mt-3 text-center fw-bold">
+                            {$s->GetName()}
                         </div>
-                    {/foreach}
+
+                        {foreach from=$availability item=i}
+                            {if $section.dateField == 'NextTime'}
+                                {assign var=date value=$i->NextTime()}
+                            {else}
+                                {assign var=date value=$i->ReservationEnds()}
+                            {/if}
+
+                            <div class="availabilityItem row gy-2 p-2 border-bottom align-items-center">
+
+                                {* Resource name *}
+                                <div class="col-12 col-sm-5">
+                                    <span class="resourceName px-2 py-1 rounded-1"
+                                        {if $i->GetColor()}style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};" {/if}>
+
+                                        <i resource-id="{$i->ResourceId()}" class="resourceNameSelector bi bi-info-circle-fill"></i>
+                                        <a resource-id="{$i->ResourceId()}" class="resourceNameSelector"
+                                            {if $i->GetColor()}style="color:{$i->GetTextColor()};" {/if}
+                                            href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}">
+                                            {$i->ResourceName()}
+                                        </a>
+                                    </span>
+                                </div>
+
+                                {* Availability *}
+                                <div class="availability col-12 col-sm-4">
+                                    {if $date != null}
+                                        {translate key=$section.label}
+                                        {format_date date=$date timezone=$Timezone key=dashboard}
+                                    {else}
+                                        <span class="no-data fst-italic">
+                                            {translate key=AllNoUpcomingReservations args=30}
+                                        </span>
+                                    {/if}
+                                </div>
+
+                                {* Button *}
+                                <div class="reserveButton col-12 col-sm-3 d-grid">
+                                    <button class="btn btn-sm btn-primary"
+                                        onclick="window.location.href='{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}{if $section.urlDate && $date}&{QueryStringKeys::START_DATE}={format_date date=$date timezone=$Timezone key=url_full}{/if}'">
+                                        {translate key=Reserve}
+                                    </button>
+                                </div>
+
+                            </div>
+                        {/foreach}
+                    {/if}
+                {/foreach}
+
+                {* No data *}
+                {if !$hasData}
+                    <div class="no-data text-center fst-italic fs-5">
+                        {translate key=None}
+                    </div>
                 {/if}
+
             {/foreach}
 
-            {if empty($availability)}
-                <div class="no-data text-center fst-italic fs-5">{translate key=None}</div>
-            {/if}
-
-            <div class="header fw-bold fs-5 mt-3">{translate key=Unavailable}</div>
-
-            {foreach from=$Schedules item=s}
-                {assign var=availability value=$Unavailable[$s->GetId()]}
-                {if is_array($availability) && $availability|default:array()|count > 0}
-                    <div class="text-body-secondary fs-4 mt-3 text-center fw-bold">{$s->GetName()}</div>
-                    {foreach from=$availability item=i}
-                        <div class="availabilityItem row py-2 border-bottom align-items-center">
-                            <div class="col-12 col-sm-5">
-                                <span class="resourceName px-2 rounded-1 {if !$i->GetColor()}bg-success bg-opacity-10{/if}"
-                                    {if $i->GetColor()}style="background-color:{$i->GetColor()};color:{$i->GetTextColor()};" {/if}>
-                                    <i resource-id="{$i->ResourceId()}" class="resourceNameSelector bi bi-info-circle-fill
-                                    {if !$i->GetColor()}link-success{/if}"></i>
-                                    <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
-                                        resource-id="{$i->ResourceId()}"
-                                        class="resourceNameSelector
-                                    {if !$i->GetColor()}link-success link-underline-opacity-0 link-underline-opacity-100-hover{/if}"
-                                        style="color:{$i->GetTextColor()}">{$i->ResourceName()}</a>
-                                </span>
-                            </div>
-                            <div class="availability col-12 col-sm-4">
-                                {translate key=AvailableBeginningAt}
-                                {format_date date=$i->ReservationEnds() timezone=$Timezone key=dashboard}
-                            </div>
-                            <div class="reserveButton col-12 col-sm-3 d-grid gap-2">
-                                <button class="btn btn-sm btn-primary"
-                                    onclick="window.location.href='{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}&{QueryStringKeys::START_DATE}={format_date date=$i->ReservationEnds() timezone=$Timezone key=url_full}'">
-                                    {translate key=Reserve}
-                                </button>
-                            </div>
-                        </div>
-                    {/foreach}
-                {/if}
-            {/foreach}
-
-            {if empty($Unavailable)}
-                <div class="no-data text-center fst-italic fs-5">{translate key=None}</div>
-            {/if}
-
-            <div class="header fw-bold fs-5 mt-3">{translate key=UnavailableAllDay}</div>
-            {foreach from=$Schedules item=s}
-                {assign var=availability value=$UnavailableAllDay[$s->GetId()]}
-                {if is_array($availability) && $availability|default:array()|count > 0}
-                    <div class="text-body-secondary fs-4 mt-3 text-center fw-bold">{$s->GetName()}</div>
-                    {foreach from=$availability item=i}
-                        <div class="availabilityItem row py-2 border-bottom align-items-center">
-                            <div class="col-12 col-sm-5">
-                                <span class="resourceName px-2 rounded-1 {if !$i->GetColor()}bg-success bg-opacity-10{/if}"><i
-                                        resource-id="{$i->ResourceId()}" class="resourceNameSelector bi bi-info-circle-fill
-                                        {if !$i->GetColor()}link-success{/if}"></i>
-                                    <a href="{$Path}{Pages::RESERVATION}?{QueryStringKeys::RESOURCE_ID}={$i->ResourceId()}"
-                                        resource-id="{$i->ResourceId()}"
-                                        class="resourceNameSelector
-                                    {if !$i->GetColor()}link-success link-underline-opacity-0 link-underline-opacity-100-hover{/if}"
-                                        style="color:{$i->GetTextColor()}">{$i->ResourceName()}</a>
-                                </span>
-                            </div>
-                            <div class="availability col-12 col-sm-4">
-                                {translate key=AvailableAt}
-                                {format_date date=$i->ReservationEnds() timezone=$Timezone key=dashboard}
-                            </div>
-                            <div class="reserveButton col-12 col-sm-3 d-grid gap-2">
-                                <button class="btn btn-sm btn-primary"
-                                    onclick="window.location.href='{{$Path}}{{Pages::RESERVATION}}?{{QueryStringKeys::RESOURCE_ID}}={{$i->ResourceId()}}&{{QueryStringKeys::START_DATE}}={{format_date date=$i->ReservationEnds() timezone=$Timezone key=url_full}}'">
-                                    {{translate key=Reserve}}
-                                </button>
-                            </div>
-                        </div>
-                    {/foreach}
-                {/if}
-            {/foreach}
-
-            {if empty($UnavailableAllDay)}
-                <div class="no-data text-center fst-italic fs-5">{translate key=None}</div>
-            {/if}
         </div>
     </div>
 </div>


### PR DESCRIPTION
Refactored the resource availability dashboard template to reduce duplication and improve maintainability.
- Replaced repeated blocks (Available, Unavailable, UnavailableAllDay) with a single loop using a `sections` configuration array
- Centralized section behavior:
  - `title`
  - data source (`$Available`, `$Unavailable`, `$UnavailableAllDay`)
  - date field (`NextTime`, `ReservationEnds`)
  - label translation key
  - conditional URL date handling
- Simplified date handling logic using a unified `$date` variable
- Reduced duplicated markup across sections
- Improved readability and maintainability of the template

Assisted-by: Copilot:GPT-4.5