### PR TITLE
fix(reservation.label): avoid null replacement in attribute label for…

### DIFF
--- a/lib/Application/Schedule/SlotLabelFactory.php
+++ b/lib/Application/Schedule/SlotLabelFactory.php
@@ -114,7 +114,7 @@ class SlotLabelFactory
         if (count($matches) > 0) {
             for ($m = 0; $m < count($matches); $m++) {
                 $id = filter_var($matches[$m], FILTER_SANITIZE_NUMBER_INT);
-                $value = $reservation->GetAttributeValue($id);
+                $value = $reservation->GetAttributeValue($id) ?? '';
 
                 $label = str_replace($matches[$m], $value, $label);
             }


### PR DESCRIPTION
…matting

- When using a label format like: 'reservation.label' => '{att120}' and the attribute with that ID does not exist, GetAttributeValue()
returns null. This caused the following deprecated warning in PHP:    str_replace(): Passing null to parameter 2 ($replace)
    of type array|string is deprecated
File: SlotLabelFactory.php (line 119)
- The fix ensures null values are converted to an empty string before
calling str_replace, preventing the warning and keeping label rendering stable.