### PR TITLE
fix: 404 on plus icon in condensed week schedule display

### DIFF
--- a/tpl/Schedule/schedule-week-condensed.tpl
+++ b/tpl/Schedule/schedule-week-condensed.tpl
@@ -161,4 +161,4 @@
             });
         });
     </script>
-{/block}Z
+{/block}

--- a/tpl/Schedule/schedule-week-condensed.tpl
+++ b/tpl/Schedule/schedule-week-condensed.tpl
@@ -128,7 +128,7 @@
                                         <div class="reservable clickres" ref="{$href}&rd={formatdate date=$date key=url}"
                                             data-href="{$href}" data-start="{$date->Format('Y-m-d H:i:s')|escape:url}"
                                             data-end="{$date->Format('Y-m-d H:i:s')|escape:url}">
-                                            <i class="bi bi-plus-circle-fill"></i> {translate key=CreateReservation}
+                                            <i class="bi bi-plus-circle-fill pe-none"></i> {translate key=CreateReservation}
                                             <input type="hidden" class="href" value="{$href}" />
                                         </div>
                                     {/if}


### PR DESCRIPTION
Fixes the condensed week schedule “Create Reservation” (+) icon click behavior to prevent a 404 by ensuring the data attributes of the parent element apply 

Close #1352

Changes:

Add bootstraps pe-none class to the plus icon in the condensed week schedule display so pointer events of the parent div apply and clicking the icon navigates correctly.
Remove an accidental trailing Z after the closing {/block}.