### PR TITLE
fix(DeprecatedPHP8.5): Transforming null values ​​to an empty string

### DIFF
--- a/lib/Application/Attributes/AttributeService.php
+++ b/lib/Application/Attributes/AttributeService.php
@@ -179,7 +179,7 @@ class AttributeService implements IAttributeService
                 continue;
             }
 
-            $value = trim($values[$attribute->Id()]);
+            $value = trim($values[$attribute->Id()] ?? '');
             $label = $attribute->Label();
 
             if (empty($value) && ($ignoreEmpty || $isAdmin)) {

--- a/lib/Common/SmartyPage.php
+++ b/lib/Common/SmartyPage.php
@@ -1034,7 +1034,7 @@ class SmartyPage extends Smarty
 
     public function ArrayKeyExists(string|int|float|bool|null $key, array $array): bool
     {
-        return array_key_exists($key, $array);
+        return array_key_exists($key ?? '', $array);
     }
 
     public function Count(Countable|array $value, int $mode = COUNT_NORMAL): int

--- a/lib/Email/Messages/ReservationEmailTemplateContext.php
+++ b/lib/Email/Messages/ReservationEmailTemplateContext.php
@@ -274,7 +274,8 @@ class ReservationEmailTemplateContext
         $groups = $this->ResourceAdminGroupsById();
         $groupId = $resource->GetAdminGroupId();
 
-        return isset($groups[$groupId]) ? $groups[$groupId]->Name : '';
+        $key = $groupId ?? '';
+        return isset($groups[$key]) ? $groups[$key]->Name : '';
     }
 
     /**

--- a/tpl/Admin/Resources/manage_resources.tpl
+++ b/tpl/Admin/Resources/manage_resources.tpl
@@ -494,7 +494,14 @@
 																	<span class="propertyValue resourceAdminValue"
 																		data-type="select" data-pk="{$id}"
 																		data-value="{$resource->GetAdminGroupId()}"
-																		data-name="{FormKeys::RESOURCE_ADMIN_GROUP_ID}">{$GroupLookup[$resource->GetAdminGroupId()]->Name}</span>
+																		 data-name="{FormKeys::RESOURCE_ADMIN_GROUP_ID}">
+																			{assign var=adminGroupId value=$resource->GetAdminGroupId()}
+																			{if $adminGroupId !== null && isset($GroupLookup[$adminGroupId])}
+																				{$GroupLookup[$adminGroupId]->Name|escape:'html'}
+																			{else}
+																				{translate key='None'}
+																			{/if}
+																		</span>
 																</div>
 															</div>
 															<div class="mt-2">

--- a/tpl/Admin/Resources/view_resources.tpl
+++ b/tpl/Admin/Resources/view_resources.tpl
@@ -292,9 +292,15 @@
                                                                 </div>
                                                             </div>
                                                             <div>
-                                                                <label
-                                                                    class="inline fw-bold">{translate key='ResourceAdministrator'}</label>
-                                                                <span>{$ResourceAdminGroup[$resource->GetAdminGroupId()]->Name}</span>
+                                                                <label class="inline fw-bold">{translate key='ResourceAdministrator'}</label>
+                                                                <span>
+                                                                    {assign var=adminGroupId value=$resource->GetAdminGroupId()}
+                                                                    {if $adminGroupId !== null && isset($ResourceAdminGroup[$adminGroupId])}
+                                                                        {$ResourceAdminGroup[$adminGroupId]->Name|escape:'html'}
+                                                                    {else}
+                                                                        {translate key='None'}
+                                                                    {/if}
+                                                                </span>
                                                             </div>
 
                                                         </div>

--- a/tpl/Admin/Schedules/manage_schedules.tpl
+++ b/tpl/Admin/Schedules/manage_schedules.tpl
@@ -69,10 +69,11 @@
 																data-type="select" data-pk="{$id}"
 																data-value="{$schedule->GetAdminGroupId()}"
 																data-name="{FormKeys::SCHEDULE_ADMIN_GROUP_ID}">
-																{if isset($GroupLookup[$schedule->GetAdminGroupId()])}
-																	{$GroupLookup[$schedule->GetAdminGroupId()]->Name|escape:'html'}
+																{assign var=adminGroupId value=$schedule->GetAdminGroupId()}
+																{if $adminGroupId !== null && isset($GroupLookup[$adminGroupId])}
+																	{$GroupLookup[$adminGroupId]->Name|escape:'html'}
 																{else}
-																	None
+																	{translate key='None'}
 																{/if}
 															</span>
 															{if $AdminGroups|default:array()|count > 0}

--- a/tpl/Admin/Schedules/view_schedules.tpl
+++ b/tpl/Admin/Schedules/view_schedules.tpl
@@ -49,7 +49,13 @@
 
 														<div>{translate key='ScheduleAdministrator'}
 															<span
-																class="fw-bold">{($GroupLookup[$schedule->GetAdminGroupId()]) ? $GroupLookup[$schedule->GetAdminGroupId()]->Name : 'None'}
+																class="fw-bold">
+																{assign var=adminGroupId value=$schedule->GetAdminGroupId()}
+																{if $adminGroupId !== null && isset($GroupLookup[$adminGroupId])}
+																	{$GroupLookup[$adminGroupId]->Name|escape:'html'}
+																{else}
+																	{translate key='None'}
+																{/if}
 															</span>
 														</div>
 

--- a/tpl/Admin/Users/manage_users.tpl
+++ b/tpl/Admin/Users/manage_users.tpl
@@ -103,7 +103,7 @@
                         {foreach from=$users item=user}
                             {assign var=id value=$user->Id}
                             <tr data-userId="{$id}">
-                                <td>{fullname first=$user->First|unescape:'html' last=$user->Last|unescape:'html' ignorePrivacy="true"}
+                                <td>{fullname first=$user->First|default:''|unescape:'html' last=$user->Last|default:''|unescape:'html' ignorePrivacy="true"}
                                 </td>
                                 <td>{$user->Username}</td>
                                 <td><a href="mailto:{$user->Email}" class="link-primary">{$user->Email}</a></td>


### PR DESCRIPTION
- Null values ​​are handled to improve compatibility with PHP 8.5 and avoid "Deprecated" messages

Assisted-by: Copilot:GPT-4.5